### PR TITLE
Translate media blocks in Divi Page Builder

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,12 +1,12 @@
 ---
 checks:
-  php:
-    code_rating: true
-    duplication: true
+    php:
+        code_rating: true
+        duplication: true
 filter:
     excluded_paths:
-        - "tests/"
-        - "vendor/"
+    - "tests/"
+    - "vendor/"
 coding_style:
     php:
         indentation:
@@ -18,41 +18,39 @@ coding_style:
                 negation: true
 
 build:
-  cache:
-    directories:
-      - vendor/
-  nodes:
-    phpcs:
-      environment:
-        php: 5.6
-      tests:
-        override:
-          -
-            on_node: 1
-            idle_timeout: 4800
-            command: "phpcs-run ./"
+    cache:
+        directories:
+        - vendor/
+    nodes:
 
-    phpunit:
-      environment:
-        php: 5.6
-      tests:
+        php-coding-standards:
+            environment:
+                php: 7.1
+            tests:
+                override:
+                - idle_timeout: 4800
+                  command: "phpcs-run ./"
+
+        phpunit:
+            environment:
+                php: 5.6
+            tests:
+                override:
+                - idle_timeout: 4800
+                  command: "./vendor/bin/phpunit --coverage-clover ./coverage.xml"
+                  coverage:
+                      file: coverage.xml
+                      format: php-clover
+
+        php70:
+            environment:
+                php: 7.0
+
+        php71:
+            environment:
+                php: 7.1
+
+    tests:
         override:
-          -
-            on_node: 2
-            idle_timeout: 4800
-            command: "./vendor/bin/phpunit --coverage-clover ./coverage.xml"
-            coverage:
-              file: coverage.xml
-              format: php-clover
-    php70:
-      environment:
-        php: 7.0
-    php71:
-      environment:
-        php: 7.1
-  tests:
-    override:
-      -
-        on_node: 1
-        idle_timeout: 4800
-        command: "./vendor/bin/phpunit"
+        - idle_timeout: 4800
+          command: "./vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,15 @@
         "symfony/dom-crawler": "^3.1",
         "symfony/css-selector": "^3.1",
         "phpunit/phpunit": "^5",
-        "otgs/phpunit-tools": "dev-master"
+        "otgs/phpunit-tools": "dev-master",
+
+        "squizlabs/php_codesniffer": "~3",
+        "phpcompatibility/php-compatibility": "*",
+        "dealerdirect/phpcodesniffer-composer-installer": "*",
+
+        "wp-coding-standards/wpcs": "^0",
+
+        "m4tthumphrey/php-gitlab-api": "^9.0.0",
+        "php-http/guzzle6-adapter": "^1.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,33 @@
 {
-  "name": "wpml/page-builders",
-  "description": "A library used by WPML to handle page builders plugins and themes",
-  "type": "library",
-  "license": "GPL-3.0-or-later",
-  "authors": [
-    {
-      "name": "OnTheGoSystems",
-      "email": "hello@wpml.org"
+    "name": "wpml/page-builders",
+    "description": "A library used by WPML to handle page builders plugins and themes",
+    "type": "library",
+    "license": "GPL-3.0-or-later",
+    "authors": [
+        {
+            "name": "OnTheGoSystems",
+            "email": "hello@wpml.org"
+        }
+    ],
+    "autoload": {
+        "classmap": [
+            "src/"
+        ]
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/phpunit/stubs/",
+            "tests/phpunit/util/"
+        ]
+    },
+    "require-dev": {
+        "roave/security-advisories": "dev-master",
+
+        "10up/wp_mock": "~0.2.0",
+        "lucatume/function-mocker": "1.3.4",
+        "symfony/dom-crawler": "^3.1",
+        "symfony/css-selector": "^3.1",
+        "phpunit/phpunit": "^5",
+        "otgs/phpunit-tools": "dev-master"
     }
-  ],
-  "autoload": {
-    "classmap": [
-      "src/"
-    ]
-  },
-  "autoload-dev": {
-    "classmap": [
-      "tests/phpunit/stubs/",
-      "tests/phpunit/util/"
-    ]
-  },
-  "require": {
-    "roave/security-advisories": "dev-master"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "~5.7",
-    "otgs/unit-tests-framework": "~1.2.0"
-  }
 }

--- a/phpcs.compatibility.xml
+++ b/phpcs.compatibility.xml
@@ -2,9 +2,7 @@
 <ruleset name="WPML">
 	<description>WPML Coding Standards</description>
 
-	<rule ref="WordPress-Core"/>
-	<rule ref="WordPress-Docs"/>
-	<rule ref="WordPress-Extra"/>
+	<config name="testVersion" value="5.2"/>
 
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
@@ -14,12 +12,5 @@
 	<exclude-pattern>*.twig</exclude-pattern>
 	<exclude-pattern>*.css</exclude-pattern>
 	<exclude-pattern>*.scss</exclude-pattern>
-
-	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<severity>0</severity>
-	</rule>
-	<rule ref="Squiz.Commenting.ClassComment.Missing">
-		<severity>0</severity>
-	</rule>
 
 </ruleset>

