### PR TITLE
Base code to load and run page builders media updaters

### DIFF
--- a/src/media/class-wpml-page-builders-media-hooks.php
+++ b/src/media/class-wpml-page-builders-media-hooks.php
@@ -1,0 +1,35 @@
+<?php
+
+class WPML_Page_Builders_Media_Hooks implements IWPML_Action {
+
+	/** @var IWPML_PB_Media_Update_Factory $media_update_factory */
+	private $media_update_factory;
+
+	/** @var string $page_builder_slug */
+	private $page_builder_slug;
+
+	/**
+	 * WPML_Page_Builders_Media_Hooks constructor.
+	 *
+	 * @param IWPML_PB_Media_Update_Factory $media_update_factory
+	 * @param string                        $page_builder_slug
+	 */
+	public function __construct( IWPML_PB_Media_Update_Factory $media_update_factory, $page_builder_slug ) {
+		$this->media_update_factory = $media_update_factory;
+		$this->page_builder_slug    = $page_builder_slug;
+	}
+	public function add_hooks() {
+		add_filter( 'wmpl_pb_get_media_updaters', array( $this, 'add_media_updater' ) );
+	}
+	/**
+	 * @param IWPML_PB_Media_Update[] $updaters
+	 *
+	 * @return IWPML_PB_Media_Update[]
+	 */
+	public function add_media_updater( $updaters ) {
+		if ( ! array_key_exists( $this->page_builder_slug, $updaters ) ) {
+			$updaters[ $this->page_builder_slug ] = $this->media_update_factory->create();
+		}
+		return $updaters;
+	}
+}

--- a/src/media/class-wpml-page-builders-media-translate.php
+++ b/src/media/class-wpml-page-builders-media-translate.php
@@ -1,0 +1,85 @@
+<?php
+
+class WPML_Page_Builders_Media_Translate {
+
+	/** @var WPML_Translation_Element_Factory $element_factory */
+	private $element_factory;
+
+	/** @var WPML_Media_Image_Translate $image_translate */
+	protected $image_translate;
+
+	/** @var array $translated_urls */
+	protected $translated_urls = array();
+
+	/** @var WP_Post[] $translated_posts */
+	protected $translated_posts = array();
+
+	public function __construct(
+		WPML_Translation_Element_Factory $element_factory,
+		WPML_Media_Image_Translate $image_translate
+	) {
+		$this->element_factory = $element_factory;
+		$this->image_translate = $image_translate;
+	}
+
+	/**
+	 * @param string $url
+	 * @param string $lang
+	 * @param string $source_lang
+	 *
+	 * @return string
+	 */
+	public function translate_image_url( $url, $lang, $source_lang ) {
+		$key = $url . $lang . $source_lang;
+
+		if ( ! array_key_exists( $key, $this->translated_urls ) ) {
+			$translated_url = $this->image_translate->get_translated_image_by_url( $url, $source_lang, $lang );
+			$this->translated_urls[ $key ] = $url;
+
+			if ( $translated_url ) {
+				$this->translated_urls[ $key ] = $translated_url;
+			}
+		}
+
+		return $this->translated_urls[ $key ];
+	}
+
+	/**
+	 * @param int    $id
+	 * @param string $lang
+	 *
+	 * @return int
+	 */
+	public function translate_id( $id, $lang ) {
+		$translated_attachment = $this->get_translated_attachment( $id, $lang );
+
+		if ( isset( $translated_attachment->ID ) ) {
+			return $translated_attachment->ID;
+		}
+
+		return $id;
+	}
+
+	/**
+	 * @param int    $id
+	 * @param string $lang
+	 *
+	 * @return WP_Post|null
+	 */
+	private function get_translated_attachment( $id, $lang ) {
+		$key = $id . $lang;
+
+		if ( ! array_key_exists( $key, $this->translated_posts ) ) {
+			$this->translated_posts[ $key ] = null;
+			$element                       = $this->element_factory->create_post( $id );
+			$translation                   = $element->get_translation( $lang );
+
+			if ( $translation ) {
+				$this->translated_posts[ $key ] = $translation->get_wp_object();
+			}
+		}
+
+
+		return $this->translated_posts[ $key ];
+	}
+}

