### PR TITLE
Use a predefined subroutine in order to decrease the portion which do…

### DIFF
--- a/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
@@ -80,17 +80,15 @@ class WPML_PB_Update_Shortcodes_In_Content {
 
 	private function replace_string_with_translation( $block, $original, $translation, $is_attribute = false ) {
 		$translation = apply_filters( 'wpml_pb_before_replace_string_with_translation', $translation, $is_attribute );
-
-		$new_block = $block;
+		$original    = str_replace( ' ', '\ ', $original );
+		$new_block   = $block;
 		if ( $translation ) {
 			if ( $is_attribute ) {
-				$pattern   = '/(["\'])' . preg_quote( $original, '/' ) . '(["\'])/';
-				$new_block = preg_replace( $pattern, '${1}' . $translation . '${2}', $block );
+				$new_block = preg_replace( '/(?(DEFINE)(?<text>(["\'])' . $original . '(["\'])))(?&text)/x', '"' . $translation . '"', $block );
 			} else {
-				$pattern   = '/(]\s*)' . preg_quote( trim( $original ), '/' ) . '(\s*\[)/';
-				$new_block = preg_replace( $pattern, '${1}' . trim( $translation ) . '${2}', $block );
+				$new_block = preg_replace( '/(?(DEFINE)(?<text>(]\s*)' . trim( $original ) . '(\s*\[)))(?&text)/x', ']' . trim( $translation ) . '[', $block );
 			}
-			$this->new_content = preg_replace( '/'. preg_quote( $block, '/' ) . '/', $new_block, $this->new_content, 1 );
+			$this->new_content = preg_replace( '/' . preg_quote( $block, '/' ) . '/', $new_block, $this->new_content, 1 );
 		}
 
 		return $new_block;


### PR DESCRIPTION
…es the matching

This fix is needed because we are exceeding memory limit when doing preg_replace for really big strings.

The idea is to create a sub regex routine which will hold the expression together with the long string. Moreover, the portion which in fact does te matching will be smaller, e.g: `(?&text)`.

https://github.com/OnTheGoSystems/wpml-page-builders/issues/6