### PR TITLE
Add shared logic and interface for media translation

### DIFF
--- a/src/media/class-wpml-page-builders-update-media.php
+++ b/src/media/class-wpml-page-builders-update-media.php
@@ -1,0 +1,43 @@
+<?php
+
+abstract class WPML_Page_Builders_Update_Media implements IWPML_PB_Media_Update {
+
+	/** @var WPML_Page_Builders_Update $pb_update */
+	private $pb_update;
+
+	/** @var WPML_Translation_Element_Factory $element_factory */
+	private $element_factory;
+
+	public function __construct(
+		WPML_Page_Builders_Update $pb_update,
+		WPML_Translation_Element_Factory $element_factory
+	) {
+		$this->pb_update       = $pb_update;
+		$this->element_factory = $element_factory;
+	}
+
+	/**
+	 * @param WP_Post $post
+	 */
+	public function translate( $post ) {
+		$element        = $this->element_factory->create_post( $post->ID );
+		$source_element = $element->get_source_element();
+
+
+		if ( ! $source_element ) {
+			return;
+		}
+
+		$original_post_id = $source_element->get_id();
+		$converted_data   = $this->pb_update->get_converted_data( $original_post_id );
+		$converted_data   = $this->translate_media_in_modules( $converted_data );
+		$this->pb_update->save( $post->ID, $original_post_id, $converted_data );
+	}
+
+	/**
+	 * @param array $converted_data
+	 *
+	 * @return mixed
+	 */
+	abstract protected function translate_media_in_modules( array $converted_data );
+}

--- a/src/media/interface-iwpml-pb-media-update.php
+++ b/src/media/interface-iwpml-pb-media-update.php
@@ -1,0 +1,9 @@
+<?php
+
+interface IWPML_PB_Media_Update {
+
+	/**
+	 * @param WP_Post $post
+	 */
+	public function translate( $post );
+}

--- a/src/st/compatibility/class-wpml-page-builders-update-translation.php
+++ b/src/st/compatibility/class-wpml-page-builders-update-translation.php
@@ -3,29 +3,24 @@
 /**
  * Class WPML_Page_Builders_Update_Translation
  */
