### PR TITLE
Handling page builder page without translatable elements

### DIFF
--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -8,7 +8,6 @@ class WPML_PB_Loader {
 		WPML_ST_Settings $st_settings,
 		$pb_integration = null // Only needed for testing
 	) {
-
 		do_action( 'wpml_load_page_builders_integration' );
 
 		$page_builder_strategies = array();
@@ -19,6 +18,16 @@ class WPML_PB_Loader {
 			$strategy = new WPML_PB_Shortcode_Strategy();
 			$strategy->add_shortcodes( $page_builder_config_import->get_settings() );
 			$page_builder_strategies[] = $strategy;
+		}
+
+		if ( class_exists( 'WPML_Config_Built_With_Page_Builders' ) ) {
+			$post_body_handler = new WPML_PB_Handle_Post_Body(
+				new WPML_Page_Builders_Page_Built(
+					new WPML_Config_Built_With_Page_Builders()
+				)
+			);
+
+			$post_body_handler->add_hooks();
 		}
 
 		$required = apply_filters( 'wpml_page_builder_support_required', array() );

--- a/src/tm/class-wpml-pb-handle-custom-fields.php
+++ b/src/tm/class-wpml-pb-handle-custom-fields.php
@@ -1,0 +1,47 @@
+<?php
+
+class WPML_PB_Handle_Custom_Fields {
+
+	protected $data_settings;
+
+	public function __construct( IWPML_Page_Builders_Data_Settings $data_settings ) {
+		$this->data_settings = $data_settings;
+	}
+
+	public function add_hooks() {
+		add_filter( 'wpml_pb_is_page_builder_page', array( $this, 'is_page_builder_page_filter' ), 10, 2 );
+		add_action( 'wpml_pb_after_page_without_elements_post_content_copy', array(
+			$this,
+			'copy_custom_fields'
+		), 10, 2 );
+	}
+
+	/**
+	 * @param bool $is_page_builder_page
+	 * @param WP_Post $post
+	 *
+	 * @return bool
+	 */
+	public function is_page_builder_page_filter( $is_page_builder_page, WP_Post $post ) {
+		if ( get_post_meta( $post->ID, $this->data_settings->get_meta_field() ) ) {
+			$is_page_builder_page = true;
+		}
+
+		return $is_page_builder_page;
+	}
+
+	/**
+	 * @param int $new_post_id
+	 * @param int $original_post_id
+	 */
+	public function copy_custom_fields( $new_post_id, $original_post_id ) {
+		$fields = array_merge( $this->data_settings->get_fields_to_copy(), $this->data_settings->get_fields_to_save() );
+
+		foreach ( $fields as $field ) {
+			$original_field = get_post_meta( $original_post_id, $field, true );
+			if ( $original_field ) {
+				update_post_meta( $new_post_id, $field, $original_field );
+			}
+		}
+	}
+}

--- a/src/tm/class-wpml-pb-handle-post-body.php
+++ b/src/tm/class-wpml-pb-handle-post-body.php
@@ -1,0 +1,53 @@
+<?php
+
+class WPML_PB_Handle_Post_Body {
+
+	private $page_builders_built;
+
+	public function __construct( WPML_Page_Builders_Page_Built $page_builders_built ) {
+		$this->page_builders_built = $page_builders_built;
+	}
+
+	public function add_hooks() {
+		add_filter( 'wpml_pb_should_body_be_translated', array( $this, 'should_translate' ), 10, 3 );
+		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'copy' ), 10, 3 );
+	}
+
+	/**
+	 * @param int $translate
+	 * @param WP_Post $post
+	 *
+	 * @return int
+	 */
+	public function should_translate( $translate, WP_Post $post ) {
+		return $this->page_builders_built->is_page_builder_page( $post ) ? 0 : $translate;
+	}
+
+	/**
+	 * @param int $new_post_id
+	 * @param int $original_post_id
+	 * @param array $fields
+	 */
+	public function copy( $new_post_id, $original_post_id, array $fields ) {
+		$original_post = get_post( $original_post_id );
+		if ( $this->page_builders_built->is_page_builder_page( $original_post ) && ! $this->job_has_packages( $fields ) ) {
+			wp_update_post( array( 'ID' => $new_post_id, 'post_content' => $original_post->post_content ) );
+			do_action( 'wpml_pb_after_page_without_elements_post_content_copy', $new_post_id, $original_post_id );
+		}
+	}
+
+	/**
+	 * @param array $fields
+	 *
+	 * @return bool
+	 */
+	private function job_has_packages( array $fields ) {
+		foreach ( $fields as $key => $field ) {
+			if ( 0 === strpos( $key, 'package' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -22,7 +22,6 @@ class WPML_TM_Page_Builders {
 	 * @return array
 	 */
 	public function translation_job_data_filter( array $translation_package, $post ) {
-
 		if ( self::PACKAGE_TYPE_EXTERNAL !== $translation_package['type'] && isset( $post->ID ) ) {
 			$post_element        = new WPML_Post_Element( $post->ID, $this->sitepress );
 			$source_post_id      = $post->ID;
@@ -36,6 +35,8 @@ class WPML_TM_Page_Builders {
 			$job_source_is_not_post_source = $post->ID !== $source_post_id;
 
 			$string_packages = apply_filters( 'wpml_st_get_post_string_packages', false, $source_post_id );
+
+			$translation_package['contents']['body']['translate'] = apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
 
 			if ( $string_packages ) {
 
@@ -100,7 +101,7 @@ class WPML_TM_Page_Builders {
 			}
 		}
 
-		do_action( 'wpml_pb_finished_adding_string_translations' );
+		do_action( 'wpml_pb_finished_adding_string_translations', $new_post_id, $job->original_doc_id, $fields );
 	}
 
 	/**

--- a/src/utilities/class-wpml-page-builders-page-built-with-built.php
+++ b/src/utilities/class-wpml-page-builders-page-built-with-built.php
@@ -1,0 +1,20 @@
+<?php
+
+class WPML_Page_Builders_Page_Built {
+
+	private $config;
+
+	public function __construct( array $config ) {
+		$this->config = $config;
+	}
+
+	/**
+	 * @param WP_Post $post
+	 *
+	 * @return bool
+	 */
+	public function is_page_builder_page( WP_Post $post ) {
+		return isset( $this->config['wpml-config']['built_with_page_builder'] )
+		       && preg_match( '/' . $this->config['wpml-config']['built_with_page_builder'] . '/', $post->post_content );
+	}
+}

--- a/src/utilities/class-wpml-page-builders-page-built-with-built.php
+++ b/src/utilities/class-wpml-page-builders-page-built-with-built.php
@@ -4,7 +4,7 @@ class WPML_Page_Builders_Page_Built {
 
 	private $config;
 
-	public function __construct( array $config ) {
+	public function __construct( WPML_Config_Built_With_Page_Builders $config ) {
 		$this->config = $config;
 	}
 
@@ -14,7 +14,19 @@ class WPML_Page_Builders_Page_Built {
 	 * @return bool
 	 */
 	public function is_page_builder_page( WP_Post $post ) {
-		return isset( $this->config['wpml-config']['built_with_page_builder'] )
-		       && preg_match( '/' . $this->config['wpml-config']['built_with_page_builder'] . '/', $post->post_content );
+		$result      = false;
+		$config_data = $this->config->get();
+
+		if ( is_array( $config_data ) ) {
+			foreach ( $config_data as $pattern ) {
+				$result = (bool) preg_match_all( $pattern, $post->post_content );
+
+				if ( $result ) {
+					break;
+				}
+			}
+		}
+
+		return apply_filters( 'wpml_pb_is_page_builder_page', $result, $post );
 	}
 }

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * Class Test_WPML_PB_Handle_Custom_Fields
+ *
+ * @group wpmlpb-149
+ */
+class Test_WPML_PB_Handle_Custom_Fields extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_adds_hooks() {
+		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+		                      ->setMethods( array(
+			                      'get_node_id_field',
+			                      'get_fields_to_copy',
+			                      'get_fields_to_save',
+			                      'get_meta_field',
+			                      'convert_data_to_array',
+			                      'prepare_data_for_saving',
+			                      'get_pb_name',
+			                      'add_hooks',
+		                      ) )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
+
+		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
+
+		\WP_Mock::expectFilterAdded( 'wpml_pb_is_page_builder_page', array(
+			$subject,
+			'is_page_builder_page_filter'
+		), 10, 2 );
+		\WP_Mock::expectActionAdded( 'wpml_pb_after_page_without_elements_post_content_copy', array(
+			$subject,
+			'copy_custom_fields'
+		), 10, 2 );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_true_when_post_has_the_custom_field() {
+		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+		                      ->setMethods( array(
+			                      'get_node_id_field',
+			                      'get_fields_to_copy',
+			                      'get_fields_to_save',
+			                      'get_meta_field',
+			                      'convert_data_to_array',
+			                      'prepare_data_for_saving',
+			                      'get_pb_name',
+			                      'add_hooks',
+		                      ) )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
+
+		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
+
+		$post = $this->getMockBuilder( 'WP_Post' )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$post->ID    = 10;
+		$field       = 'my-custom-field';
+		$field_value = 'something';
+
+		$data_settings->method( 'get_meta_field' )
+		              ->willReturn( $field );
+
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'args'   => array( $post->ID, $field ),
+			'return' => $field_value,
+		) );
+
+		$this->assertTrue( $subject->is_page_builder_page_filter( false, $post ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_unfiltered_result_when_post_does_not_have_the_custom_field() {
+		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+		                      ->setMethods( array(
+			                      'get_node_id_field',
+			                      'get_fields_to_copy',
+			                      'get_fields_to_save',
+			                      'get_meta_field',
+			                      'convert_data_to_array',
+			                      'prepare_data_for_saving',
+			                      'get_pb_name',
+			                      'add_hooks',
+		                      ) )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
+
+		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
+
+		$post = $this->getMockBuilder( 'WP_Post' )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$post->ID = 10;
+		$field    = 'my-custom-field';
+
+		$data_settings->method( 'get_meta_field' )
+		              ->willReturn( $field );
+
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'args'   => array( $post->ID, $field ),
+			'return' => false,
+		) );
+
+		$this->assertFalse( $subject->is_page_builder_page_filter( false, $post ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_copies_custom_fields_when_original_custom_field_exists() {
+		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+		                      ->setMethods( array(
+			                      'get_node_id_field',
+			                      'get_fields_to_copy',
+			                      'get_fields_to_save',
+			                      'get_meta_field',
+			                      'convert_data_to_array',
+			                      'prepare_data_for_saving',
+			                      'get_pb_name',
+			                      'add_hooks',
+		                      ) )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
+
+		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
+
+		$field                = 'my-custom-field';
+		$original_field_value = 'something';
+
+		$new_post_id      = 1;
+		$original_post_id = 2;
+
+		$data_settings->method( 'get_meta_field' )
+		              ->willReturn( $field );
+
+		$data_settings->method( 'get_fields_to_copy' )
+		              ->willReturn( array( $field ) );
+
+		$data_settings->method( 'get_fields_to_save' )
+		              ->willReturn( array() );
+
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'args'   => array( $original_post_id, $field, true ),
+			'return' => $original_field_value,
+		) );
+
+		\WP_Mock::wpFunction( 'update_post_meta', array(
+			'args'  => array( $new_post_id, $field, $original_field_value ),
+			'times' => 1,
+		) );
+
+		$subject->copy_custom_fields( $new_post_id, $original_post_id );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_copy_custom_fields_when_original_custom_field_does_not_exists() {
+		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+		                      ->setMethods( array(
+			                      'get_node_id_field',
+			                      'get_fields_to_copy',
+			                      'get_fields_to_save',
+			                      'get_meta_field',
+			                      'convert_data_to_array',
+			                      'prepare_data_for_saving',
+			                      'get_pb_name',
+			                      'add_hooks',
+		                      ) )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
+
+		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
+
+		$field                = 'my-custom-field';
+		$original_field_value = '';
+
+		$new_post_id      = 1;
+		$original_post_id = 2;
+
+		$data_settings->method( 'get_meta_field' )
+		              ->willReturn( $field );
+
+		$data_settings->method( 'get_fields_to_copy' )
+		              ->willReturn( array( $field ) );
+
+		$data_settings->method( 'get_fields_to_save' )
+		              ->willReturn( array() );
+
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'args'   => array( $original_post_id, $field, true ),
+			'return' => $original_field_value,
+		) );
+
+		\WP_Mock::wpFunction( 'update_post_meta', array(
+			'times' => 0,
+		) );
+
+		$subject->copy_custom_fields( $new_post_id, $original_post_id );
+	}
+}

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Class Test_WPML_PB_Handle_Post_Body
+ *
+ * @group wpmlcore-5684
+ */
+class Test_WPML_PB_Handle_Post_Body extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_adds_hooks() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+		                            ->disableOriginalConstructor()
+		                            ->getMock();
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+		\WP_Mock::expectFilterAdded( 'wpml_pb_should_body_be_translated', array(
+			$subject,
+			'should_translate'
+		), 10, 3 );
+		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array( $subject, 'copy' ), 10, 3 );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_0_if_page_is_built_with_page_builders() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+		                            ->disableOriginalConstructor()
+		                            ->getMock();
+
+		$post = $this->getMockBuilder( 'WP_Post' )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $post )
+		                    ->willReturn( true );
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+		$this->assertEquals( 0, $subject->should_translate( 1, $post, false ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_unfiltered_data_if_page_is_not_a_page_builder_page_neither_has_string_packages() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+		                            ->disableOriginalConstructor()
+		                            ->getMock();
+
+		$post = $this->getMockBuilder( 'WP_Post' )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $post )
+		                    ->willReturn( false );
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+		$this->assertEquals( 1, $subject->should_translate( 1, $post, false ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_copies_post_content_from_original_to_translation_when_it_is_page_builder_page_and_has_no_string_package() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+		                            ->disableOriginalConstructor()
+		                            ->getMock();
+
+		$new_post_id                 = 2;
+		$original_post_id            = 1;
+		$original_post               = $this->getMockBuilder( 'WP_Post' )
+		                                    ->disableOriginalConstructor()
+		                                    ->getMock();
+		$original_post->post_content = 'my-content';
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $original_post )
+		                    ->willReturn( true );
+
+		$fields = array(
+			'not-a-package' => 'something',
+		);
+
+		\WP_Mock::wpFunction( 'get_post', array(
+			'args'   => $original_post_id,
+			'return' => $original_post,
+		) );
+
+		\WP_Mock::wpFunction( 'wp_update_post', array(
+			'times' => 1,
+			'args'  => array(
+				array( 'ID' => $new_post_id, 'post_content' => $original_post->post_content ),
+			)
+		) );
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $original_post )
+		                    ->willReturn( true );
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+		$subject->copy( $new_post_id, $original_post_id, $fields );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_copy_post_content_from_original_to_translation_when_it_is_not_page_builder_page() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+		                            ->disableOriginalConstructor()
+		                            ->getMock();
+
+		$new_post_id                 = 2;
+		$original_post_id            = 1;
+		$original_post               = $this->getMockBuilder( 'WP_Post' )
+		                                    ->disableOriginalConstructor()
+		                                    ->getMock();
+		$original_post->post_content = 'my-content';
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $original_post )
+		                    ->willReturn( false );
+
+		$fields = array(
+			'not-a-package' => 'something',
+		);
+
+		\WP_Mock::wpFunction( 'get_post', array(
+			'args'   => $original_post_id,
+			'return' => $original_post,
+		) );
+
+		\WP_Mock::wpFunction( 'wp_update_post', array(
+			'times' => 0,
+			'args'  => array(
+				'ID'           => $new_post_id,
+				'post_content' => $original_post->post_content,
+			)
+		) );
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $original_post )
+		                    ->willReturn( true );
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+		$subject->copy( $new_post_id, $original_post_id, $fields );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_copy_post_content_from_original_to_translation_when_page_contains_string_package() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+		                            ->disableOriginalConstructor()
+		                            ->getMock();
+
+		$new_post_id                 = 2;
+		$original_post_id            = 1;
+		$original_post               = $this->getMockBuilder( 'WP_Post' )
+		                                    ->disableOriginalConstructor()
+		                                    ->getMock();
+		$original_post->post_content = 'my-content';
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $original_post )
+		                    ->willReturn( true );
+
+		$fields = array(
+			'package-something' => 'something',
+		);
+
+		\WP_Mock::wpFunction( 'get_post', array(
+			'args'   => $original_post_id,
+			'return' => $original_post,
+		) );
+
+		\WP_Mock::wpFunction( 'wp_update_post', array(
+			'times' => 0,
+			'args'  => array(
+				'ID'           => $new_post_id,
+				'post_content' => $original_post->post_content,
+			)
+		) );
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $original_post )
+		                    ->willReturn( true );
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+		$subject->copy( $new_post_id, $original_post_id, $fields );
+	}
+}

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -2,6 +2,7 @@
 
 /**
  * @group page-builders
+ * @group adriano
  */
 class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 
