### PR TITLE
Fix performance hit when saving the translation editor with a lot of

### DIFF
--- a/src/st/class-wpml-pb-string-translation.php
+++ b/src/st/class-wpml-pb-string-translation.php
@@ -27,9 +27,6 @@ class WPML_PB_String_Translation {
 			$package = $this->factory->get_wpml_package( $package_id );
 			if ( $package->post_id && $this->strategy->get_package_kind() === $package->kind ) {
 				$this->add_package_to_update_list( $package, $language );
-				if ( defined( 'DOING_AJAX' ) && DOING_AJAX || defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
-					$this->save_translations_to_post();
-				}
 			}
 		}
 	}


### PR DESCRIPTION
page builder fields

We were updating the translated post content on each package string
update. This was already done in the shutdown for all attached packages
that were modified.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5304
https://github.com/OnTheGoSystems/wpml-page-builders/issues/10