### PR TITLE
Add support for `raw-html` attribute

### DIFF
--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -16,7 +16,7 @@ class WPML_PB_Loader {
 		$page_builder_config_import = new WPML_PB_Config_Import_Shortcode( $st_settings );
 		$page_builder_config_import->add_hooks();
 		if ( $page_builder_config_import->has_settings() ) {
-			$strategy = new WPML_PB_Shortcode_Strategy();
+			$strategy = new WPML_PB_Shortcode_Strategy( new WPML_Page_Builder_Settings() );
 			$strategy->add_shortcodes( $page_builder_config_import->get_settings() );
 			$page_builder_strategies[] = $strategy;
 		}

--- a/src/st/strategy/shortcode/class-wpml-pb-config-import-shortcode.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-config-import-shortcode.php
@@ -66,6 +66,7 @@ class WPML_PB_Config_Import_Shortcode {
 						'encoding'           => isset( $data['tag']['attr']['encoding'] ) ? $data['tag']['attr']['encoding'] : '',
 						'encoding-condition' => isset( $data['tag']['attr']['encoding-condition'] ) ? $data['tag']['attr']['encoding-condition'] : '',
 						'type'               => isset( $data['tag']['attr']['type'] ) ? $data['tag']['attr']['type'] : '',
+						'raw-html'           => isset( $data['tag']['attr']['raw-html'] ) ? $data['tag']['attr']['raw-html'] : '',
 					),
 					'attributes' => $attributes,
 				);

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
@@ -6,10 +6,23 @@ class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 	/** @var  WPML_PB_Factory $factory */
 	private $factory;
 
+	/** @var WPML_Page_Builder_Settings $page_builder_settings */
+	private $page_builder_settings;
+
+	public function __construct( WPML_Page_Builder_Settings $page_builder_settings ) {
+		$this->page_builder_settings = $page_builder_settings;
+	}
+
 	public function add_shortcodes( $shortcode_data ) {
 
 		foreach ( $shortcode_data as $shortcode ) {
-			$tag = $shortcode['tag']['value'];
+			$tag         = $shortcode['tag']['value'];
+			$is_raw_html = isset( $shortcode['tag']['raw-html'] ) && $shortcode['tag']['raw-html'];
+
+			if ( $is_raw_html && ! $this->page_builder_settings->is_raw_html_translatable() ) {
+				continue;
+			}
+
 			if ( ! in_array( $tag, $this->shortcodes ) ) {
 				$this->shortcodes[ $tag ] = array(
 					'encoding'           => $shortcode['tag']['encoding'],

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
@@ -1,0 +1,70 @@
+<?php
+
+class Test_WPML_PB_Shortcode_Strategy extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @dataProvider dp_raw_html_shortcodes
+	 * @group wpmlpb-154
+	 *
+	 * @param array $shortcode_data
+	 * @param bool  $is_translatable
+	 * @param array $expected_shortcodes
+	 */
+	public function it_should_add_shortcodes_with_raw_html( $shortcode_data, $is_translatable, $expected_shortcodes ) {
+		$page_builder_settings = $this->get_page_builder_settings();
+		$page_builder_settings->method( 'is_raw_html_translatable' )->willReturn( $is_translatable );
+
+		$subject = $this->get_subject( $page_builder_settings );
+
+		$subject->add_shortcodes( $shortcode_data );
+
+		$this->assertEquals( $expected_shortcodes, $subject->get_shortcodes() );
+	}
+
+	public function dp_raw_html_shortcodes() {
+		$shortcode_data = array(
+			array(
+				'tag' => array(
+					'value' => 'tag1',
+					'encoding' => '',
+				),
+			),
+			array(
+				'tag' => array(
+					'value' => 'tag2',
+					'raw-html' => '',
+					'encoding' => '',
+				),
+			),
+			array(
+				'tag' => array(
+					'value' => 'tag3',
+					'raw-html' => '0',
+					'encoding' => '',
+				),
+			),
+			array(
+				'tag' => array(
+					'value' => 'tag4',
+					'raw-html' => '1',
+					'encoding' => '',
+				),
+			),
+		);
+
+		return array(
+			'raw html translatable'     => array( $shortcode_data, true, array( 'tag1', 'tag2', 'tag3', 'tag4' ) ),
+			'raw html not translatable' => array( $shortcode_data, false, array( 'tag1', 'tag2', 'tag3' ) ),
+		);
+	}
+
+	private function get_subject( $page_builder_settings ) {
+		return new WPML_PB_Shortcode_Strategy( $page_builder_settings );
+	}
+
+	private function get_page_builder_settings() {
+		return $this->getMockBuilder( 'WPML_Page_Builder_Settings' )
+			->setMethods( array( 'is_raw_html_translatable' ) )->getMock();
+	}
+}

--- a/tests/phpunit/tests/st/test-wpml-pb-config-import.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-config-import.php
@@ -41,7 +41,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'encoding-condition' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'encoding-condition' => '', 'type' => '', 'raw-html' => '' ),
 					'attributes' => array(
 						array( 'value' => 'attribute1', 'encoding' => '', 'type' => '' ),
 						array( 'value' => 'attribute2', 'encoding' => '', 'type' => '' ),
@@ -54,7 +54,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					'attributes' => array( 'attribute' => array( 'value' => 'attribute3' ) ),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag2', 'encoding' => '', 'encoding-condition' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag2', 'encoding' => '', 'encoding-condition' => '', 'type' => '', 'raw-html' => '' ),
 					'attributes' => array(
 						array( 'value' => 'attribute3', 'encoding' => '', 'type' => '' ),
 					),
@@ -65,7 +65,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					'tag' => array( 'value' => 'tag3' ),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag3', 'encoding' => '', 'encoding-condition' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag3', 'encoding' => '', 'encoding-condition' => '', 'type' => '', 'raw-html' => '' ),
 					'attributes' => array(),
 				),
 			),