--- a/src/media/class-wpml-page-builders-update-media.php
+++ b/src/media/class-wpml-page-builders-update-media.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class WPML_Page_Builders_Update_Media implements IWPML_PB_Media_Update {
+class WPML_Page_Builders_Update_Media implements IWPML_PB_Media_Update {
 
 	/** @var WPML_Page_Builders_Update $pb_update */
 	private $pb_update;
@@ -8,12 +8,17 @@ abstract class WPML_Page_Builders_Update_Media implements IWPML_PB_Media_Update 
 	/** @var WPML_Translation_Element_Factory $element_factory */
 	private $element_factory;
 
+	/** @var IWPML_PB_Media_Nodes_Iterator $node_iterator */
+	protected $node_iterator;
+
 	public function __construct(
 		WPML_Page_Builders_Update $pb_update,
-		WPML_Translation_Element_Factory $element_factory
+		WPML_Translation_Element_Factory $element_factory,
+		IWPML_PB_Media_Nodes_Iterator $node_iterator
 	) {
 		$this->pb_update       = $pb_update;
 		$this->element_factory = $element_factory;
+		$this->node_iterator   = $node_iterator;
 	}
 
 	/**
@@ -23,21 +28,15 @@ abstract class WPML_Page_Builders_Update_Media implements IWPML_PB_Media_Update 
 		$element        = $this->element_factory->create_post( $post->ID );
 		$source_element = $element->get_source_element();
 
-
 		if ( ! $source_element ) {
 			return;
 		}
 
+		$lang             = $element->get_language_code();
+		$source_lang      = $source_element->get_language_code();
 		$original_post_id = $source_element->get_id();
 		$converted_data   = $this->pb_update->get_converted_data( $original_post_id );
-		$converted_data   = $this->translate_media_in_modules( $converted_data );
+		$converted_data   = $this->node_iterator->translate( $converted_data, $lang, $source_lang );
 		$this->pb_update->save( $post->ID, $original_post_id, $converted_data );
 	}
-
-	/**
-	 * @param array $converted_data
-	 *
-	 * @return mixed
-	 */
-	abstract protected function translate_media_in_modules( array $converted_data );
 }

--- a/src/media/class-wpml-page-builders-update-media.php
+++ b/src/media/class-wpml-page-builders-update-media.php
@@ -1,0 +1,43 @@
+<?php
+
+abstract class WPML_Page_Builders_Update_Media implements IWPML_PB_Media_Update {
+
+	/** @var WPML_Page_Builders_Update $pb_update */
+	private $pb_update;
+
+	/** @var WPML_Translation_Element_Factory $element_factory */
+	private $element_factory;
+
+	public function __construct(
+		WPML_Page_Builders_Update $pb_update,
+		WPML_Translation_Element_Factory $element_factory
+	) {
+		$this->pb_update       = $pb_update;
+		$this->element_factory = $element_factory;
+	}
+
+	/**
+	 * @param WP_Post $post
+	 */
+	public function translate( $post ) {
+		$element        = $this->element_factory->create_post( $post->ID );
+		$source_element = $element->get_source_element();
+
+
+		if ( ! $source_element ) {
+			return;
+		}
+
+		$original_post_id = $source_element->get_id();
+		$converted_data   = $this->pb_update->get_converted_data( $original_post_id );
+		$converted_data   = $this->translate_media_in_modules( $converted_data );
+		$this->pb_update->save( $post->ID, $original_post_id, $converted_data );
+	}
+
+	/**
+	 * @param array $converted_data
+	 *
+	 * @return mixed
+	 */
+	abstract protected function translate_media_in_modules( array $converted_data );
+}

--- a/src/media/interface-iwpml-pb-media-nodes-iterator.php
+++ b/src/media/interface-iwpml-pb-media-nodes-iterator.php
@@ -1,0 +1,6 @@
+<?php
+
+interface IWPML_PB_Media_Nodes_Iterator {
+
+	public function translate( $data, $lang, $source_lang );
+}

--- a/src/media/interface-iwpml-pb-media-update-factory.php
+++ b/src/media/interface-iwpml-pb-media-update-factory.php
@@ -1,0 +1,7 @@
+<?php
+
+interface IWPML_PB_Media_Update_Factory {
+
+	/** @return IWPML_PB_Media_Update */
+	public function create();
+}

--- a/src/media/interface-iwpml-pb-media-update.php
+++ b/src/media/interface-iwpml-pb-media-update.php
@@ -1,0 +1,9 @@
+<?php
+
+interface IWPML_PB_Media_Update {
+
+	/**
+	 * @param WP_Post $post
+	 */
+	public function translate( $post );
+}

--- a/src/st/compatibility/class-wpml-page-builders-update-translation.php
+++ b/src/st/compatibility/class-wpml-page-builders-update-translation.php
@@ -3,29 +3,24 @@
 /**
  * Class WPML_Page_Builders_Update_Translation
  */
-abstract class WPML_Page_Builders_Update_Translation {
+abstract class WPML_Page_Builders_Update_Translation extends WPML_Page_Builders_Update {
 
 	const TRANSLATION_COMPLETE = 10;
-
-	private $string_translations;
-	private $lang;
 
 	/**
 	 * @var IWPML_Page_Builders_Translatable_Nodes
 	 */
 	protected $translatable_nodes;
 
-	/**
-	 * @var IWPML_Page_Builders_Data_Settings
-	 */
-	protected $data_settings;
+	private $string_translations;
+	private $lang;
 
 	public function __construct(
 		IWPML_Page_Builders_Translatable_Nodes $translatable_nodes,
-		IWPML_Page_Builders_Data_Settings $data_settings ) {
-
-		$this->data_settings = $data_settings;
+		IWPML_Page_Builders_Data_Settings $data_settings
+	) {
 		$this->translatable_nodes = $translatable_nodes;
+		parent::__construct( $data_settings );
 	}
 
 	/**
@@ -36,43 +31,12 @@ abstract class WPML_Page_Builders_Update_Translation {
 	 */
 	public function update( $translated_post_id, $original_post, $string_translations, $lang ) {
 		$this->string_translations = $string_translations;
-		$this->lang = $lang;
+		$this->lang                = $lang;
 
-		$data = get_post_meta( $original_post->ID, $this->data_settings->get_meta_field(), true );
-		$converted_data = $this->data_settings->convert_data_to_array( $data );
-
+		$converted_data = $this->get_converted_data( $original_post->ID );
 		$this->update_strings_in_modules( $converted_data );
-		$this->save_data( $translated_post_id, $this->data_settings->get_fields_to_save(), $this->data_settings->prepare_data_for_saving( $converted_data ) );
-		$this->copy_meta_fields( $translated_post_id, $original_post->ID, $this->data_settings->get_fields_to_copy() );
+		$this->save( $translated_post_id, $original_post->ID, $converted_data );
 
-	}
-
-	/**
-	 * @param int $translated_post_id
-	 * @param int $original_post_id
-	 * @param array $meta_fields
-	 */
-	private function copy_meta_fields( $translated_post_id, $original_post_id, $meta_fields ) {
-		foreach ( $meta_fields as $meta_key ) {
-			$value = get_post_meta( $original_post_id, $meta_key, true );
-
-			update_post_meta(
-				$translated_post_id,
-				$meta_key,
-				apply_filters( 'wpml_pb_copy_meta_field', $value, $translated_post_id, $original_post_id, $meta_key )
-			);
-		}
-	}
-
-	/**
-	 * @param int $post_id
-	 * @param array $fields
-	 * @param mixed $data
-	 */
-	private function save_data( $post_id, $fields, $data ) {
-		foreach ( $fields as $field ) {
-			update_post_meta( $post_id, $field, $data );
-		}
 	}
 
 	/**

--- a/src/st/compatibility/class-wpml-page-builders-update.php
+++ b/src/st/compatibility/class-wpml-page-builders-update.php
@@ -1,0 +1,59 @@
+<?php
+
+class WPML_Page_Builders_Update {
+
+	/** @var IWPML_Page_Builders_Data_Settings */
+	protected $data_settings;
+
+	public function __construct( IWPML_Page_Builders_Data_Settings $data_settings ) {
+		$this->data_settings = $data_settings;
+	}
+
+	/**
+	 * @param int $post_id
+	 *
+	 * @return array
+	 */
+	public function get_converted_data( $post_id ) {
+		$data = get_post_meta( $post_id, $this->data_settings->get_meta_field(), true );
+		return $this->data_settings->convert_data_to_array( $data );
+	}
+
+	/**
+	 * @param int   $post_id
+	 * @param int   $original_post_id
+	 * @param array $converted_data
+	 */
+	public function save( $post_id, $original_post_id, $converted_data ) {
+		$this->save_data( $post_id, $this->data_settings->get_fields_to_save(), $this->data_settings->prepare_data_for_saving( $converted_data ) );
+		$this->copy_meta_fields( $post_id, $original_post_id, $this->data_settings->get_fields_to_copy() );
+	}
+
+	/**
+	 * @param int   $post_id
+	 * @param array $fields
+	 * @param mixed $data
+	 */
+	private function save_data( $post_id, $fields, $data ) {
+		foreach ( $fields as $field ) {
+			update_post_meta( $post_id, $field, $data );
+		}
+	}
+
+	/**
+	 * @param int   $translated_post_id
+	 * @param int   $original_post_id
+	 * @param array $meta_fields
+	 */
+	private function copy_meta_fields( $translated_post_id, $original_post_id, $meta_fields ) {
+		foreach ( $meta_fields as $meta_key ) {
+			$value = get_post_meta( $original_post_id, $meta_key, true );
+
+			update_post_meta(
+				$translated_post_id,
+				$meta_key,
+				apply_filters( 'wpml_pb_copy_meta_field', $value, $translated_post_id, $original_post_id, $meta_key )
+			);
+		}
+	}
+}

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-hooks.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-hooks.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Page_Builders_Media_Hooks extends OTGS_TestCase {
+
+	const SLUG_TEST = 'the-page-builder';
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_iwpml_action() {
+		$this->assertInstanceOf( 'IWPML_Action', $this->get_subject() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_add_hooks() {
+		$subject = $this->get_subject();
+		\WP_Mock::expectFilterAdded( 'wmpl_pb_get_media_updaters', array( $subject, 'add_media_updater' ) );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_add_media_updater_only_once() {
+		$updaters = array(
+			'some-plugin' => $this->get_media_update(),
+		);
+
+		$pb_updater = $this->get_media_update();
+
+		$factory = $this->get_media_update_factory();
+		$factory->expects( $this->once() )->method( 'create' )->willReturn( $pb_updater );
+
+		$subject = $this->get_subject( $factory );
+
+		$filtered_updaters = $subject->add_media_updater( $updaters );
+		$this->check_updaters( $updaters, $filtered_updaters );
+		$filtered_updaters = $subject->add_media_updater( $filtered_updaters );
+		$this->check_updaters( $updaters, $filtered_updaters );
+	}
+
+	private function check_updaters( $updaters, $filtered_updaters ) {
+		$this->assertCount( 2, $filtered_updaters );
+		$this->assertSame( $updaters['some-plugin'], $filtered_updaters['some-plugin'] );
+		$this->assertInstanceOf( 'IWPML_PB_Media_Update', $filtered_updaters[ self::SLUG_TEST ] );
+	}
+
+	private function get_subject( $media_update_factory = null ) {
+		$media_update_factory = $media_update_factory ? $media_update_factory : $this->get_media_update_factory();
+		return new WPML_Page_Builders_Media_Hooks( $media_update_factory, self::SLUG_TEST );
+	}
+
+	private function get_media_update_factory() {
+		return $this->getMockBuilder( 'IWPML_PB_Media_Update_Factory' )
+			->setMethods( array( 'create' ) )->getMock();
+	}
+
+	private function get_media_update() {
+		return $this->getMockBuilder( 'IWPML_PB_Media_Update' )->getMock();
+	}
+}
+
+if ( ! interface_exists( 'IWPML_Action' ) ) {
+	interface IWPML_Action {}
+}

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Page_Builders_Media_Translate extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate_image_url_and_cache_it() {
+		$url            = 'http://example/dog.jpg';
+		$translated_url = 'http://exemple/chien.jpg';
+		$lang           = 'fr';
+		$source_lang    = 'en';
+
+		$image_translate = $this->get_image_translate();
+		$image_translate->expects( $this->once() )
+			->method( 'get_translated_image_by_url' )
+			->with( $url, $source_lang, $lang )
+			->willReturn( $translated_url );
+
+		$subject = $this->get_subject( null, $image_translate );
+
+		$this->assertSame( $translated_url, $subject->translate_image_url( $url, $lang, $source_lang ) );
+		$this->assertSame( $translated_url, $subject->translate_image_url( $url, $lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_the_same_url_if_no_translation_is_found() {
+		$url         = 'http://example/dog.jpg';
+		$lang        = 'fr';
+		$source_lang = 'en';
+
+		$image_translate = $this->get_image_translate();
+		$image_translate->expects( $this->once() )
+		                ->method( 'get_translated_image_by_url' )
+		                ->with( $url, $source_lang, $lang )
+		                ->willReturn( false );
+
+		$subject = $this->get_subject( null, $image_translate );
+
+		$this->assertSame( $url, $subject->translate_image_url( $url, $lang, $source_lang ) );
+		$this->assertSame( $url, $subject->translate_image_url( $url, $lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate_id_and_cache_it() {
+		$id            = mt_rand( 1, 10 );
+		$translated_id = mt_rand( 11, 20 );
+		$lang          = 'fr';
+
+		$translated_attachment = $this->get_wp_object( $translated_id );
+
+		$translated_element = $this->get_element();
+		$translated_element->method( 'get_wp_object' )->willReturn( $translated_attachment );
+
+		$element = $this->get_element();
+		$element->method( 'get_translation' )->with( $lang )->willReturn( $translated_element );
+
+		$factory = $this->get_element_factory();
+		$factory->expects( $this->once() )->method( 'create_post' )->with( $id )->willReturn( $element );
+
+		$subject = $this->get_subject( $factory, null );
+
+		$this->assertSame( $translated_id, $subject->translate_id( $id, $lang ) );
+		$this->assertSame( $translated_id, $subject->translate_id( $id, $lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_the_original_id_if_no_translation_was_found() {
+		$id   = mt_rand( 1, 10 );
+		$lang = 'fr';
+
+		$element = $this->get_element();
+		$element->method( 'get_translation' )->with( $lang )->willReturn( null );
+
+		$factory = $this->get_element_factory();
+		$factory->method( 'create_post' )->with( $id )->willReturn( $element );
+
+		$subject = $this->get_subject( $factory, null );
+
+		$this->assertSame( $id, $subject->translate_id( $id, $lang ) );
+	}
+
+	private function get_subject( $factory = null, $image_translate = null ) {
+		$factory         = $factory ? $factory : $this->get_element_factory();
+		$image_translate = $image_translate ? $image_translate : $this->get_image_translate();
+		return new WPML_Page_Builders_Media_Translate( $factory, $image_translate );
+	}
+
+	private function get_element_factory() {
+		return $this->getMockBuilder( 'WPML_Translation_Element_Factory' )
+			->setMethods( array( 'create_post' ) )
+			->disableOriginalConstructor()->getMock();
+	}
+
+	private function get_element() {
+		return $this->getMockBuilder( 'WPML_Post_Element' )
+			->setMethods( array( 'get_translation', 'get_wp_object' ) )
+			->disableOriginalConstructor()->getMock();
+	}
+
+	private function get_wp_object( $id ) {
+		$wp_object = $this->getMockBuilder( 'WP_Post' )->getMock();
+		$wp_object->ID = $id;
+		return $wp_object;
+	}
+
+	private function get_image_translate() {
+		return $this->getMockBuilder( 'WPML_Media_Image_Translate' )
+			->setMethods( array( 'get_translated_image_by_url' ) )
+			->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/test-wpml-page-builders-update-media.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-update-media.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Page_Builders_Update_Media extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_translate_if_post_is_source() {
+		$post     = $this->getMockBuilder( 'WP_Post' )->getMock();
+		$post->ID = mt_rand( 1, 10 );
+
+		$updater = $this->get_updater();
+		$updater->expects( $this->never() )->method( 'save' );
+
+		$element = $this->get_element();
+		$element->method( 'get_source_element' )->willReturn( null );
+
+		$factory = $this->get_element_factory();
+		$factory->method( 'create_post' )->with( $post->ID )->willReturn( $element );
+
+		$iterator = $this->get_node_iterator();
+		$iterator->expects( $this->never() )->method( 'translate' );
+
+		$subject = $this->get_subject( $updater, $factory, $iterator );
+
+		$subject->translate( $post );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate_if_post_is_a_translation() {
+		$lang            = 'fr';
+		$source_lang     = 'en';
+		$original_id     = mt_rand( 11, 20 );
+		$original_data   = array( 'original data' );
+		$translated_data = array( 'translated data' );
+
+		$post     = $this->getMockBuilder( 'WP_Post' )->getMock();
+		$post->ID = mt_rand( 1, 10 );
+
+		$updater = $this->get_updater();
+		$updater->method( 'get_converted_data' )->with( $original_id )->willReturn( $original_data );
+		$updater->expects( $this->once() )->method( 'save' )->with( $post->ID, $original_id, $translated_data );
+
+		$source_element = $this->get_element();
+		$source_element->method( 'get_language_code' )->willReturn( $source_lang );
+		$source_element->method( 'get_id' )->willReturn( $original_id );
+
+		$element = $this->get_element();
+		$element->method( 'get_source_element' )->willReturn( $source_element );
+		$element->method( 'get_language_code' )->willReturn( $lang );
+
+		$factory = $this->get_element_factory();
+		$factory->method( 'create_post' )->with( $post->ID )->willReturn( $element );
+
+		$iterator = $this->get_node_iterator();
+		$iterator->expects( $this->once() )->method( 'translate' )->with( $original_data )->willReturn( $translated_data );
+
+		$subject = $this->get_subject( $updater, $factory, $iterator );
+
+		$subject->translate( $post );
+	}
+
+	private function get_subject( $updater = null, $factory = null, $iterator = null ) {
+		return new WPML_Page_Builders_Update_Media( $updater, $factory, $iterator );
+	}
+
+	private function get_updater() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Update' )
+		            ->setMethods( array( 'get_converted_data', 'save' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+
+	private function get_element_factory() {
+		return $this->getMockBuilder( 'WPML_Translation_Element_Factory' )
+		            ->setMethods( array( 'create_post' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+
+	private function get_element() {
+		return $this->getMockBuilder( 'WPML_Post_Element' )
+		            ->setMethods( array( 'get_language_code', 'get_source_element', 'get_id' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+
+	private function get_node_iterator() {
+		return $this->getMockBuilder( 'IWPML_PB_Media_Nodes_Iterator' )
+		            ->setMethods( array( 'translate' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
+++ b/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
@@ -1,0 +1,96 @@
+<?php
+
+class Test_WPML_Page_Builders_Update extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_get_converted_data() {
+		$post_id        = mt_rand( 1, 100 );
+		$meta_key       = 'the-meta-field-key';
+		$raw_data       = array( 'raw data' );
+		$converted_data = array( 'converted data' );
+
+		\WP_Mock::userFunction( 'get_post_meta', array(
+			'args'   => array( $post_id, $meta_key, true ),
+			'return' => $raw_data,
+		));
+
+		$data_settings = $this->get_data_settings();
+		$data_settings->method( 'get_meta_field' )->willReturn( $meta_key );
+		$data_settings->method( 'convert_data_to_array' )->with( $raw_data )->willReturn( $converted_data );
+
+		$subject = $this->get_subject( $data_settings );
+
+		$this->assertEquals( $converted_data, $subject->get_converted_data( $post_id ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_save() {
+		$post_id = mt_rand( 1, 100 );
+		$original_post_id = mt_rand( 101, 200 );
+		$converted_data = array( 'converted data' );
+		$prepared_data  = array( 'prepared data' );
+		$fields_to_save = array( 'the-meta-field-key-1', 'the-meta-field-key-2' );
+		$fields_to_copy = array( 'the-field-to-copy-1', 'the-field-to-copy-2' );
+
+		foreach ( $fields_to_save as $field_to_save ) {
+			\WP_Mock::userFunction( 'update_post_meta', array(
+				'args'   => array( $post_id, $field_to_save, $prepared_data ),
+				'times' => 1,
+			));
+		}
+
+		foreach ( $fields_to_copy as $field_to_copy ) {
+			$field_value = 'value of ' . $field_to_copy;
+			$filterd_value = 'filtered ' . $field_value;
+
+			\WP_Mock::userFunction( 'get_post_meta', array(
+				'args'   => array( $original_post_id, $field_to_copy, true ),
+				'return' => $field_value,
+			));
+
+			\WP_Mock::onFilter( 'wpml_pb_copy_meta_field' )
+				->with( $field_value, $post_id, $original_post_id, $field_to_copy )
+				->reply( $filterd_value );
+
+			\WP_Mock::userFunction( 'update_post_meta', array(
+				'args'   => array( $post_id, $field_to_copy, $filterd_value ),
+				'times' => 1,
+			));
+		}
+
+		$data_settings = $this->get_data_settings();
+		$data_settings->method( 'get_fields_to_save' )->willReturn( $fields_to_save );
+		$data_settings->method( 'prepare_data_for_saving' )->with( $converted_data )->willReturn( $prepared_data );
+		$data_settings->method( 'get_fields_to_copy' )->willReturn( $fields_to_copy );
+
+		$subject = $this->get_subject( $data_settings );
+
+		$subject->save( $post_id, $original_post_id, $converted_data );
+	}
+
+	private function get_subject( $data_settings ) {
+		return new WPML_Page_Builders_Update( $data_settings );
+	}
+
+	private function get_data_settings() {
+		return $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+			->setMethods(
+				array(
+					'get_meta_field',
+					'convert_data_to_array',
+					'get_fields_to_save',
+					'prepare_data_for_saving',
+					'get_fields_to_copy',
+					// Abstract methods not used here but need to be declared
+					'get_node_id_field',
+					'get_pb_name',
+					'add_hooks',
+				)
+			)->disableOriginalConstructor()->getMock();
+	}
+
+}

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -1,8 +1,10 @@
 <?php
 
 /**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ *
  * @group page-builders
- * @group adriano
  */
 class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 


### PR DESCRIPTION
- Reused part of `WPML_Page_Builders_Update_Translation` moved to `WPML_Page_Builders_Update` which I will now use in composition.
- Introduced the interface `IWPML_PB_Media_Update`,  `IWPML_PB_Media_Update_Factory`, and `IWPML_PB_Media_Node_Iterator`.
- Introduced `WPML_Page_Builders_Update_Media` and `WPML_Page_Builders_Media_Hooks` which can be used in composition.
- Introduced the filter `wmpl_pb_get_media_updaters` which will provide the `IWPML_PB_Media_Update` instances to run the media translation. This filter might also be used later in WPML Media.
- Added the media translate logic during shutdown action in PB Integration.

See how this code is used in https://github.com/OnTheGoSystems/wpml-page-builders-beaver-builder/pull/10.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-160