### PR TITLE
[wpmltm-2670] Add a hook for translations into the post

### DIFF
--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -100,6 +100,7 @@ class WPML_PB_Integration {
 		add_action( 'save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
 		add_action( 'icl_st_add_string_translation', array( $this, 'new_translation' ), 10, 1 );
 		add_action( 'shutdown', array( $this, 'do_shutdown_action' ) );
+		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'save_translations_to_post' ) );
 		add_action( 'wpml_pro_translation_completed', array( $this, 'cleanup_strings_after_translation_completed' ), 10, 3 );
 
 		add_filter( 'wpml_tm_translation_job_data', array( $this, 'rescan' ), 9, 2 );

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -88,7 +88,6 @@ class WPML_TM_Page_Builders {
 			$string_id = $wrapper->get_string_id();
 
 			if ( $string_id ) {
-
 				do_action(
 					'wpml_add_string_translation',
 					$string_id,
@@ -100,6 +99,8 @@ class WPML_TM_Page_Builders {
 				);
 			}
 		}
+
+		do_action( 'wpml_pb_finished_adding_string_translations' );
 	}
 
 	/**

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -57,6 +57,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 			'cleanup_strings_after_translation_completed',
 		),	10, 3 );
 		\WP_Mock::expectFilterAdded( 'wpml_tm_translation_job_data', array( $pb_integration, 'rescan' ), 9, 2 );
+		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array( $pb_integration, 'save_translations_to_post' ) );
 
 		$pb_integration->add_hooks();
 	}

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -285,6 +285,8 @@ class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 			$job->translation_service
 		);
 
+		\WP_Mock::expectAction( 'wpml_pb_finished_adding_string_translations' );
+
 		$subject->pro_translation_completed_action( $new_post_id, $fields, $job );
 	}
 


### PR DESCRIPTION
Recently we've stopped updating the post on each string package iteration (when updating) because it was causing performance issues, so we choose to only update it once in the “shutdown” hook. However, this change is avoiding third parties to properly use the hook `wpml_pro_translation_completed`, because when they hook into it, the translated post body does not have any content in the post body yet (because shutdown didn’t get triggered at that time).

Now, I’ve added a new action to run as soon as all string packages are updated and, of course, before the shutdown action. This new action is actually added inside of the Page Builders callback of `wpml_pro_translation_completed`.