@@ -261,6 +262,7 @@ class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 		$job->language_code       = rand_str( 2 );
 		$job->translator_id       = rand( 1, 50 );
 		$job->translation_service = rand( 1, 50 );
+		$job->original_doc_id     = 20;
 
 		$field_string1 = $this->find_field_with_slug( $data['string1_field_name'], $fields );
 		$field_string2 = $this->find_field_with_slug( $data['string2_field_name'], $fields );
@@ -285,7 +287,7 @@ class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 			$job->translation_service
 		);
 
-		\WP_Mock::expectAction( 'wpml_pb_finished_adding_string_translations' );
+		\WP_Mock::expectAction( 'wpml_pb_finished_adding_string_translations', $new_post_id, $job->original_doc_id, $fields );
 
 		$subject->pro_translation_completed_action( $new_post_id, $fields, $job );
 	}

--- a/tests/phpunit/tests/utilities/test-wpml-page-builders-page-built.php
+++ b/tests/phpunit/tests/utilities/test-wpml-page-builders-page-built.php
@@ -12,18 +12,20 @@ class Test_WPML_Page_Builders_Page_Built extends OTGS_TestCase {
 	 */
 	public function it_returns_true_when_it_is_a_page_builder_page() {
 		$post = $this->getMockBuilder( 'WP_Post' )
-			->disableOriginalConstructor()
-			->getMock();
+		             ->disableOriginalConstructor()
+		             ->getMock();
 
 		$post->post_content = '[vc_row][/vc_row]';
 
-		$config = array(
-			'wpml-config' => array(
-				'built_with_page_builder' => 'vc_row',
-			),
-		);
+		$config = $this->getMockBuilder( 'WPML_Config_Built_With_Page_Builders' )
+		               ->setMethods( array( 'get' ) )
+		               ->disableOriginalConstructor()
+		               ->getMock();
 
-		$subject = new WPML_Page_Builders_Page( $config );
+		$config->method( 'get' )
+		       ->willReturn( array( '/\[vc_row\]/' ) );
+
+		$subject = new WPML_Page_Builders_Page_Built( $config );
 		$this->assertTrue( $subject->is_page_builder_page( $post ) );
 	}
 
@@ -37,13 +39,15 @@ class Test_WPML_Page_Builders_Page_Built extends OTGS_TestCase {
 
 		$post->post_content = 'my content';
 
-		$config = array(
-			'wpml-config' => array(
-				'built_with_page_builder' => 'vc_row',
-			),
-		);
+		$config = $this->getMockBuilder( 'WPML_Config_Built_With_Page_Builders' )
+		               ->setMethods( array( 'get' ) )
+		               ->disableOriginalConstructor()
+		               ->getMock();
 
-		$subject = new WPML_Page_Builders_Page( $config );
+		$config->method( 'get' )
+		       ->willReturn( array( '/\[vc_row\]/' ) );
+
+		$subject = new WPML_Page_Builders_Page_Built( $config );
 		$this->assertFalse( $subject->is_page_builder_page( $post ) );
 	}
 }

