### PR TITLE
[wpmlcore-5379] Implemented entities for page builder based on custom fields

### DIFF
--- a/src/st/strategy/custom-field/class-wpml-pb-custom-field-config-import.php
+++ b/src/st/strategy/custom-field/class-wpml-pb-custom-field-config-import.php
@@ -5,7 +5,7 @@ class WPML_PB_Custom_Field_Config_Import {
 	private $config;
 
 	public function add_hooks() {
-		add_filter( 'wpml_config_array', array( $this, 'save_config' ) );
+		add_filter( 'wpml_config_array', array( $this, 'parse' ) );
 	}
 
 	/**
@@ -13,7 +13,7 @@ class WPML_PB_Custom_Field_Config_Import {
 	 *
 	 * @return array
 	 */
-	public function save_config( $config_data ) {
+	public function parse( $config_data ) {
 		$old_config = $this->get();
 		$config     = array();
 

--- a/src/st/strategy/custom-field/class-wpml-pb-custom-field-config-import.php
+++ b/src/st/strategy/custom-field/class-wpml-pb-custom-field-config-import.php
@@ -1,0 +1,113 @@
+<?php
+
+class WPML_PB_Custom_Field_Config_Import {
+
+	private $config;
+
+	public function add_hooks() {
+		add_filter( 'wpml_config_array', array( $this, 'save_config' ) );
+	}
+
+	/**
+	 * @param array $config_data
+	 *
+	 * @return array
+	 */
+	public function save_config( $config_data ) {
+		$old_config = $this->get();
+		$config     = array();
+
+		if ( array_key_exists( WPML_PB_Custom_Field_Config::CUSTOM_FIELD_DATA_KEY, $config_data['wpml-config'] ) ) {
+			$params = array(
+				'custom_field' => $config_data['wpml-config'][ WPML_PB_Custom_Field_Config::CUSTOM_FIELD_DATA_KEY ][ WPML_PB_Custom_Field_Config::CUSTOM_FIELD_KEY ]['value'],
+				'format'       => $config_data['wpml-config'][ WPML_PB_Custom_Field_Config::CUSTOM_FIELD_DATA_KEY ][ WPML_PB_Custom_Field_Config::FORMAT_KEY ]['value'],
+				'node_type'    => $config_data['wpml-config'][ WPML_PB_Custom_Field_Config::CUSTOM_FIELD_DATA_KEY ][ WPML_PB_Custom_Field_Config::NODE_TYPE_KEY ]['value'],
+				'nodes'        => $this->get_nodes( $config_data['wpml-config'][ WPML_PB_Custom_Field_Config::CUSTOM_FIELD_DATA_KEY ][ WPML_PB_Custom_Field_Config::NODES_KEY ] ),
+			);
+
+			$config = new WPML_PB_Custom_Field_Config( $params );
+		}
+
+		if ( $config != $old_config ) {
+			$this->update( $config );
+		}
+
+		return $config_data;
+	}
+
+	/**
+	 * @param array $nodes
+	 *
+	 * @return array
+	 */
+	private function get_nodes( $nodes ) {
+		$nodes_config = array();
+		foreach ( $nodes as $node_key => $node ) {
+			if ( is_array( $node ) ) {
+				foreach ( $node as $field_key => $field ) {
+					if ( is_array( $field ) ) {
+						$node_config = new WPML_PB_Custom_Field_Node();
+
+						$fields      = array();
+						$parent_node = '';
+
+						if ( WPML_PB_Custom_Field_Config::NODE_FIELDS_KEY === $field_key ) {
+							$name = $node_key;
+							foreach ( $field as $item_field ) {
+								$fields[] = $this->get_new_node_field( $item_field );
+							}
+						} else {
+							$name        = $field_key;
+							$parent_node = $node_key;
+							if ( array_key_exists( WPML_PB_Custom_Field_Config::NODE_FIELDS_KEY, $field ) ) {
+								foreach ( $field[ WPML_PB_Custom_Field_Config::NODE_FIELDS_KEY ] as $item ) {
+									$fields[] = $this->get_new_node_field( $item );
+								}
+							}
+						}
+
+						$node_config->set_name( $name );
+						if ( $parent_node ) {
+							$node_config->set_parent_node( $parent_node );
+						}
+						$node_config->set_fields( $fields );
+						$nodes_config[] = $node_config;
+					}
+				}
+			}
+		}
+
+		return $nodes_config;
+	}
+
+	/**
+	 * @param array $field
+	 *
+	 * @return WPML_PB_Custom_Field_Node_Field
+	 */
+	private function get_new_node_field( $field ) {
+		return new WPML_PB_Custom_Field_Node_Field( array(
+			'name'        => $field['value'],
+			'editor_type' => $field['attr'][ WPML_PB_Custom_Field_Node_Field::EDITOR_TYPE_KEY ],
+			'label'       => $field['attr'][ WPML_PB_Custom_Field_Node_Field::LABEL_KEY ],
+		) );
+	}
+
+	/**
+	 * @return WPML_PB_Custom_Field_Config
+	 */
+	public function get() {
+		if ( ! $this->config ) {
+			$this->config = get_option( WPML_PB_Custom_Field_Config::CONFIG_FIELD_KEY );
+		}
+
+		return $this->config;
+	}
+
+	/**
+	 * @param WPML_PB_Custom_Field_Config $data
+	 */
+	private function update( $data ) {
+		update_option( WPML_PB_Custom_Field_Config::CONFIG_FIELD_KEY, $data );
+	}
+}

--- a/src/st/strategy/custom-field/class-wpml-pb-custom-field-config-import.php
+++ b/src/st/strategy/custom-field/class-wpml-pb-custom-field-config-import.php
@@ -3,6 +3,11 @@
 class WPML_PB_Custom_Field_Config_Import {
 
 	private $config;
+	private $custom_field_factory;
+
+	public function __construct( WPML_PB_Custom_Field_Factory $custom_field_factory ) {
+		$this->custom_field_factory = $custom_field_factory;
+	}
 
 	public function add_hooks() {
 		add_filter( 'wpml_config_array', array( $this, 'parse' ) );
@@ -25,7 +30,7 @@ class WPML_PB_Custom_Field_Config_Import {
 				'nodes'        => $this->get_nodes( $config_data['wpml-config'][ WPML_PB_Custom_Field_Config::CUSTOM_FIELD_DATA_KEY ][ WPML_PB_Custom_Field_Config::NODES_KEY ] ),
 			);
 
-			$config = new WPML_PB_Custom_Field_Config( $params );
+			$config = $this->custom_field_factory->create_config( $params );
 		}
 
 		if ( $config != $old_config ) {
@@ -46,7 +51,7 @@ class WPML_PB_Custom_Field_Config_Import {
 			if ( is_array( $node ) ) {
 				foreach ( $node as $field_key => $field ) {
 					if ( is_array( $field ) ) {
-						$node_config = new WPML_PB_Custom_Field_Node();
+						$node_config = $this->custom_field_factory->create_node();
 
 						$fields      = array();
 						$parent_node = '';
@@ -86,7 +91,7 @@ class WPML_PB_Custom_Field_Config_Import {
 	 * @return WPML_PB_Custom_Field_Node_Field
 	 */
 	private function get_new_node_field( $field ) {
-		return new WPML_PB_Custom_Field_Node_Field( array(
+		return $this->custom_field_factory->create_node_field( array(
 			'name'        => $field['value'],
 			'editor_type' => $field['attr'][ WPML_PB_Custom_Field_Node_Field::EDITOR_TYPE_KEY ],
 			'label'       => $field['attr'][ WPML_PB_Custom_Field_Node_Field::LABEL_KEY ],

--- a/src/st/strategy/custom-field/class-wpml-pb-custom-field-config.php
+++ b/src/st/strategy/custom-field/class-wpml-pb-custom-field-config.php
@@ -1,0 +1,56 @@
+<?php
+
+class WPML_PB_Custom_Field_Config {
+
+	const CUSTOM_FIELD_DATA_KEY = 'page-builder-custom-field';
+	const CUSTOM_FIELD_KEY = 'custom-field';
+	const FORMAT_KEY = 'format';
+	const NODE_TYPE_KEY = 'node-type';
+	const NODES_KEY = 'nodes';
+	const NODE_FIELDS_KEY = 'fields';
+	const CONFIG_FIELD_KEY = '_wpml_pb_custom_field_schema';
+
+	/**
+	 * @var string
+	 */
+	private $custom_field;
+
+	/**
+	 * @var string
+	 */
+	private $format;
+
+	/**
+	 * @var string
+	 */
+	private $node_type;
+
+	/**
+	 * @var array
+	 */
+	private $nodes;
+
+	public function __construct( array $params ) {
+		foreach ( get_object_vars( $this ) as $property => $value ) {
+			if ( array_key_exists( $property, $params ) ) {
+				$this->$property = $params[ $property ];
+			}
+		}
+	}
+
+	public function get_custom_field() {
+		return $this->custom_field;
+	}
+
+	public function get_format() {
+		return $this->format;
+	}
+
+	public function get_node_type() {
+		return $this->node_type;
+	}
+
+	public function get_nodes() {
+		return $this->nodes;
+	}
+}

--- a/src/st/strategy/custom-field/class-wpml-pb-custom-field-node-field.php
+++ b/src/st/strategy/custom-field/class-wpml-pb-custom-field-node-field.php
@@ -1,0 +1,42 @@
+<?php
+
+class WPML_PB_Custom_Field_Node_Field {
+
+	const EDITOR_TYPE_KEY = 'editor-type';
+	const LABEL_KEY = 'label';
+
+	/**
+	 * @var string
+	 */
+	private $editor_type;
+
+	/**
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * @var string
+	 */
+	private $label;
+
+	public function __construct( array $params ) {
+		foreach ( get_object_vars( $this ) as $property => $value ) {
+			if ( array_key_exists( $property, $params ) ) {
+				$this->$property = $params[ $property ];
+			}
+		}
+	}
+
+	public function get_editor_type() {
+		return $this->editor_type;
+	}
+
+	public function get_label() {
+		return $this->label;
+	}
+
+	public function get_name() {
+		return $this->name;
+	}
+}

--- a/src/st/strategy/custom-field/class-wpml-pb-custom-field-node.php
+++ b/src/st/strategy/custom-field/class-wpml-pb-custom-field-node.php
@@ -1,0 +1,51 @@
+<?php
+
+class WPML_PB_Custom_Field_Node {
+
+	/**
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * @var array
+	 */
+	private $fields;
+
+	/**
+	 * @var string
+	 */
+	private $parent_node;
+
+	public function __construct( array $params = array() ) {
+		foreach ( get_object_vars( $this ) as $property => $value ) {
+			if ( array_key_exists( $property, $params ) ) {
+				$this->$property = $params[ $property ];
+			}
+		}
+	}
+
+	public function get_name() {
+		return $this->name;
+	}
+
+	public function get_fields() {
+		return $this->fields;
+	}
+
+	public function get_parent_node() {
+		return $this->parent_node;
+	}
+
+	public function set_fields( $fields ) {
+		$this->fields = $fields;
+	}
+
+	public function set_name( $name ) {
+		$this->name = $name;
+	}
+
+	public function set_parent_node( $node ) {
+		$this->parent_node = $node;
+	}
+}

--- a/src/st/strategy/custom-field/class-wpml-pb-custom-field-parser.php
+++ b/src/st/strategy/custom-field/class-wpml-pb-custom-field-parser.php
@@ -1,0 +1,4 @@
+<?php
+
+class WPML_PB_Custom_Field_Parser {
+}

--- a/src/st/strategy/custom-field/factory/class-wpml-pb-custom-field-node-factory.php
+++ b/src/st/strategy/custom-field/factory/class-wpml-pb-custom-field-node-factory.php
@@ -1,0 +1,31 @@
+<?php
+
+class WPML_PB_Custom_Field_Factory {
+
+	/**
+	 * @param array $params
+	 *
+	 * @return WPML_PB_Custom_Field_Node
+	 */
+	public function create_node( $params = array() ) {
+		return new WPML_PB_Custom_Field_Node( $params );
+	}
+
+	/**
+	 * @param array $params
+	 *
+	 * @return WPML_PB_Custom_Field_Node_Field
+	 */
+	public function create_node_field( $params = array() ) {
+		return new WPML_PB_Custom_Field_Node_Field( $params );
+	}
+
+	/**
+	 * @param array $params
+	 *
+	 * @return WPML_PB_Custom_Field_Config
+	 */
+	public function create_config( $params = array() ) {
+		return new WPML_PB_Custom_Field_Config( $params );
+	}
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -37,4 +37,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../../vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';
+require_once __DIR__ . '/../../../../../vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';

--- a/tests/phpunit/tests/st/strategy/custom-field/test-wpml-pb-custom-field-config-import.php
+++ b/tests/phpunit/tests/st/strategy/custom-field/test-wpml-pb-custom-field-config-import.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Class Test_WPML_PB_Custom_Field_Config_Import
+ *
+ * @group wpmlcore-5378
+ */
+class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_adds_hooks() {
+		$subject = new WPML_PB_Custom_Field_Config_Import();
+		\WP_Mock::expectFilterAdded( 'wpml_config_array', array( $subject, 'save_config' ) );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dp_nodes
+	 */
+	public function it_saves_config( $node ) {
+		$config = $this->get_config_data();
+		$config['wpml-config']['page-builder-custom-field']['nodes'] = $node;
+		$subject = new WPML_PB_Custom_Field_Config_Import();
+
+		\WP_Mock::wpFunction( 'get_option', array(
+			'args' => WPML_PB_Custom_Field_Config::CONFIG_FIELD_KEY,
+			'return' => array(),
+		));
+
+		$custom_field = '_cornerstone_data';
+		$format = 'json';
+		$node_type = '_type';
+		$node_name = array_keys( $node )[0];
+
+		$field = new WPML_PB_Custom_Field_Node_Field( array(
+			'name' => $node[ $node_name ]['fields'][0]['value'],
+			'editor_type' => $node[ $node_name ]['fields'][0]['attr']['editor-type'],
+			'label' => $node[ $node_name ]['fields'][0]['attr']['label'],
+		) );
+
+		$node = new WPML_PB_Custom_Field_Node( array(
+			'name' => $node_name,
+			'fields' => array( $field ),
+		) );
+
+		$data = new WPML_PB_Custom_Field_Config( array(
+			'custom_field' => $custom_field,
+			'format' => $format,
+			'node_type' => $node_type,
+			'nodes' => array( $node ),
+		) );
+
+		\WP_Mock::wpFunction( 'update_option', array(
+			'args' => array( WPML_PB_Custom_Field_Config::CONFIG_FIELD_KEY, \WP_Mock\Functions::type( 'WPML_PB_Custom_Field_Config' ) ),
+			'times' => 1,
+		));
+
+		$this->assertEquals( $config, $subject->save_config( $config ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_gets_config() {
+		$config_data = rand_str( 10 );
+		$subject     = new WPML_PB_Custom_Field_Config_Import();
+
+		\WP_Mock::wpFunction( 'get_option', array(
+			'args' => WPML_PB_Custom_Field_Config::CONFIG_FIELD_KEY,
+			'return' => $config_data,
+			'times' => 1,
+		));
+
+
+		$this->assertEquals( $config_data, $subject->get() );
+	}
+
+	private function get_config_data() {
+		return array(
+			'wpml-config' => array(
+				'page-builder-custom-field' =>
+					array(
+						'value'        => '',
+						'custom-field' =>
+							array(
+								'value' => '_cornerstone_data',
+							),
+						'format'       =>
+							array(
+								'value' => 'json',
+							),
+						'node-type'    =>
+							array(
+								'value' => '_type',
+							),
+					)
+			)
+		);
+	}
+
+	public function dp_nodes() {
+		return array(
+			'Node without subitems' => array(
+				'fields' => array(
+					'my-node' => array(
+						'fields' => array(
+							array( 'value' => 'title', 'attr' => array( 'editor-type' => 'LINE', 'label' => 'My Title' ) )
+						),
+					),
+				)
+			),
+			'Node with items' => array(
+				'fields' => array(
+					'my-node' => array(
+						'fields' => array(
+							array( 'value' => 'title', 'attr' => array( 'editor-type' => 'LINE', 'label' => 'My Title' ) )
+						),
+						'node-item' => array(
+							'fields' => array(
+								array( 'value' => 'my sub node', 'attr' => array( 'editor-type' => 'LINE', 'label' => 'My sub node title' ) ),
+							)
+						)
+					),
+				)
+			)
+		);
+	}
+}

--- a/tests/phpunit/tests/st/strategy/custom-field/test-wpml-pb-custom-field-config-import.php
+++ b/tests/phpunit/tests/st/strategy/custom-field/test-wpml-pb-custom-field-config-import.php
@@ -3,6 +3,7 @@
 /**
  * Class Test_WPML_PB_Custom_Field_Config_Import
  *
+ * @group custom-field
  * @group wpmlcore-5378
  */
 class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
@@ -11,7 +12,7 @@ class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
 	 * @test
 	 */
 	public function it_adds_hooks() {
-		$subject = new WPML_PB_Custom_Field_Config_Import();
+		$subject = new WPML_PB_Custom_Field_Config_Import( $this->get_custom_field_factory() );
 		\WP_Mock::expectFilterAdded( 'wpml_config_array', array( $subject, 'parse' ) );
 		$subject->add_hooks();
 	}
@@ -21,9 +22,10 @@ class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
 	 * @dataProvider dp_nodes
 	 */
 	public function it_parse_config_data( $node ) {
+		$custom_field_factory = $this->get_custom_field_factory();
 		$config = $this->get_config_data();
 		$config['wpml-config']['page-builder-custom-field']['nodes'] = $node;
-		$subject = new WPML_PB_Custom_Field_Config_Import();
+		$subject = new WPML_PB_Custom_Field_Config_Import( $custom_field_factory );
 
 		\WP_Mock::wpFunction( 'get_option', array(
 			'args' => WPML_PB_Custom_Field_Config::CONFIG_FIELD_KEY,
@@ -65,8 +67,9 @@ class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
 	 * @test
 	 */
 	public function it_gets_config() {
+		$custom_field_factory = $this->get_custom_field_factory();
 		$config_data = rand_str( 10 );
-		$subject     = new WPML_PB_Custom_Field_Config_Import();
+		$subject     = new WPML_PB_Custom_Field_Config_Import( $custom_field_factory );
 
 		\WP_Mock::wpFunction( 'get_option', array(
 			'args' => WPML_PB_Custom_Field_Config::CONFIG_FIELD_KEY,
@@ -127,5 +130,11 @@ class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
 				)
 			)
 		);
+	}
+
+	private function get_custom_field_factory() {
+		return $this->getMockBuilder( 'WPML_PB_Custom_Field_Factory' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 }

--- a/tests/phpunit/tests/st/strategy/custom-field/test-wpml-pb-custom-field-config-import.php
+++ b/tests/phpunit/tests/st/strategy/custom-field/test-wpml-pb-custom-field-config-import.php
@@ -12,7 +12,7 @@ class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
 	 */
 	public function it_adds_hooks() {
 		$subject = new WPML_PB_Custom_Field_Config_Import();
-		\WP_Mock::expectFilterAdded( 'wpml_config_array', array( $subject, 'save_config' ) );
+		\WP_Mock::expectFilterAdded( 'wpml_config_array', array( $subject, 'parse' ) );
 		$subject->add_hooks();
 	}
 
@@ -20,7 +20,7 @@ class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
 	 * @test
 	 * @dataProvider dp_nodes
 	 */
-	public function it_saves_config( $node ) {
+	public function it_parse_config_data( $node ) {
 		$config = $this->get_config_data();
 		$config['wpml-config']['page-builder-custom-field']['nodes'] = $node;
 		$subject = new WPML_PB_Custom_Field_Config_Import();
@@ -58,7 +58,7 @@ class Test_WPML_PB_Custom_Field_Config_Import extends OTGS_TestCase {
 			'times' => 1,
 		));
 
-		$this->assertEquals( $config, $subject->save_config( $config ) );
+		$this->assertEquals( $config, $subject->parse( $config ) );
 	}
 
 	/**


### PR DESCRIPTION
- The importer class will be responsible by fetching WPML config data (XML) and cache an option for page builder custom fields
- I've created some entities for the configuration data, nodes, and fields