@@ -74,7 +74,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					'tag' => array( 'value' => 'tag4', 'attr' => array( 'encoding' => 'encoding1' ) ),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag4', 'encoding' => 'encoding1', 'encoding-condition' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag4', 'encoding' => 'encoding1', 'encoding-condition' => '', 'type' => '', 'raw-html' => '' ),
 					'attributes' => array(),
 				),
 			),
@@ -83,7 +83,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					'tag' => array( 'value' => 'tag4', 'attr' => array( 'encoding' => 'encoding1', 'encoding-condition' => 'option:something=1' ) ),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag4', 'encoding' => 'encoding1', 'encoding-condition' => 'option:something=1', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag4', 'encoding' => 'encoding1', 'encoding-condition' => 'option:something=1', 'type' => '', 'raw-html' => '' ),
 					'attributes' => array(),
 				),
 			),
@@ -98,10 +98,19 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 					),
 				),
 				array(
-					'tag'        => array( 'value' => 'tag5', 'encoding' => '', 'encoding-condition' => '', 'type' => '' ),
+					'tag'        => array( 'value' => 'tag5', 'encoding' => '', 'encoding-condition' => '', 'type' => '', 'raw-html' => '' ),
 					'attributes' => array(
 						array( 'value' => 'attribute4', 'encoding' => 'encoding2', 'type' => '' ),
 					),
+				),
+			),
+			'tag with raw html'  => array(
+				array(
+					'tag'        => array( 'value' => 'tag1', 'attr' => array( 'raw-html' => '1' ) ),
+				),
+				array(
+					'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'encoding-condition' => '', 'type' => '', 'raw-html' => '1' ),
+					'attributes' => array(),
 				),
 			),
 
@@ -158,7 +167,7 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 		);
 
 		$expected_value = array(
-			'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'encoding-condition' => '', 'type' => 'link' ),
+			'tag'        => array( 'value' => 'tag1', 'encoding' => '', 'encoding-condition' => '', 'type' => 'link', 'raw-html' => '' ),
 			'attributes' => array(
 				array( 'value' => 'attribute1', 'encoding' => '', 'type' => 'link' ),
 				array( 'value' => 'attribute2', 'encoding' => '', 'type' => '' ),

--- a/tests/phpunit/tests/st/test-wpml-pb-loader.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-loader.php
@@ -100,5 +100,4 @@ class Test_WPML_PB_Loader extends WPML_PB_TestCase {
 		            ->disableOriginalConstructor()
 		            ->getMock();
 	}
-
 }

--- a/tests/phpunit/util/wpml-pb-test-case.php
+++ b/tests/phpunit/util/wpml-pb-test-case.php
@@ -16,6 +16,7 @@ abstract class WPML_PB_TestCase extends OTGS_TestCase {
 		Mockery::mock( 'AbsoluteLinks' );
 		Mockery::mock( 'WPML_Absolute_To_Permalinks' );
 		Mockery::mock( 'WPML_Translate_Link_Targets' );
+		Mockery::mock( 'WPML_Page_Builder_Settings' );
 	}
 
 	protected function get_factory( $wpdb, $sitepress ) {
@@ -25,7 +26,8 @@ abstract class WPML_PB_TestCase extends OTGS_TestCase {
 	}
 
 	protected function get_shortcode_strategy( WPML_PB_Factory $factory, $encoding = '', $encoding_condition = '' ) {
-		$strategy = new WPML_PB_Shortcode_Strategy();
+		$page_builder_settings = Mockery::mock( 'WPML_Page_Builder_Settings' );
+		$strategy = new WPML_PB_Shortcode_Strategy( $page_builder_settings );
 		$strategy->add_shortcodes(
 			array(
 				array(


### PR DESCRIPTION
- This new attribute is now parsed in the config file.
- If raw html is set to "not translate" in the settings, the shortcodes
with `raw-html` set to 1 will not be added.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-154