--- a/tests/phpunit/tests/utilities/test-wpml-page-builders-page-built.php
+++ b/tests/phpunit/tests/utilities/test-wpml-page-builders-page-built.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Class Test_WPML_Page_Builders_Page_Built
+ *
+ * @group wpmlpb-148
+ */
+class Test_WPML_Page_Builders_Page_Built extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_returns_true_when_it_is_a_page_builder_page() {
+		$post = $this->getMockBuilder( 'WP_Post' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$post->post_content = '[vc_row][/vc_row]';
+
+		$config = array(
+			'wpml-config' => array(
+				'built_with_page_builder' => 'vc_row',
+			),
+		);
+
+		$subject = new WPML_Page_Builders_Page( $config );
+		$this->assertTrue( $subject->is_page_builder_page( $post ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_false_when_it_is_not_a_page_builder_page() {
+		$post = $this->getMockBuilder( 'WP_Post' )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$post->post_content = 'my content';
+
+		$config = array(
+			'wpml-config' => array(
+				'built_with_page_builder' => 'vc_row',
+			),
+		);
+
+		$subject = new WPML_Page_Builders_Page( $config );
+		$this->assertFalse( $subject->is_page_builder_page( $post ) );
+	}
+}


### PR DESCRIPTION
- Added a new filter `wpml_pb_post_content_translate` which can be used to say whether a post content is set as translatable or not (0 or 1). In this case I needed that to say that if a particular page is a page builder page then it should not send the post content for translations, but rather copy that.

- Added some parameters into the existing fitler `wpml_pb_finished_adding_string_translations` so I'm able to copy the content of original post to translation when needed.

- Added another action `wpml_pb_after_page_without_elements_post_content_copy` which will be used by other custom page builders like Elementor and Beaver Builder in order to copy needed custom fields when needed.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-146