-abstract class WPML_Page_Builders_Update_Translation {
+abstract class WPML_Page_Builders_Update_Translation extends WPML_Page_Builders_Update {
 
 	const TRANSLATION_COMPLETE = 10;
-
-	private $string_translations;
-	private $lang;
 
 	/**
 	 * @var IWPML_Page_Builders_Translatable_Nodes
 	 */
 	protected $translatable_nodes;
 
-	/**
-	 * @var IWPML_Page_Builders_Data_Settings
-	 */
-	protected $data_settings;
+	private $string_translations;
+	private $lang;
 
 	public function __construct(
 		IWPML_Page_Builders_Translatable_Nodes $translatable_nodes,
-		IWPML_Page_Builders_Data_Settings $data_settings ) {
-
-		$this->data_settings = $data_settings;
+		IWPML_Page_Builders_Data_Settings $data_settings
+	) {
 		$this->translatable_nodes = $translatable_nodes;
+		parent::__construct( $data_settings );
 	}
 
 	/**
@@ -36,43 +31,12 @@ abstract class WPML_Page_Builders_Update_Translation {
 	 */
 	public function update( $translated_post_id, $original_post, $string_translations, $lang ) {
 		$this->string_translations = $string_translations;
-		$this->lang = $lang;
+		$this->lang                = $lang;
 
-		$data = get_post_meta( $original_post->ID, $this->data_settings->get_meta_field(), true );
-		$converted_data = $this->data_settings->convert_data_to_array( $data );
-
+		$converted_data = $this->get_converted_data( $original_post->ID );
 		$this->update_strings_in_modules( $converted_data );
-		$this->save_data( $translated_post_id, $this->data_settings->get_fields_to_save(), $this->data_settings->prepare_data_for_saving( $converted_data ) );
-		$this->copy_meta_fields( $translated_post_id, $original_post->ID, $this->data_settings->get_fields_to_copy() );
+		$this->save( $translated_post_id, $original_post->ID, $converted_data );
 
-	}
-
-	/**
-	 * @param int $translated_post_id
-	 * @param int $original_post_id
-	 * @param array $meta_fields
-	 */
-	private function copy_meta_fields( $translated_post_id, $original_post_id, $meta_fields ) {
-		foreach ( $meta_fields as $meta_key ) {
-			$value = get_post_meta( $original_post_id, $meta_key, true );
-
-			update_post_meta(
-				$translated_post_id,
-				$meta_key,
-				apply_filters( 'wpml_pb_copy_meta_field', $value, $translated_post_id, $original_post_id, $meta_key )
-			);
-		}
-	}
-
-	/**
-	 * @param int $post_id
-	 * @param array $fields
-	 * @param mixed $data
-	 */
-	private function save_data( $post_id, $fields, $data ) {
-		foreach ( $fields as $field ) {
-			update_post_meta( $post_id, $field, $data );
-		}
 	}
 
 	/**

--- a/src/st/compatibility/class-wpml-page-builders-update.php
+++ b/src/st/compatibility/class-wpml-page-builders-update.php
@@ -1,0 +1,59 @@
+<?php
+
+class WPML_Page_Builders_Update {
+
+	/** @var IWPML_Page_Builders_Data_Settings */
+	protected $data_settings;
+
+	public function __construct( IWPML_Page_Builders_Data_Settings $data_settings ) {
+		$this->data_settings = $data_settings;
+	}
+
+	/**
+	 * @param int $post_id
+	 *
+	 * @return array
+	 */
+	public function get_converted_data( $post_id ) {
+		$data = get_post_meta( $post_id, $this->data_settings->get_meta_field(), true );
+		return $this->data_settings->convert_data_to_array( $data );
+	}
+
+	/**
+	 * @param int   $post_id
+	 * @param int   $original_post_id
+	 * @param array $converted_data
+	 */
+	public function save( $post_id, $original_post_id, $converted_data ) {
+		$this->save_data( $post_id, $this->data_settings->get_fields_to_save(), $this->data_settings->prepare_data_for_saving( $converted_data ) );
+		$this->copy_meta_fields( $post_id, $original_post_id, $this->data_settings->get_fields_to_copy() );
+	}
+
+	/**
+	 * @param int   $post_id
+	 * @param array $fields
+	 * @param mixed $data
+	 */
+	private function save_data( $post_id, $fields, $data ) {
+		foreach ( $fields as $field ) {
+			update_post_meta( $post_id, $field, $data );
+		}
+	}
+
+	/**
+	 * @param int   $translated_post_id
+	 * @param int   $original_post_id
+	 * @param array $meta_fields
+	 */
+	private function copy_meta_fields( $translated_post_id, $original_post_id, $meta_fields ) {
+		foreach ( $meta_fields as $meta_key ) {
+			$value = get_post_meta( $original_post_id, $meta_key, true );
+
+			update_post_meta(
+				$translated_post_id,
+				$meta_key,
+				apply_filters( 'wpml_pb_copy_meta_field', $value, $translated_post_id, $original_post_id, $meta_key )
+			);
+		}
+	}
+}

--- a/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
+++ b/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
@@ -1,0 +1,96 @@
+<?php
+
+class Test_WPML_Page_Builders_Update extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_get_converted_data() {
+		$post_id        = mt_rand( 1, 100 );
+		$meta_key       = 'the-meta-field-key';
+		$raw_data       = array( 'raw data' );
+		$converted_data = array( 'converted data' );
+
+		\WP_Mock::userFunction( 'get_post_meta', array(
+			'args'   => array( $post_id, $meta_key, true ),
+			'return' => $raw_data,
+		));
+
+		$data_settings = $this->get_data_settings();
+		$data_settings->method( 'get_meta_field' )->willReturn( $meta_key );
+		$data_settings->method( 'convert_data_to_array' )->with( $raw_data )->willReturn( $converted_data );
+
+		$subject = $this->get_subject( $data_settings );
+
+		$this->assertEquals( $converted_data, $subject->get_converted_data( $post_id ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_save() {
+		$post_id = mt_rand( 1, 100 );
+		$original_post_id = mt_rand( 101, 200 );
+		$converted_data = array( 'converted data' );
+		$prepared_data  = array( 'prepared data' );
+		$fields_to_save = array( 'the-meta-field-key-1', 'the-meta-field-key-2' );
+		$fields_to_copy = array( 'the-field-to-copy-1', 'the-field-to-copy-2' );
+
+		foreach ( $fields_to_save as $field_to_save ) {
+			\WP_Mock::userFunction( 'update_post_meta', array(
+				'args'   => array( $post_id, $field_to_save, $prepared_data ),
+				'times' => 1,
+			));
+		}
+
+		foreach ( $fields_to_copy as $field_to_copy ) {
+			$field_value = 'value of ' . $field_to_copy;
+			$filterd_value = 'filtered ' . $field_value;
+
+			\WP_Mock::userFunction( 'get_post_meta', array(
+				'args'   => array( $original_post_id, $field_to_copy, true ),
+				'return' => $field_value,
+			));
+
+			\WP_Mock::onFilter( 'wpml_pb_copy_meta_field' )
+				->with( $field_value, $post_id, $original_post_id, $field_to_copy )
+				->reply( $filterd_value );
+
+			\WP_Mock::userFunction( 'update_post_meta', array(
+				'args'   => array( $post_id, $field_to_copy, $filterd_value ),
+				'times' => 1,
+			));
+		}
+
+		$data_settings = $this->get_data_settings();
+		$data_settings->method( 'get_fields_to_save' )->willReturn( $fields_to_save );
+		$data_settings->method( 'prepare_data_for_saving' )->with( $converted_data )->willReturn( $prepared_data );
+		$data_settings->method( 'get_fields_to_copy' )->willReturn( $fields_to_copy );
+
+		$subject = $this->get_subject( $data_settings );
+
+		$subject->save( $post_id, $original_post_id, $converted_data );
+	}
+
+	private function get_subject( $data_settings ) {
+		return new WPML_Page_Builders_Update( $data_settings );
+	}
+
+	private function get_data_settings() {
+		return $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+			->setMethods(
+				array(
+					'get_meta_field',
+					'convert_data_to_array',
+					'get_fields_to_save',
+					'prepare_data_for_saving',
+					'get_fields_to_copy',
+					// Abstract methods not used here but need to be declared
+					'get_node_id_field',
+					'get_pb_name',
+					'add_hooks',
+				)
+			)->disableOriginalConstructor()->getMock();
+	}
+
+}


### PR DESCRIPTION
- Reused part of `WPML_Page_Builders_Update_Translation` moved to `WPML_Page_Builders_Update` which I will now use in composition.
- Introduced the interface `IWPML_PB_Media_Update`.
- Introduced `WPML_Page_Builders_Update_Media` which can be used as a base class for page builders using API.
- Introduced the filter `wmpl_pb_get_media_updaters` which will provide the `IWPML_PB_Media_Update` instances to run the media translation. This filter might also be used later in WPML Media.
- Added the media translate logic during shutdown action in PB Integration.

I started using this code in https://github.com/OnTheGoSystems/wpml-page-builders-beaver-builder/pull/8.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-160