### PR TITLE
[wpmltm-1847] Added attribute in tag XML config file for encoding con…

### DIFF
--- a/src/st/strategy/shortcode/class-wpml-pb-config-import-shortcode.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-config-import-shortcode.php
@@ -62,9 +62,10 @@ class WPML_PB_Config_Import_Shortcode {
 				}
 				$shortcode_data[] = array(
 					'tag'        => array(
-						'value'    => $data['tag']['value'],
-						'encoding' => isset( $data['tag']['attr']['encoding'] ) ? $data['tag']['attr']['encoding'] : '',
-						'type'     => isset( $data['tag']['attr']['type'] ) ? $data['tag']['attr']['type'] : '',
+						'value'              => $data['tag']['value'],
+						'encoding'           => isset( $data['tag']['attr']['encoding'] ) ? $data['tag']['attr']['encoding'] : '',
+						'encoding-condition' => isset( $data['tag']['attr']['encoding-condition'] ) ? $data['tag']['attr']['encoding-condition'] : '',
+						'type'               => isset( $data['tag']['attr']['type'] ) ? $data['tag']['attr']['type'] : '',
 					),
 					'attributes' => $attributes,
 				);

--- a/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
@@ -52,10 +52,11 @@ class WPML_PB_Register_Shortcodes {
 		}
 
 		foreach ( $shortcodes as $shortcode ) {
-			$shortcode_content = $shortcode['content'];
-			$encoding          = $this->shortcode_strategy->get_shortcode_tag_encoding( $shortcode['tag'] );
-			$type              = $this->shortcode_strategy->get_shortcode_tag_type( $shortcode['tag'] );
-			$shortcode_content = $this->encoding->decode( $shortcode_content, $encoding );
+			$shortcode_content  = $shortcode['content'];
+			$encoding           = $this->shortcode_strategy->get_shortcode_tag_encoding( $shortcode['tag'] );
+			$encoding_condition = $this->shortcode_strategy->get_shortcode_tag_encoding_condition( $shortcode['tag'] );
+			$type               = $this->shortcode_strategy->get_shortcode_tag_type( $shortcode['tag'] );
+			$shortcode_content  = $this->encoding->decode( $shortcode_content, $encoding, $encoding_condition );
 
 			$this->register_string( $post_id, $shortcode_content, $shortcode, 'content', $type );
 

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcode-encoding.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcode-encoding.php
@@ -8,12 +8,16 @@ class WPML_PB_Shortcode_Encoding {
 	const ENCODE_TYPES_VISUAL_COMPOSER_LINK = 'vc_link';
 	const ENCODE_TYPES_ENFOLD_LINK          = 'av_link';
 
-	public function decode( $string, $encoding ) {
+	public function decode( $string, $encoding, $encoding_condition = '' ) {
 		$encoded_string = $string;
+
+		if ( $encoding_condition && ! $this->should_decode( $encoding_condition ) ) {
+			return html_entity_decode( $string );
+		}
 
 		switch ( $encoding ) {
 			case self::ENCODE_TYPES_BASE64:
-				$string = rawurldecode( base64_decode( strip_tags( $string ) ) );
+				$string = html_entity_decode( rawurldecode( base64_decode( strip_tags( $string ) ) ) );
 				break;
 
 			case self::ENCODE_TYPES_VISUAL_COMPOSER_LINK:
@@ -77,5 +81,16 @@ class WPML_PB_Shortcode_Encoding {
 		}
 
 		return apply_filters( 'wpml_pb_shortcode_encode', $string, $encoding, $decoded_string );
+	}
+
+	/**
+	 * @param string $condition
+	 *
+	 * @return bool
+	 */
+	private function should_decode( $condition ) {
+		preg_match( '/(?P<type>\w+):(?P<field>\w+)=(?P<value>\w+)/', $condition, $matches );
+
+		return 'option' === $matches['type'] && get_option( $matches['field'] ) === $matches['value'];
 	}
 }

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
@@ -12,9 +12,10 @@ class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 			$tag = $shortcode['tag']['value'];
 			if ( ! in_array( $tag, $this->shortcodes ) ) {
 				$this->shortcodes[ $tag ] = array(
-					'encoding' => $shortcode['tag']['encoding'],
-					'type' => isset( $shortcode['tag']['type'] ) ? $shortcode['tag']['type'] : '',
-					'attributes' => array(),
+					'encoding'           => $shortcode['tag']['encoding'],
+					'encoding-condition' => isset( $shortcode['tag']['encoding-condition'] ) ? $shortcode['tag']['encoding-condition'] : '',
+					'type'               => isset( $shortcode['tag']['type'] ) ? $shortcode['tag']['type'] : '',
+					'attributes'         => array(),
 				);
 			}
 			if ( isset( $shortcode['attributes'] ) ) {
@@ -35,6 +36,10 @@ class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 
 	public function get_shortcode_tag_encoding( $tag ) {
 		return $this->shortcodes[ $tag ]['encoding'];
+	}
+
+	public function get_shortcode_tag_encoding_condition( $tag ) {
+		return $this->shortcodes[ $tag ]['encoding-condition'];
 	}
 
 	public function get_shortcode_tag_type( $tag ) {

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-register-shortcodes.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-register-shortcodes.php
@@ -4,6 +4,7 @@
  * Class Test_WPML_PB_Register_Shortcodes
  *
  * @group page-builders
+ * @group wpmltm-1847
  */
 class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 
@@ -178,6 +179,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 			                            'get_shortcode_tag_type',
 			                            'get_shortcode_attributes',
 			                            'get_shortcode_attribute_encoding',
+			                            'get_shortcode_tag_encoding_condition',
 			                            'remove_string'
 		                            ) )
 		                            ->disableOriginalConstructor()

--- a/tests/phpunit/tests/st/test-wpml-pb-config-import.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-config-import.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * Class Test_WPML_PB_Config_Import
+ */
 class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 	/**
 	 * @param $shortcode
@@ -38,7 +41,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'encoding-condition' => '', 'type' => '' ),
 					'attributes' => array(
 						array( 'value' => 'attribute1', 'encoding' => '', 'type' => '' ),
 						array( 'value' => 'attribute2', 'encoding' => '', 'type' => '' ),
@@ -51,7 +54,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					'attributes' => array( 'attribute' => array( 'value' => 'attribute3' ) ),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag2', 'encoding' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag2', 'encoding' => '', 'encoding-condition' => '', 'type' => '' ),
 					'attributes' => array(
 						array( 'value' => 'attribute3', 'encoding' => '', 'type' => '' ),
 					),
@@ -62,7 +65,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					'tag' => array( 'value' => 'tag3' ),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag3', 'encoding' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag3', 'encoding' => '', 'encoding-condition' => '', 'type' => '' ),
 					'attributes' => array(),
 				),
 			),
@@ -71,7 +74,16 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					'tag' => array( 'value' => 'tag4', 'attr' => array( 'encoding' => 'encoding1' ) ),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag4', 'encoding' => 'encoding1', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag4', 'encoding' => 'encoding1', 'encoding-condition' => '', 'type' => '' ),
+					'attributes' => array(),
+				),
+			),
+			'encoded tag with condition'        => array(
+				array(
+					'tag' => array( 'value' => 'tag4', 'attr' => array( 'encoding' => 'encoding1', 'encoding-condition' => 'option:something=1' ) ),
+				),
+				array(
+					'tag'        => array( 'value' => 'tag4', 'encoding' => 'encoding1', 'encoding-condition' => 'option:something=1', 'type' => '' ),
 					'attributes' => array(),
 				),
 			),
@@ -86,7 +98,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag5', 'encoding' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag5', 'encoding' => '', 'encoding-condition' => '', 'type' => '' ),
 					'attributes' => array(
 						array( 'value' => 'attribute4', 'encoding' => 'encoding2', 'type' => '' ),
 					),
@@ -146,7 +158,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 		);
 
 		$expected_value = array(
-			'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'type' => 'link' ),
+			'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'encoding-condition' => '', 'type' => 'link' ),
 			'attributes' => array(
 				array( 'value' => 'attribute1', 'encoding' => '', 'type' => 'link' ),
 				array( 'value' => 'attribute2', 'encoding' => '', 'type' => '' ),

--- a/tests/phpunit/tests/st/test-wpml-pb-factory.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-factory.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Class Test_WPML_PB_Factory
+ *
+ * @group 123456
+ */
 class Test_WPML_PB_Factory extends WPML_PB_TestCase {
 
 	private $wpdb_original;

--- a/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
@@ -33,6 +33,7 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 		$this->shortcode_strategy = \Mockery::mock( 'WPML_PB_Shortcode_Strategy' );
 		$this->shortcode_strategy->shouldReceive( 'get_shortcode_parser' )->andReturn( $shortcode_parser );
 		$this->shortcode_strategy->shouldReceive( 'get_shortcode_tag_encoding' )->andReturn( '' );
+		$this->shortcode_strategy->shouldReceive( 'get_shortcode_tag_encoding_condition' )->andReturn( '' );
 		$this->shortcode_strategy->shouldReceive( 'get_shortcode_tag_type' )->with( 'vc_btn' )->andReturn( 'VISUAL' );
 		$this->shortcode_strategy->shouldReceive( 'get_shortcode_attribute_encoding' )->andReturnValues( array(
 			                                                                                                 '',

--- a/tests/phpunit/util/wpml-pb-test-case.php
+++ b/tests/phpunit/util/wpml-pb-test-case.php
@@ -24,27 +24,16 @@ abstract class WPML_PB_TestCase extends OTGS_TestCase {
 		return $factory;
 	}
 
-	protected function get_shortcode_strategy( WPML_PB_Factory $factory, $encoding = '' ) {
+	protected function get_shortcode_strategy( WPML_PB_Factory $factory, $encoding = '', $encoding_condition = '' ) {
 		$strategy = new WPML_PB_Shortcode_Strategy();
 		$strategy->add_shortcodes(
 			array(
 				array(
 					'tag'        => array(
-						'value'    => 'vc_column_text',
-						'encoding' => $encoding,
-						'type' => '',
-					),
-					'attributes' => array(
-						array( 'value' => 'text', 'encoding' => $encoding, 'type' => '' ),
-						array( 'value' => 'heading', 'encoding' => $encoding, 'type' => '' ),
-						array( 'value' => 'title', 'encoding' => $encoding, 'type' => '' ),
-					),
-				),
-				array(
-					'tag'        => array(
-						'value'    => 'vc_text_separator',
-						'encoding' => $encoding,
-						'type' => '',
+						'value'              => 'vc_column_text',
+						'encoding'           => $encoding,
+						'encoding-condition' => $encoding_condition,
+						'type'               => '',
 					),
 					'attributes' => array(
 						array( 'value' => 'text', 'encoding' => $encoding, 'type' => '' ),
@@ -54,15 +43,30 @@ abstract class WPML_PB_TestCase extends OTGS_TestCase {
 				),
 				array(
 					'tag' => array(
-						'value'    => 'vc_message',
-						'encoding' => $encoding,
+						'value'              => 'vc_text_separator',
+						'encoding'           => $encoding,
+						'encoding-condition' => $encoding_condition,
+						'type'               => '',
+					),
+					'attributes' => array(
+						array( 'value' => 'text', 'encoding' => $encoding, 'type' => '' ),
+						array( 'value' => 'heading', 'encoding' => $encoding, 'type' => '' ),
+						array( 'value' => 'title', 'encoding' => $encoding, 'type' => '' ),
 					),
 				),
 				array(
-					'tag'        => array(
-						'value'    => 'tag_with_link',
-						'encoding' => $encoding,
-						'type' => 'link',
+					'tag' => array(
+						'value'              => 'vc_message',
+						'encoding'           => $encoding,
+						'encoding-condition' => $encoding_condition,
+					),
+				),
+				array(
+					'tag' => array(
+						'value'              => 'tag_with_link',
+						'encoding'           => $encoding,
+						'encoding-condition' => $encoding_condition,
+						'type'               => 'link',
 					),
 					'attributes' => array(
 						array( 'value' => 'link', 'encoding' => $encoding, 'type' => 'link' ),


### PR DESCRIPTION
…dition

A new attribute `encoding-condition` has been added in shortcode tag for the XML config file. This attribute will allow us to conditionally encode a tag defined to be encoded.

For now it only works in this format `option:my_option_name=my_option_value`. Which means that if such option has such value, then the tag will be encoded.