--- a/src/media/class-wpml-page-builders-media-translate.php
+++ b/src/media/class-wpml-page-builders-media-translate.php
@@ -51,6 +51,10 @@ class WPML_Page_Builders_Media_Translate {
 	 * @return int
 	 */
 	public function translate_id( $id, $lang ) {
+		if ( (int) $id < 1 ) {
+			return $id;
+		}
+
 		$translated_attachment = $this->get_translated_attachment( $id, $lang );
 
 		if ( isset( $translated_attachment->ID ) ) {

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update-factory.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update-factory.php
@@ -1,0 +1,62 @@
+<?php
+
+class WPML_Page_Builders_Media_Shortcodes_Update_Factory implements IWPML_PB_Media_Update_Factory {
+
+	public function create() {
+		global $sitepress;
+
+		$element_factory  = new WPML_Translation_Element_Factory( $sitepress );
+		$media_shortcodes = $this->get_media_shortcodes( $element_factory, $sitepress );
+
+		return new WPML_Page_Builders_Media_Shortcodes_Update( $element_factory, $media_shortcodes );
+	}
+
+	/**
+	 * @param $element_factory
+	 * @param $sitepress
+	 *
+	 * @return WPML_Page_Builders_Media_Shortcodes
+	 */
+	private function get_media_shortcodes( $element_factory, $sitepress ) {
+		$media_translate = new WPML_Page_Builders_Media_Translate(
+			$element_factory,
+			new WPML_Media_Image_Translate( $sitepress, new WPML_Media_Attachment_By_URL_Factory() )
+		);
+
+		return new WPML_Page_Builders_Media_Shortcodes( $media_translate, $this->get_shortcodes_config() );
+	}
+
+	/** @return array */
+	private function get_shortcodes_config() {
+		/**
+		 * @todo: Move configuration to wpml-config.xml
+		 */
+		if ( defined( 'ET_BUILDER_THEME' ) ) {
+			return array(
+				WPML_Page_Builders_Media_Shortcodes::ALL_TAGS => array(
+					'background_image' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+				),
+				'et_pb_video_slider_item|et_pb_video'         => array(
+					'image_src' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+				),
+				'et_pb_gallery'                               => array(
+					'gallery_ids' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS,
+				),
+				'et_pb_image'                                 => array(
+					'src' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+				),
+				'et_pb_slide'                                 => array(
+					'image' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+				),
+				'et_pb_team_member'                           => array(
+					'image_url' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+				),
+				'et_pb_testimonial'                           => array(
+					'portrait_url' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+				),
+			);
+		}
+
+		return array();
+	}
+}

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update-factory.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update-factory.php
@@ -2,6 +2,13 @@
 
 class WPML_Page_Builders_Media_Shortcodes_Update_Factory implements IWPML_PB_Media_Update_Factory {
 
+	/** @var WPML_PB_Config_Import_Shortcode WPML_PB_Config_Import_Shortcode */
+	private $page_builder_config_import;
+
+	public function __construct( WPML_PB_Config_Import_Shortcode $page_builder_config_import ) {
+		$this->page_builder_config_import = $page_builder_config_import;
+	}
+
 	public function create() {
 		global $sitepress;
 
@@ -23,40 +30,9 @@ class WPML_Page_Builders_Media_Shortcodes_Update_Factory implements IWPML_PB_Med
 			new WPML_Media_Image_Translate( $sitepress, new WPML_Media_Attachment_By_URL_Factory() )
 		);
 
-		return new WPML_Page_Builders_Media_Shortcodes( $media_translate, $this->get_shortcodes_config() );
-	}
-
-	/** @return array */
-	private function get_shortcodes_config() {
-		/**
-		 * @todo: Move configuration to wpml-config.xml
-		 */
-		if ( defined( 'ET_BUILDER_THEME' ) ) {
-			return array(
-				WPML_Page_Builders_Media_Shortcodes::ALL_TAGS => array(
-					'background_image' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
-				),
-				'et_pb_video_slider_item|et_pb_video'         => array(
-					'image_src' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
-				),
-				'et_pb_gallery'                               => array(
-					'gallery_ids' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS,
-				),
-				'et_pb_image'                                 => array(
-					'src' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
-				),
-				'et_pb_slide'                                 => array(
-					'image' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
-				),
-				'et_pb_team_member'                           => array(
-					'image_url' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
-				),
-				'et_pb_testimonial'                           => array(
-					'portrait_url' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
-				),
-			);
-		}
-
-		return array();
+		return new WPML_Page_Builders_Media_Shortcodes(
+			$media_translate,
+			$this->page_builder_config_import->get_media_settings()
+		);
 	}
 }

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update.php
@@ -1,0 +1,43 @@
+<?php
+
+class WPML_Page_Builders_Media_Shortcodes_Update implements IWPML_PB_Media_Update {
+
+	/** @var WPML_Translation_Element_Factory $element_factory */
+	private $element_factory;
+
+	/** @var WPML_Page_Builders_Media_Shortcodes $media_shortcodes*/
+	private $media_shortcodes;
+
+	public function __construct(
+		WPML_Translation_Element_Factory $element_factory,
+		WPML_Page_Builders_Media_Shortcodes $media_shortcodes
+	) {
+		$this->element_factory  = $element_factory;
+		$this->media_shortcodes = $media_shortcodes;
+	}
+
+	/**
+	 * @param WP_Post $post
+	 */
+	public function translate( $post ) {
+		if ( $this->has_no_shortcode( $post->post_content ) ) {
+			return;
+		}
+
+		$element = $this->element_factory->create_post( $post->ID );
+
+		if ( ! $element->get_source_language_code() ) {
+			return;
+		}
+
+		$post->post_content = $this->media_shortcodes->set_target_lang( $element->get_language_code() )
+		                                             ->set_source_lang( $element->get_source_language_code() )
+		                                             ->translate( $post->post_content );
+
+		wp_update_post( $post );
+	}
+
+	private function has_no_shortcode( $content ) {
+		return strpos( $content, '[' ) === false;
+	}
+}

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
@@ -24,16 +24,45 @@ class WPML_Page_Builders_Media_Shortcodes {
 	}
 
 	public function translate( $content )  {
-		foreach ( $this->config as $tag => $attributes ) {
-			$content = $this->translate_attributes( $content, $tag, $attributes );
+		foreach ( $this->config as $shortcode ) {
+			$shortcode = $this->sanitize_shortcode( $shortcode );
+			$tag_name  = $this->get_tag_name( $shortcode );
+
+			if ( ! empty( $shortcode['attributes'] ) ) {
+				$content = $this->translate_attributes( $content, $tag_name, $shortcode['attributes'] );
+			}
 		}
 
 		return $content;
 	}
 
+	/**
+	 * @param array $shortcode
+	 *
+	 * @return array
+	 */
+	private function sanitize_shortcode( array $shortcode ) {
+		$defaults = array(
+			'attributes' => null,
+		);
+
+		return array_merge( $defaults, $shortcode );
+	}
+
+	/**
+	 * @param array $shortcode
+	 *
+	 * @return string
+	 */
+	private function get_tag_name( $shortcode ) {
+		$tag_name = isset( $shortcode['tag']['name'] ) ? $shortcode['tag']['name'] : '';
+		return str_replace( '*', self::ALL_TAGS, $tag_name );
+	}
+
 	private function translate_attributes( $content, $tag, $attributes ) {
-		foreach ( $attributes as $attribute => $type ) {
+		foreach ( $attributes as $attribute => $data ) {
 			$pattern = '/(\[(?:' . $tag . ')(?: [^\]]* | )' . $attribute . '=")([^"]*)/';
+			$type    = isset( $data['type'] ) ? $data['type'] : '';
 			$content = preg_replace_callback( $pattern, array( $this, $this->get_callback( $type ) ), $content );
 		}
 

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
@@ -1,0 +1,86 @@
+<?php
+
+class WPML_Page_Builders_Media_Shortcodes {
+
+	const ALL_TAGS = '\w+';
+	const TYPE_URL = 'url';
+	const TYPE_IDS = 'ids';
+
+	/** @var WPML_Page_Builders_Media_Translate $media_translate */
+	private $media_translate;
+
+	/** @var string $target_lang */
+	private $target_lang;
+
+	/** @var string $source_lang */
+	private $source_lang;
+
+	/** @var array $config */
+	private $config;
+
+	public function __construct( WPML_Page_Builders_Media_Translate $media_translate, array $config ) {
+		$this->media_translate = $media_translate;
+		$this->config          = $config;
+	}
+
+	public function translate( $content )  {
+		foreach ( $this->config as $tag => $attributes ) {
+			$content = $this->translate_attributes( $content, $tag, $attributes );
+		}
+
+		return $content;
+	}
+
+	private function translate_attributes( $content, $tag, $attributes ) {
+		foreach ( $attributes as $attribute => $type ) {
+			$pattern = '/(\[(?:' . $tag . ')(?: [^\]]* | )' . $attribute . '=")([^"]*)/';
+			$content = preg_replace_callback( $pattern, array( $this, $this->get_callback( $type ) ), $content );
+		}
+
+		return $content;
+	}
+
+	private function get_callback( $type ) {
+		if ( self::TYPE_URL === $type ) {
+			return 'replace_url_callback';
+		}
+
+		return 'replace_ids_callback';
+	}
+
+	private function replace_url_callback( array $matches ) {
+		$translated_url = $this->media_translate->translate_image_url( $matches[2], $this->target_lang, $this->source_lang );
+
+		return $matches[1] . $translated_url;
+	}
+
+	private function replace_ids_callback( array $matches ) {
+		$ids = explode( ',', $matches[2] );
+
+		foreach ( $ids as &$id ) {
+			$id = $this->media_translate->translate_id( (int) $id, $this->target_lang );
+		}
+
+		return $matches[1] . implode( ',', $ids );
+	}
+
+	/**
+	 * @param string $target_lang
+	 *
+	 * @return self
+	 */
+	public function set_target_lang( $target_lang ) {
+		$this->target_lang = $target_lang;
+		return $this;
+	}
+
+	/**
+	 * @param string $source_lang
+	 *
+	 * @return self
+	 */
+	public function set_source_lang( $source_lang ) {
+		$this->source_lang = $source_lang;
+		return $this;
+	}
+}

--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -18,6 +18,14 @@ class WPML_PB_Loader {
 			$strategy = new WPML_PB_Shortcode_Strategy( new WPML_Page_Builder_Settings() );
 			$strategy->add_shortcodes( $page_builder_config_import->get_settings() );
 			$page_builder_strategies[] = $strategy;
+
+			if ( is_admin() && defined( 'WPML_MEDIA_VERSION' ) ) {
+				$shortcodes_media_hooks = new WPML_Page_Builders_Media_Hooks(
+					new WPML_Page_Builders_Media_Shortcodes_Update_Factory(),
+					'shortcodes'
+				);
+				$shortcodes_media_hooks->add_hooks();
+			}
 		}
 
 		if ( class_exists( 'WPML_Config_Built_With_Page_Builders' ) ) {

--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -19,9 +19,9 @@ class WPML_PB_Loader {
 			$strategy->add_shortcodes( $page_builder_config_import->get_settings() );
 			$page_builder_strategies[] = $strategy;
 
-			if ( is_admin() && defined( 'WPML_MEDIA_VERSION' ) ) {
+			if ( is_admin() && defined( 'WPML_MEDIA_VERSION' ) && $page_builder_config_import->get_media_settings() ) {
 				$shortcodes_media_hooks = new WPML_Page_Builders_Media_Hooks(
-					new WPML_Page_Builders_Media_Shortcodes_Update_Factory(),
+					new WPML_Page_Builders_Media_Shortcodes_Update_Factory( $page_builder_config_import ),
 					'shortcodes'
 				);
 				$shortcodes_media_hooks->add_hooks();

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -37,4 +37,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../../vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';

--- a/tests/phpunit/tests/WPML_PageBuilders_TestCase.php
+++ b/tests/phpunit/tests/WPML_PageBuilders_TestCase.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author OnTheGo Systems
+ */
+
+use tad\FunctionMocker\FunctionMocker;
+
+abstract class WPML_PageBuilders_TestCase extends \OTGS\PHPUnit\Tools\TestCase {
+	function setUp() {
+		parent::setUp();
+		FunctionMocker::setUp();
+		WP_Mock::setUp();
+	}
+
+	function tearDown() {
+		WP_Mock::tearDown();
+		FunctionMocker::tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+
+}

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Shortcodes_Update_Factory extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Shortcodes_Update_Factory extends \OTGS\PHPUnit\Tools\TestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Page_Builders_Media_Shortcodes_Update_Factory extends OTGS_TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$this->getMockBuilder( 'WPML_Translation_Element_Factory' )->disableOriginalConstructor()->getMock();
+		$this->getMockBuilder( 'WPML_Media_Attachment_By_URL_Factory' )->disableOriginalConstructor()->getMock();
+		$this->getMockBuilder( 'WPML_Media_Image_Translate' )->disableOriginalConstructor()->getMock();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_media_update_factory() {
+		$subject = new WPML_Page_Builders_Media_Shortcodes_Update_Factory();
+		$this->assertInstanceOf( 'IWPML_PB_Media_Update_Factory', $subject );
+		$this->assertInstanceOf( 'IWPML_PB_Media_Update', $subject->create() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_create_and_return_an_instance() {
+		$subject = new WPML_Page_Builders_Media_Shortcodes_Update_Factory();
+		$this->assertInstanceOf( 'WPML_Page_Builders_Media_Shortcodes_Update', $subject->create() );
+	}
+}

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
@@ -16,7 +16,7 @@ class Test_WPML_Page_Builders_Media_Shortcodes_Update_Factory extends \OTGS\PHPU
 	 * @test
 	 */
 	public function it_should_implement_media_update_factory() {
-		$subject = new WPML_Page_Builders_Media_Shortcodes_Update_Factory();
+		$subject = new WPML_Page_Builders_Media_Shortcodes_Update_Factory( $this->get_config() );
 		$this->assertInstanceOf( 'IWPML_PB_Media_Update_Factory', $subject );
 		$this->assertInstanceOf( 'IWPML_PB_Media_Update', $subject->create() );
 	}
@@ -25,7 +25,14 @@ class Test_WPML_Page_Builders_Media_Shortcodes_Update_Factory extends \OTGS\PHPU
 	 * @test
 	 */
 	public function it_should_create_and_return_an_instance() {
-		$subject = new WPML_Page_Builders_Media_Shortcodes_Update_Factory();
+		$subject = new WPML_Page_Builders_Media_Shortcodes_Update_Factory( $this->get_config() );
 		$this->assertInstanceOf( 'WPML_Page_Builders_Media_Shortcodes_Update', $subject->create() );
+	}
+
+	private function get_config() {
+		$config = $this->getMockBuilder( 'WPML_PB_Config_Import_Shortcode' )
+		            ->setMethods( array( 'get_media_settings' ) )->disableOriginalConstructor()->getMock();
+		$config->method( 'get_media_settings' )->willReturn( array() );
+		return $config;
 	}
 }

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Page_Builders_Media_Shortcodes_Update extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_translate_if_content_has_no_shortcode() {
+		$post = $this->get_post( 'Some content with no shortcode' );
+
+		\WP_Mock::userFunction( 'wp_update_post', array(
+			'times' => 0,
+		));
+
+		$subject = $this->get_subject();
+		$subject->translate( $post );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_translate_if_post_is_source() {
+		$post = $this->get_post( '[shortcodeA]Hello[/shortcodeA]' );
+
+		\WP_Mock::userFunction( 'wp_update_post', array(
+			'times' => 0,
+		));
+
+		$element = $this->get_element( 'fr', null );
+
+		$factory = $this->get_element_factory();
+		$factory->method( 'create_post' )->with( $post->ID )->willReturn( $element );
+
+		$subject = $this->get_subject( $factory );
+		$subject->translate( $post );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$target_lang = 'fr';
+		$source_lang = 'en';
+		$original_content   = '[shortcodeA image="http://example.com/union-jack.jpg" /]';
+		$translated_content = '[shortcodeA image="http://example.com/drapeau-francais.jpg" /]';
+
+		$post = $this->get_post( $original_content );
+
+		\WP_Mock::userFunction( 'wp_update_post', array(
+			'times' => 1,
+		));
+
+		$element = $this->get_element( $target_lang, $source_lang );
+
+		$factory = $this->get_element_factory();
+		$factory->method( 'create_post' )->with( $post->ID )->willReturn( $element );
+
+		$media_shortcodes = $this->get_media_shortcodes();
+		$media_shortcodes->expects( $this->once() )->method( 'set_target_lang' )->with( $target_lang )->willReturnSelf();
+		$media_shortcodes->expects( $this->once() )->method( 'set_source_lang' )->with( $source_lang )->willReturnSelf();
+		$media_shortcodes->expects( $this->once() )
+		                 ->method( 'translate' )->with( $original_content )->willReturn( $translated_content );
+
+		$subject = $this->get_subject( $factory, $media_shortcodes );
+		$subject->translate( $post );
+	}
+
+	private function get_subject( $factory = null, $media_shortcodes = null ) {
+		$factory          = $factory ? $factory : $this->get_element_factory();
+		$media_shortcodes = $media_shortcodes ? $media_shortcodes : $this->get_media_shortcodes();
+		return new WPML_Page_Builders_Media_Shortcodes_Update( $factory, $media_shortcodes );
+	}
+
+	private function get_element_factory() {
+		return $this->getMockBuilder( 'WPML_Translation_Element_Factory' )
+					->setMethods( array( 'create_post' ) )->disableOriginalConstructor()->getMock();
+	}
+
+	private function get_element( $lang, $source_lang ) {
+		$element = $this->getMockBuilder( 'WPML_Post_Element' )
+		            ->setMethods( array( 'get_language_code', 'get_source_language_code' ) )
+		            ->disableOriginalConstructor()->getMock();
+
+		$element->method( 'get_language_code' )->willReturn( $lang );
+		$element->method( 'get_source_language_code' )->willReturn( $source_lang );
+
+		return $element;
+	}
+
+	private function get_media_shortcodes() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Shortcodes' )
+		                ->setMethods( array( 'set_target_lang', 'set_source_lang', 'translate' ) )
+		                ->disableOriginalConstructor()->getMock();
+	}
+
+	/**
+	 * @param string $content
+	 *
+	 * @return PHPUnit_Framework_MockObject_MockObject|WP_Post
+	 */
+	private function get_post( $content = '' ) {
+		$post = $this->getMockBuilder( 'WP_Post' )
+		            ->disableOriginalConstructor()->getMock();
+		$post->post_content = $content;
+		$post->ID = mt_rand( 1, 100 );
+
+		return $post;
+	}
+}

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Shortcodes_Update extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Shortcodes_Update extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Shortcodes extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Page_Builders_Media_Shortcodes extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$target_lang = 'fr';
+		$source_lang = 'en';
+
+		$original_url_1   = 'http://example.org/dog.jpg';
+		$translated_url_1 = 'http://example.org/chien.jpg';
+		$original_url_2   = 'http://example.org/england.jpg';
+		$translated_url_2 = 'http://example.org/france.jpg';
+		$original_id_1    = 2;
+		$translated_id_1  = 11;
+		$original_id_2    = 7;
+		$translated_id_2  = 19;
+
+		$content = '
+[et_pb_section bb_built="1"][et_pb_row][et_pb_column type="4_4"]
+	[et_pb_gallery _builder_version="3.12" gallery_ids="' . $original_id_1 . '" zoom_icon_color="#2ea3f2" /]
+	[et_pb_audio _builder_version="3.12" title="Audio block One" /]
+	[et_pb_audio _builder_version="3.12" title="Audio block Two" background_image="' . $original_url_1 . '" /]
+	[et_pb_cta background_image="' . $original_url_2 . '" title="The call to action" button_text="Buy me"]
+		Do not miss this opportunity!
+	[/et_pb_cta]
+	[et_pb_gallery gallery_ids="" note="No IDs specified" /]
+	[et_pb_gallery gallery_ids="' . $original_id_1 . ',' . $original_id_2 . '" zoom_icon_color="#2ea3f2" /]
+	[et_pb_video_slider _builder_version="3.12" controls_color="light"]
+		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $original_url_2 . '" background_layout="dark" src_webm="http://wpml.local/video2.webm" /]
+		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $original_url_1 . '" background_layout="dark" src_webm="http://wpml.local/video1.webm" /]
+	[/et_pb_video_slider]
+	[et_pb_video image_src="' . $original_url_1 . '" some_image_src="Should not be translated" background_image="' . $original_url_2 . '" /]
+[/et_pb_column][/et_pb_row][/et_pb_section]
+';
+
+		$translated_content = '
+[et_pb_section bb_built="1"][et_pb_row][et_pb_column type="4_4"]
+	[et_pb_gallery _builder_version="3.12" gallery_ids="' . $translated_id_1 . '" zoom_icon_color="#2ea3f2" /]
+	[et_pb_audio _builder_version="3.12" title="Audio block One" /]
+	[et_pb_audio _builder_version="3.12" title="Audio block Two" background_image="' . $translated_url_1 . '" /]
+	[et_pb_cta background_image="' . $translated_url_2 . '" title="The call to action" button_text="Buy me"]
+		Do not miss this opportunity!
+	[/et_pb_cta]
+	[et_pb_gallery gallery_ids="" note="No IDs specified" /]
+	[et_pb_gallery gallery_ids="' . $translated_id_1 . ',' . $translated_id_2 . '" zoom_icon_color="#2ea3f2" /]
+	[et_pb_video_slider _builder_version="3.12" controls_color="light"]
+		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $translated_url_2 . '" background_layout="dark" src_webm="http://wpml.local/video2.webm" /]
+		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $translated_url_1 . '" background_layout="dark" src_webm="http://wpml.local/video1.webm" /]
+	[/et_pb_video_slider]
+	[et_pb_video image_src="' . $translated_url_1 . '" some_image_src="Should not be translated" background_image="' . $translated_url_2 . '" /]
+[/et_pb_column][/et_pb_row][/et_pb_section]
+';
+
+
+		$config = array(
+			WPML_Page_Builders_Media_Shortcodes::ALL_TAGS => array(
+				'background_image' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+			),
+			'et_pb_video_slider_item|et_pb_video'         => array(
+				'image_src' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+			),
+			'et_pb_gallery'                               => array(
+				'gallery_ids' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS,
+			),
+		);
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->willReturnMap(
+			array(
+				array( $original_id_1, $target_lang, $translated_id_1 ),
+				array( $original_id_2, $target_lang, $translated_id_2 ),
+			)
+		);
+		$media_translate->method( 'translate_image_url' )->willReturnMap(
+			array(
+				array( $original_url_1, $target_lang, $source_lang, $translated_url_1 ),
+				array( $original_url_2, $target_lang, $source_lang, $translated_url_2 ),
+			)
+		);
+
+		$subject = $this->get_subject( $media_translate, $config );
+
+		$actual_content = $subject->set_target_lang( $target_lang )
+		                          ->set_source_lang( $source_lang )
+		                          ->translate( $content );
+
+		$this->assertEquals( $translated_content, $actual_content );
+	}
+
+	private function get_subject( $media_translate, $config ) {
+		return new WPML_Page_Builders_Media_Shortcodes( $media_translate, $config );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+			->setMethods( array( 'translate_id', 'translate_image_url' ) )
+			->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -57,16 +57,34 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 [/et_pb_column][/et_pb_row][/et_pb_section]
 ';
 
-
 		$config = array(
-			WPML_Page_Builders_Media_Shortcodes::ALL_TAGS => array(
-				'background_image' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+			array(
+				'tag'        => array( 'name' => '*' ),
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
 			),
-			'et_pb_video_slider_item|et_pb_video'         => array(
-				'image_src' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
+			array(
+				'tag'        => array( 'name' => 'et_pb_video_slider_item|et_pb_video' ),
+				'attributes' => array(
+					'image_src' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
 			),
-			'et_pb_gallery'                               => array(
-				'gallery_ids' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS,
+			array(
+				'tag'        => array( 'name' => 'et_pb_gallery' ),
+				'attributes' => array(
+					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
+				),
+			),
+			// Missing tag, should not alter content
+			array(
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			// No attributes, should not alter content
+			array(
+				'tag' => array( 'name' => 'et_pb_gallery' ),
 			),
 		);
 

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-hooks.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-hooks.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Hooks extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Hooks extends \OTGS\PHPUnit\Tools\TestCase {
 
 	const SLUG_TEST = 'the-page-builder';
 

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Translate extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Translate extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
@@ -89,6 +89,18 @@ class Test_WPML_Page_Builders_Media_Translate extends OTGS_TestCase {
 		$this->assertSame( $id, $subject->translate_id( $id, $lang ) );
 	}
 
+	/**
+	 * @test
+	 */
+	public function it_should_return_the_original_id_if_not_a_valid_one() {
+		$id   = 'invalid ID';
+		$lang = 'fr';
+		
+		$subject = $this->get_subject();
+
+		$this->assertSame( $id, $subject->translate_id( $id, $lang ) );
+	}
+
 	private function get_subject( $factory = null, $image_translate = null ) {
 		$factory         = $factory ? $factory : $this->get_element_factory();
 		$image_translate = $image_translate ? $image_translate : $this->get_image_translate();

--- a/tests/phpunit/tests/media/test-wpml-page-builders-update-media.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-update-media.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Update_Media extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Update_Media extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
+++ b/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WPML_Page_Builders_Update extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Update extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WPML_PB_Shortcode_Strategy extends OTGS_TestCase {
+class Test_WPML_PB_Shortcode_Strategy extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/st/test-wpml-page-builders-app.php
+++ b/tests/phpunit/tests/st/test-wpml-page-builders-app.php
@@ -7,7 +7,7 @@
  * @group beaver-builder
  * @group elementor
  */
-class Test_WPML_Page_Builders_App extends OTGS_TestCase {
+class Test_WPML_Page_Builders_App extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/st/test-wpml-page-builders-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-page-builders-integration.php
@@ -7,7 +7,7 @@
  * @group beaver-builder
  * @group elementor
  */
-class Test_WPML_Page_Builders_Integration extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Integration extends \OTGS\PHPUnit\Tools\TestCase {
 
 	private $register_strings;
 	private $update_translation;

--- a/tests/phpunit/tests/st/test-wpml-pb-api-hooks-strategy.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-api-hooks-strategy.php
@@ -6,13 +6,6 @@
  */
 
 class Test_WPML_PB_API_Hooks_Strategy extends WPML_PB_TestCase {
-
-	function setUp() {
-		parent::setUp();
-
-		$this->mock_all_core_functions();
-	}
-
 	function test_get_package_kind() {
 		$name = rand_str();
 		$subject = new WPML_PB_API_Hooks_Strategy( $name );

--- a/tests/phpunit/tests/st/test-wpml-pb-config-import.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-config-import.php
@@ -3,7 +3,7 @@
 /**
  * Class Test_WPML_PB_Config_Import
  */
-class Test_WPML_PB_Config_Import extends OTGS_TestCase {
+class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 	/**
 	 * @param $shortcode
 	 * @param $expected_value
@@ -11,8 +11,6 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 	 * @dataProvider filter_data_provider
 	 */
 	public function test_filter( $shortcode, $expected_value ) {
-		$this->mock_all_core_functions();
-
 		$data     = array(
 			'wpml-config' => array(
 				'shortcodes' => array(
@@ -121,7 +119,6 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 	 * @dataProvider settings_provider
 	 */
 	public function test_has_settings( $has_settings ) {
-		$this->mock_all_core_functions();
 		$settings = $this->get_settings_mock_for_has_settings( $has_settings );
 		$subject  = new WPML_PB_Config_Import_Shortcode( $settings );
 		$this->assertEquals( $has_settings, $subject->has_settings() );
@@ -146,7 +143,6 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 	}
 
 	public function test_link_attribute() {
-		$this->mock_all_core_functions();
 		$shortcode = array(
 			'tag'        => array( 'value' => 'tag1', 'attr' => array( 'type' => 'link' ) ),
 			'attributes' => array(

--- a/tests/phpunit/tests/st/test-wpml-pb-factory.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-factory.php
@@ -13,8 +13,6 @@ class Test_WPML_PB_Factory extends WPML_PB_TestCase {
 		parent::setUp();
 		global $wpdb;
 
-		$this->mock_all_core_functions();
-
 		$this->wpdb_original = $wpdb;
 	}
 

--- a/tests/phpunit/tests/st/test-wpml-pb-loader.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-loader.php
@@ -1,13 +1,6 @@
 <?php
 
 class Test_WPML_PB_Loader extends WPML_PB_TestCase {
-
-	function setUp() {
-		parent::setUp();
-
-		$this->mock_all_core_functions();
-	}
-
 	public function test_no_strategies() {
 		$st_settings      = $this->get_wpml_st_settings();
 		$integration_mock = $this->get_pb_integration_mock();
@@ -20,6 +13,7 @@ class Test_WPML_PB_Loader extends WPML_PB_TestCase {
 		$integration_mock = $this->get_pb_integration_mock();
 		$integration_mock->expects( $this->exactly( 1 ) )->method( 'add_hooks' );
 		$integration_mock->expects( $this->exactly( 1 ) )->method( 'add_strategy' );
+		WP_Mock::userFunction('is_admin', array('return' => true));
 		new WPML_PB_Loader( $this->get_sitepress_mock(),
 		                    $this->get_wpdb_mock(),
 		                    $this->get_settings_mock(),

--- a/tests/phpunit/tests/st/test-wpml-pb-rescan.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-rescan.php
@@ -3,7 +3,7 @@
 /**
  * Class Test_WPML_PR_Register_Shortcodes
  */
-class Test_WPML_PB_Rescan extends OTGS_TestCase {
+class Test_WPML_PB_Rescan extends \OTGS\PHPUnit\Tools\TestCase {
 	/**
 	 * @var WPML_PB_Integration
 	 */

--- a/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
@@ -4,13 +4,6 @@
  * @group page-builders
  */
 class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
-
-	function setUp() {
-		parent::setUp();
-
-		$this->mock_all_core_functions();
-	}
-
 	/**
 	 * @dataProvider new_translations_data_provider
 	 */
@@ -82,7 +75,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	}
 
 	private function get_wpdb_mock( $string_package_id, $language_1, $language_2 ) {
-		$wpdb = $this->get_wpdb_stub();
+		$wpdb = $this->stubs->wpdb();
 
 		$result_1                    = new stdClass();
 		$result_1->string_package_id = $string_package_id;

--- a/tests/phpunit/tests/st/test-wpml-pb-update-post.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-update-post.php
@@ -5,7 +5,6 @@ class Test_WPML_PB_Update_Post extends WPML_PB_TestCase {
 	function setUp() {
 		parent::setUp();
 
-		$this->mock_all_core_functions();
 		\WP_Mock::wpFunction( 'get_shortcode_regex', array(
 			'return' => '\[(\[?)(vc_column_text)(?![\w-])([^\]\/]*(?:\/(?!\])[^\]\/]*)*?)(?:(\/)\]|\](?:([^\[]*+(?:\[(?!\/\2\])[^\[]*+)*+)\[\/\2\])?)(\]?)',
 		) );
@@ -26,21 +25,31 @@ class Test_WPML_PB_Update_Post extends WPML_PB_TestCase {
 		$text_string                         = rand_str();
 		$translated_text_string              = rand_str();
 		$string_without_translation_complete = rand_str();
-		$post_id                             = wp_insert_post( array(
-				'post_content' => '[vc_column_text title="' . ( $encode ? base64_encode( $title_string ) : $title_string ) . '" text="' . ( $encode ? base64_encode( $text_string ) : $text_string ) . '"]' . ( $encode ? base64_encode( $string ) : $string ) . '[/vc_column_text]' .
-				                  '[vc_column_text title="' . ( $encode ? base64_encode( $title_string_2 ) : $title_string_2 ) . '"]' . $string_without_translation_complete . '[/vc_column_text]',
-				'post_type'    => 'page',
-			)
-		);
+		$post_id                             = 123;
+
+		/** @var \WP_Post|\PHPUnit_Framework_MockObject_MockObject $wp_post */
+		$wp_post = $this->getMockBuilder( 'WP_Post' )
+						->disableOriginalConstructor()
+						->getMock();
+
+		$wp_post->ID           = $post_id;
+		$wp_post->post_content = '[vc_column_text title="' . ( $encode ? base64_encode( $title_string ) : $title_string ) . '" text="' . ( $encode ? base64_encode( $text_string ) : $text_string ) . '"]' . ( $encode ? base64_encode( $string ) : $string ) . '[/vc_column_text]' .
+								 '[vc_column_text title="' . ( $encode ? base64_encode( $title_string_2 ) : $title_string_2 ) . '"]' . $string_without_translation_complete . '[/vc_column_text]';
+		$wp_post->post_type    = 'page';
+
 		$language                            = rand_str( 4 );
 
+		\WP_Mock::wpFunction( 'get_post', array(
+			'args'   => array( $post_id ),
+			'return' => $wp_post,
+		) );
 		\WP_Mock::wpFunction( 'wp_update_post', array(
 			'times' => 1,
 			'args'  => array(
 				array(
 					'ID'           => $post_id,
 					'post_content' => '[vc_column_text title="' . ( $encode ? base64_encode( $translated_title_string ) : $translated_title_string ) . '" text="' . ( $encode ? base64_encode( $translated_text_string ) : $translated_text_string ) . '"]' . ( $encode ? base64_encode( $translated_string ) : $translated_string ) . '[/vc_column_text]' .
-					                  '[vc_column_text title="' . ( $encode ? base64_encode( $translated_title_string ) : $translated_title_string ) . '"]' . $string_without_translation_complete . '[/vc_column_text]',
+									  '[vc_column_text title="' . ( $encode ? base64_encode( $translated_title_string ) : $translated_title_string ) . '"]' . $string_without_translation_complete . '[/vc_column_text]',
 				)
 			)
 		) );

--- a/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
@@ -15,8 +15,6 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 	function setUp() {
 		parent::setUp();
 
-		$this->mock_all_core_functions();
-
 		/** @var WPML_PB_Shortcodes|\Mockery\MockInterface $shortcode_parser */
 		$shortcode_parser = \Mockery::mock( 'WPML_PB_Shortcodes' );
 		$shortcode_parser->shouldReceive( 'get_shortcodes' )->andReturn(

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
@@ -5,7 +5,7 @@
  *
  * @group wpmlpb-149
  */
-class Test_WPML_PB_Handle_Custom_Fields extends OTGS_TestCase {
+class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
@@ -5,7 +5,7 @@
  *
  * @group wpmlcore-5684
  */
-class Test_WPML_PB_Handle_Post_Body extends OTGS_TestCase {
+class Test_WPML_PB_Handle_Post_Body extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -5,7 +5,7 @@
  *
  * @group page-builders
  */
-class Test_WPML_TM_Page_Builders_Field_Wrapper extends OTGS_TestCase {
+class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestCase {
 
 	private $package_id;
 	private $string_id;

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-hooks.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-hooks.php
@@ -5,7 +5,7 @@
  *
  * @group page-builders
  */
-class Test_WPML_TM_Page_Builders_Hooks extends OTGS_TestCase {
+class Test_WPML_TM_Page_Builders_Hooks extends \OTGS\PHPUnit\Tools\TestCase {
 
 	private $worker;
 

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -6,7 +6,7 @@
  *
  * @group page-builders
  */
-class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
+class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 
 	function setUp() {
 		parent::setUp();
@@ -21,8 +21,6 @@ class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 				return $result;
 			}
 		) );
-
-		$this->mock_all_core_functions();
 	}
 
 	/**
@@ -480,21 +478,28 @@ class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 		$wpml_tm_translation_status->method( 'filter_translation_status' )->with( null, $trid, $lang )
 			->willReturn( $status );
 
-		$actual_link = $this->get_subject()->link_to_translation_filter( $link, $post_id, $lang, $trid );
-
-		if ( $is_link_altered ) {
-			$expected_link = add_query_arg( array(
+		$altered_link = 'altered-link';
+		WP_Mock::userFunction( 'add_query_arg', array(
+			'args'   => array(
+				array(
 					'update_needed' => 1,
 					'trid'          => $trid,
 					'language_code' => $lang,
 				),
-				$link
-			);
+				$link,
+			),
+			'return' => $altered_link,
+		) );
 
-			$this->assertEquals( $expected_link, $actual_link );
+		$actual_link = $this->get_subject()->link_to_translation_filter( $link, $post_id, $lang, $trid );
+
+		if ( $is_link_altered ) {
+			$expected_link = $altered_link;
+
 		} else {
-			$this->assertEquals( $link, $actual_link );
+			$expected_link = $link;
 		}
+		$this->assertSame( $expected_link, $actual_link );
 	}
 
 	/**

--- a/tests/phpunit/tests/utilities/test-wpml-page-builders-page-built.php
+++ b/tests/phpunit/tests/utilities/test-wpml-page-builders-page-built.php
@@ -5,7 +5,7 @@
  *
  * @group wpmlpb-148
  */
-class Test_WPML_Page_Builders_Page_Built extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Page_Built extends WPML_PageBuilders_TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/util/wpml-pb-test-case.php
+++ b/tests/phpunit/util/wpml-pb-test-case.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class WPML_PB_TestCase extends OTGS_TestCase {
+abstract class WPML_PB_TestCase extends WPML_PageBuilders_TestCase {
 
 	function setUp() {
 		parent::setUp();

--- a/tests/phpunit/util/wpml-pb-test-case2.php
+++ b/tests/phpunit/util/wpml-pb-test-case2.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class WPML_PB_TestCase2 extends OTGS_TestCase {
+abstract class WPML_PB_TestCase2 extends WPML_PageBuilders_TestCase {
 
 	function setUp() {
 		parent::setUp();

--- a/tests/phpunit/util/wpml-st-test-case.php
+++ b/tests/phpunit/util/wpml-st-test-case.php
@@ -5,7 +5,7 @@
  *
  * @author OnTheGoSystems
  */
-abstract class WPML_ST_TestCase extends OTGS_TestCase {
+abstract class WPML_ST_TestCase extends WPML_PageBuilders_TestCase {
 
 	/**
 	 * @return array


### PR DESCRIPTION
Created a generic code that can be used by any shortcode page builder
using Image URL or IDs as an attribute.

For now, I hardcoded Divi configuration inside the factory class but if
we all agree, I will create a ticket to move this to `wpml-config.xml`.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5819

Also added a little improvement as a second commit.