### PR TITLE
Replace only attribute value of the current attribute

### DIFF
--- a/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
@@ -72,20 +72,20 @@ class WPML_PB_Update_Shortcodes_In_Content {
 					$encoding            = $this->strategy->get_shortcode_attribute_encoding( $shortcode_data['tag'], $attr );
 					$translation         = $this->get_translation( $attr_value, $encoding );
 					$translation         = $this->filter_attribute_translation( $translation, $encoding );
-					$shortcode_attribute = $this->replace_string_with_translation( $shortcode_attribute, $attr_value, $translation, true );
+					$shortcode_attribute = $this->replace_string_with_translation( $shortcode_attribute, $attr_value, $translation, true, $attr );
 				}
 			}
 		}
 	}
 
-	private function replace_string_with_translation( $block, $original, $translation, $is_attribute = false ) {
+	private function replace_string_with_translation( $block, $original, $translation, $is_attribute = false, $attr = '' ) {
 		$translation = apply_filters( 'wpml_pb_before_replace_string_with_translation', $translation, $is_attribute );
 
 		$new_block = $block;
 		if ( $translation ) {
-			if ( $is_attribute ) {
-				$pattern   = '/(["\'])' . preg_quote( $original, '/' ) . '(["\'])/';
-				$new_block = preg_replace( $pattern, '${1}' . $translation . '${2}', $block );
+			if ( $is_attribute && $attr ) {
+				$pattern   = '/' . $attr . '=(["\'])' . preg_quote( $original, '/' ) . '(["\'])/';
+				$new_block = preg_replace( $pattern, $attr . '=${1}' . $translation . '${2}', $block );
 			} else {
 				$pattern   = '/(]\s*)' . preg_quote( trim( $original ), '/' ) . '(\s*\[)/';
 				$new_block = preg_replace( $pattern, '${1}' . trim( $translation ) . '${2}', $block );

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-update-shortcodes-in-content.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-update-shortcodes-in-content.php
@@ -54,8 +54,19 @@ class Test_WPML_PB_Update_Shortcodes_In_Content extends WPML_PB_TestCase {
 					return $result;
 				}
 
-				list( $name, $value ) = explode( '=', trim( $attribs ) );
-				$result[ $name ] = trim( $value, '""' );
+				$attribs_arr = explode( '=', trim( $attribs ) );
+
+				if ( 2 === count( $attribs_arr ) ) {
+					list( $name, $value ) = $attribs_arr;
+					$result[ $name ] = trim( $value, '""' );
+				} else {
+					$attribs_arr = explode( '" ', trim( $attribs ) );
+
+					foreach ( $attribs_arr as $attrib ) {
+						$single_attrib_arr = explode( '=', $attrib );
+						$result[ trim( $single_attrib_arr[0], '""' ) ] = trim( $single_attrib_arr[1], '""' );
+					}
+				}
 
 				return $result;
 			},
@@ -145,6 +156,28 @@ class Test_WPML_PB_Update_Shortcodes_In_Content extends WPML_PB_TestCase {
 						'fr' => array(
 							'status' => ICL_TM_COMPLETE,
 							'value'  => '[<text>] fr title value', // test escaping of special chars from attributes
+						),
+					),
+				),
+			),
+			'Test translating only translatable attributes even when their values are the same' => array(
+				'[et_shortcode title="title value" title2="title value" /]',
+				'[et_shortcode title="fr title value" title2="title value" /]',
+				array( 'et_shortcode' ),
+				array( 'et_shortcode' => array( 'title' ) ),
+				array(
+					array(
+						'block'      => '[et_shortcode title="title value" title2="title value" /]]',
+						'tag'        => 'et_shortcode',
+						'attributes' => ' title="title value" title2="title value"',
+						'content'    => '',
+					),
+				),
+				array(
+					md5( 'title value' ) => array(
+						'fr' => array(
+							'status' => ICL_TM_COMPLETE,
+							'value'  => 'fr title value',
 						),
 					),
 				),


### PR DESCRIPTION
The old regex pattern was not looking at the attribute name when replacing the its value. It was causing problems with attributes that have same value however different attribute name. I've added the attribute name in the regex for replacing only what we want.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5288