### PR TITLE
Allow replacing long strings in page builder shortcodes

### DIFF
--- a/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
@@ -2,6 +2,8 @@
 
 class WPML_PB_Update_Shortcodes_In_Content {
 
+	const LONG_STRING_THRESHOLD = 5000;
+
 	/** @var  WPML_PB_Shortcode_Strategy $strategy */
 	private $strategy;
 	/** @var WPML_PB_Shortcode_Encoding $encoding */
@@ -80,20 +82,36 @@ class WPML_PB_Update_Shortcodes_In_Content {
 
 	private function replace_string_with_translation( $block, $original, $translation, $is_attribute = false, $attr = '' ) {
 		$translation = apply_filters( 'wpml_pb_before_replace_string_with_translation', $translation, $is_attribute );
+		$new_block   = $block;
 
-		$new_block = $block;
 		if ( $translation ) {
-			if ( $is_attribute && $attr ) {
-				$pattern   = '/' . $attr . '=(["\'])' . preg_quote( $original, '/' ) . '(["\'])/';
-				$new_block = preg_replace( $pattern, $attr . '=${1}' . $translation . '${2}', $block );
+
+			if ( $this->is_string_too_long_for_regex( $original ) ) {
+				$new_block         = str_replace( $original, $translation, $block );
+				$this->new_content = str_replace( $block, $new_block, $this->new_content );
 			} else {
-				$pattern   = '/(]\s*)' . preg_quote( trim( $original ), '/' ) . '(\s*\[)/';
-				$new_block = preg_replace( $pattern, '${1}' . trim( $translation ) . '${2}', $block );
+				if ( $is_attribute && $attr ) {
+					$pattern   = '/' . $attr . '=(["\'])' . preg_quote( $original, '/' ) . '(["\'])/';
+					$new_block = preg_replace( $pattern, $attr . '=${1}' . $translation . '${2}', $block );
+				} else {
+					$pattern   = '/(]\s*)' . preg_quote( trim( $original ), '/' ) . '(\s*\[)/';
+					$new_block = preg_replace( $pattern, '${1}' . trim( $translation ) . '${2}', $block );
+				}
+
+				$this->new_content = preg_replace( '/'. preg_quote( $block, '/' ) . '/', $new_block, $this->new_content, 1 );
 			}
-			$this->new_content = preg_replace( '/'. preg_quote( $block, '/' ) . '/', $new_block, $this->new_content, 1 );
 		}
 
 		return $new_block;
+	}
+
+	/**
+	 * @param string $string
+	 *
+	 * @return bool
+	 */
+	private function is_string_too_long_for_regex( $string ) {
+		return mb_strlen( $string ) > self::LONG_STRING_THRESHOLD;
 	}
 
 	private function get_translation( $original, $encoding = false ) {


### PR DESCRIPTION
To fix the issue https://github.com/OnTheGoSystems/wpml-page-builders/issues/6.

`preg_replace` throws an error when the number of characters is too large.

We can consider that we have a very little risk of collision for long strings so we can use a simple `str_replace` in that case.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5470