### PR TITLE
WIP - Improvements in tests and CI

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,12 +1,12 @@
 ---
 checks:
-  php:
-    code_rating: true
-    duplication: true
+    php:
+        code_rating: true
+        duplication: true
 filter:
     excluded_paths:
-        - "tests/"
-        - "vendor/"
+    - "tests/"
+    - "vendor/"
 coding_style:
     php:
         indentation:
@@ -18,41 +18,39 @@ coding_style:
                 negation: true
 
 build:
-  cache:
-    directories:
-      - vendor/
-  nodes:
-    phpcs:
-      environment:
-        php: 5.6
-      tests:
-        override:
-          -
-            on_node: 1
-            idle_timeout: 4800
-            command: "phpcs-run ./"
+    cache:
+        directories:
+        - vendor/
+    nodes:
 
-    phpunit:
-      environment:
-        php: 5.6
-      tests:
+        php-coding-standards:
+            environment:
+                php: 7.1
+            tests:
+                override:
+                - idle_timeout: 4800
+                  command: "phpcs-run ./"
+
+        phpunit:
+            environment:
+                php: 5.6
+            tests:
+                override:
+                - idle_timeout: 4800
+                  command: "./vendor/bin/phpunit --coverage-clover ./coverage.xml"
+                  coverage:
+                      file: coverage.xml
+                      format: php-clover
+
+        php70:
+            environment:
+                php: 7.0
+
+        php71:
+            environment:
+                php: 7.1
+
+    tests:
         override:
-          -
-            on_node: 2
-            idle_timeout: 4800
-            command: "./vendor/bin/phpunit --coverage-clover ./coverage.xml"
-            coverage:
-              file: coverage.xml
-              format: php-clover
-    php70:
-      environment:
-        php: 7.0
-    php71:
-      environment:
-        php: 7.1
-  tests:
-    override:
-      -
-        on_node: 1
-        idle_timeout: 4800
-        command: "./vendor/bin/phpunit"
+        - idle_timeout: 4800
+          command: "./vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,15 @@
         "symfony/dom-crawler": "^3.1",
         "symfony/css-selector": "^3.1",
         "phpunit/phpunit": "^5",
-        "otgs/phpunit-tools": "dev-master"
+        "otgs/phpunit-tools": "dev-master",
+
+        "squizlabs/php_codesniffer": "~3",
+        "phpcompatibility/php-compatibility": "*",
+        "dealerdirect/phpcodesniffer-composer-installer": "*",
+
+        "wp-coding-standards/wpcs": "^0",
+
+        "m4tthumphrey/php-gitlab-api": "^9.0.0",
+        "php-http/guzzle6-adapter": "^1.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,33 @@
 {
-  "name": "wpml/page-builders",
-  "description": "A library used by WPML to handle page builders plugins and themes",
-  "type": "library",
-  "license": "GPL-3.0-or-later",
-  "authors": [
-    {
-      "name": "OnTheGoSystems",
-      "email": "hello@wpml.org"
+    "name": "wpml/page-builders",
+    "description": "A library used by WPML to handle page builders plugins and themes",
+    "type": "library",
+    "license": "GPL-3.0-or-later",
+    "authors": [
+        {
+            "name": "OnTheGoSystems",
+            "email": "hello@wpml.org"
+        }
+    ],
+    "autoload": {
+        "classmap": [
+            "src/"
+        ]
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/phpunit/stubs/",
+            "tests/phpunit/util/"
+        ]
+    },
+    "require-dev": {
+        "roave/security-advisories": "dev-master",
+
+        "10up/wp_mock": "~0.2.0",
+        "lucatume/function-mocker": "1.3.4",
+        "symfony/dom-crawler": "^3.1",
+        "symfony/css-selector": "^3.1",
+        "phpunit/phpunit": "^5",
+        "otgs/phpunit-tools": "dev-master"
     }
-  ],
-  "autoload": {
-    "classmap": [
-      "src/"
-    ]
-  },
-  "autoload-dev": {
-    "classmap": [
-      "tests/phpunit/stubs/",
-      "tests/phpunit/util/"
-    ]
-  },
-  "require": {
-    "roave/security-advisories": "dev-master"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "~5.7",
-    "otgs/unit-tests-framework": "~1.2.0"
-  }
 }

--- a/phpcs.compatibility.xml
+++ b/phpcs.compatibility.xml
@@ -2,9 +2,7 @@
 <ruleset name="WPML">
 	<description>WPML Coding Standards</description>
 
-	<rule ref="WordPress-Core"/>
-	<rule ref="WordPress-Docs"/>
-	<rule ref="WordPress-Extra"/>
+	<config name="testVersion" value="5.2"/>
 
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
@@ -14,12 +12,5 @@
 	<exclude-pattern>*.twig</exclude-pattern>
 	<exclude-pattern>*.css</exclude-pattern>
 	<exclude-pattern>*.scss</exclude-pattern>
-
-	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<severity>0</severity>
-	</rule>
-	<rule ref="Squiz.Commenting.ClassComment.Missing">
-		<severity>0</severity>
-	</rule>
 
 </ruleset>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -37,4 +37,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../../vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';

--- a/tests/phpunit/tests/WPML_PageBuilders_TestCase.php
+++ b/tests/phpunit/tests/WPML_PageBuilders_TestCase.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author OnTheGo Systems
+ */
+
+use tad\FunctionMocker\FunctionMocker;
+
+abstract class WPML_PageBuilders_TestCase extends \OTGS\PHPUnit\Tools\TestCase {
+	function setUp() {
+		parent::setUp();
+		FunctionMocker::setUp();
+		WP_Mock::setUp();
+	}
+
+	function tearDown() {
+		WP_Mock::tearDown();
+		FunctionMocker::tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+
+}

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Shortcodes_Update_Factory extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Shortcodes_Update_Factory extends \OTGS\PHPUnit\Tools\TestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Shortcodes_Update extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Shortcodes_Update extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Shortcodes extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-hooks.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-hooks.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Hooks extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Hooks extends \OTGS\PHPUnit\Tools\TestCase {
 
 	const SLUG_TEST = 'the-page-builder';
 

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Media_Translate extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Media_Translate extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/media/test-wpml-page-builders-update-media.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-update-media.php
@@ -3,7 +3,7 @@
 /**
  * @group media
  */
-class Test_WPML_Page_Builders_Update_Media extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Update_Media extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
+++ b/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WPML_Page_Builders_Update extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Update extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_WPML_PB_Shortcode_Strategy extends OTGS_TestCase {
+class Test_WPML_PB_Shortcode_Strategy extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/st/test-wpml-page-builders-app.php
+++ b/tests/phpunit/tests/st/test-wpml-page-builders-app.php
@@ -7,7 +7,7 @@
  * @group beaver-builder
  * @group elementor
  */
-class Test_WPML_Page_Builders_App extends OTGS_TestCase {
+class Test_WPML_Page_Builders_App extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/st/test-wpml-page-builders-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-page-builders-integration.php
@@ -7,7 +7,7 @@
  * @group beaver-builder
  * @group elementor
  */
-class Test_WPML_Page_Builders_Integration extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Integration extends \OTGS\PHPUnit\Tools\TestCase {
 
 	private $register_strings;
 	private $update_translation;

--- a/tests/phpunit/tests/st/test-wpml-pb-api-hooks-strategy.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-api-hooks-strategy.php
@@ -6,13 +6,6 @@
  */
 
 class Test_WPML_PB_API_Hooks_Strategy extends WPML_PB_TestCase {
-
-	function setUp() {
-		parent::setUp();
-
-		$this->mock_all_core_functions();
-	}
-
 	function test_get_package_kind() {
 		$name = rand_str();
 		$subject = new WPML_PB_API_Hooks_Strategy( $name );

--- a/tests/phpunit/tests/st/test-wpml-pb-config-import.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-config-import.php
@@ -3,7 +3,7 @@
 /**
  * Class Test_WPML_PB_Config_Import
  */
-class Test_WPML_PB_Config_Import extends OTGS_TestCase {
+class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 	/**
 	 * @param $shortcode
 	 * @param $expected_value
@@ -11,8 +11,6 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 	 * @dataProvider filter_data_provider
 	 */
 	public function test_filter( $shortcode, $expected_value ) {
-		$this->mock_all_core_functions();
-
 		$data     = array(
 			'wpml-config' => array(
 				'shortcodes' => array(
@@ -121,7 +119,6 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 	 * @dataProvider settings_provider
 	 */
 	public function test_has_settings( $has_settings ) {
-		$this->mock_all_core_functions();
 		$settings = $this->get_settings_mock_for_has_settings( $has_settings );
 		$subject  = new WPML_PB_Config_Import_Shortcode( $settings );
 		$this->assertEquals( $has_settings, $subject->has_settings() );
@@ -146,7 +143,6 @@ class Test_WPML_PB_Config_Import extends OTGS_TestCase {
 	}
 
 	public function test_link_attribute() {
-		$this->mock_all_core_functions();
 		$shortcode = array(
 			'tag'        => array( 'value' => 'tag1', 'attr' => array( 'type' => 'link' ) ),
 			'attributes' => array(

--- a/tests/phpunit/tests/st/test-wpml-pb-factory.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-factory.php
@@ -13,8 +13,6 @@ class Test_WPML_PB_Factory extends WPML_PB_TestCase {
 		parent::setUp();
 		global $wpdb;
 
-		$this->mock_all_core_functions();
-
 		$this->wpdb_original = $wpdb;
 	}
 

--- a/tests/phpunit/tests/st/test-wpml-pb-loader.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-loader.php
@@ -1,13 +1,6 @@
 <?php
 
 class Test_WPML_PB_Loader extends WPML_PB_TestCase {
-
-	function setUp() {
-		parent::setUp();
-
-		$this->mock_all_core_functions();
-	}
-
 	public function test_no_strategies() {
 		$st_settings      = $this->get_wpml_st_settings();
 		$integration_mock = $this->get_pb_integration_mock();
@@ -20,6 +13,7 @@ class Test_WPML_PB_Loader extends WPML_PB_TestCase {
 		$integration_mock = $this->get_pb_integration_mock();
 		$integration_mock->expects( $this->exactly( 1 ) )->method( 'add_hooks' );
 		$integration_mock->expects( $this->exactly( 1 ) )->method( 'add_strategy' );
+		WP_Mock::userFunction('is_admin', array('return' => true));
 		new WPML_PB_Loader( $this->get_sitepress_mock(),
 		                    $this->get_wpdb_mock(),
 		                    $this->get_settings_mock(),

--- a/tests/phpunit/tests/st/test-wpml-pb-rescan.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-rescan.php
@@ -3,7 +3,7 @@
 /**
  * Class Test_WPML_PR_Register_Shortcodes
  */
-class Test_WPML_PB_Rescan extends OTGS_TestCase {
+class Test_WPML_PB_Rescan extends \OTGS\PHPUnit\Tools\TestCase {
 	/**
 	 * @var WPML_PB_Integration
 	 */

--- a/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
@@ -4,13 +4,6 @@
  * @group page-builders
  */
 class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
-
-	function setUp() {
-		parent::setUp();
-
-		$this->mock_all_core_functions();
-	}
-
 	/**
 	 * @dataProvider new_translations_data_provider
 	 */
@@ -82,7 +75,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	}
 
 	private function get_wpdb_mock( $string_package_id, $language_1, $language_2 ) {
-		$wpdb = $this->get_wpdb_stub();
+		$wpdb = $this->stubs->wpdb();
 
 		$result_1                    = new stdClass();
 		$result_1->string_package_id = $string_package_id;

--- a/tests/phpunit/tests/st/test-wpml-pb-update-post.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-update-post.php
@@ -5,7 +5,6 @@ class Test_WPML_PB_Update_Post extends WPML_PB_TestCase {
 	function setUp() {
 		parent::setUp();
 
-		$this->mock_all_core_functions();
 		\WP_Mock::wpFunction( 'get_shortcode_regex', array(
 			'return' => '\[(\[?)(vc_column_text)(?![\w-])([^\]\/]*(?:\/(?!\])[^\]\/]*)*?)(?:(\/)\]|\](?:([^\[]*+(?:\[(?!\/\2\])[^\[]*+)*+)\[\/\2\])?)(\]?)',
 		) );
@@ -26,21 +25,31 @@ class Test_WPML_PB_Update_Post extends WPML_PB_TestCase {
 		$text_string                         = rand_str();
 		$translated_text_string              = rand_str();
 		$string_without_translation_complete = rand_str();
-		$post_id                             = wp_insert_post( array(
-				'post_content' => '[vc_column_text title="' . ( $encode ? base64_encode( $title_string ) : $title_string ) . '" text="' . ( $encode ? base64_encode( $text_string ) : $text_string ) . '"]' . ( $encode ? base64_encode( $string ) : $string ) . '[/vc_column_text]' .
-				                  '[vc_column_text title="' . ( $encode ? base64_encode( $title_string_2 ) : $title_string_2 ) . '"]' . $string_without_translation_complete . '[/vc_column_text]',
-				'post_type'    => 'page',
-			)
-		);
+		$post_id                             = 123;
+
+		/** @var \WP_Post|\PHPUnit_Framework_MockObject_MockObject $wp_post */
+		$wp_post = $this->getMockBuilder( 'WP_Post' )
+						->disableOriginalConstructor()
+						->getMock();
+
+		$wp_post->ID           = $post_id;
+		$wp_post->post_content = '[vc_column_text title="' . ( $encode ? base64_encode( $title_string ) : $title_string ) . '" text="' . ( $encode ? base64_encode( $text_string ) : $text_string ) . '"]' . ( $encode ? base64_encode( $string ) : $string ) . '[/vc_column_text]' .
+								 '[vc_column_text title="' . ( $encode ? base64_encode( $title_string_2 ) : $title_string_2 ) . '"]' . $string_without_translation_complete . '[/vc_column_text]';
+		$wp_post->post_type    = 'page';
+
 		$language                            = rand_str( 4 );
 
+		\WP_Mock::wpFunction( 'get_post', array(
+			'args'   => array( $post_id ),
+			'return' => $wp_post,
+		) );
 		\WP_Mock::wpFunction( 'wp_update_post', array(
 			'times' => 1,
 			'args'  => array(
 				array(
 					'ID'           => $post_id,
 					'post_content' => '[vc_column_text title="' . ( $encode ? base64_encode( $translated_title_string ) : $translated_title_string ) . '" text="' . ( $encode ? base64_encode( $translated_text_string ) : $translated_text_string ) . '"]' . ( $encode ? base64_encode( $translated_string ) : $translated_string ) . '[/vc_column_text]' .
-					                  '[vc_column_text title="' . ( $encode ? base64_encode( $translated_title_string ) : $translated_title_string ) . '"]' . $string_without_translation_complete . '[/vc_column_text]',
+									  '[vc_column_text title="' . ( $encode ? base64_encode( $translated_title_string ) : $translated_title_string ) . '"]' . $string_without_translation_complete . '[/vc_column_text]',
 				)
 			)
 		) );

--- a/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
@@ -15,8 +15,6 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 	function setUp() {
 		parent::setUp();
 
-		$this->mock_all_core_functions();
-
 		/** @var WPML_PB_Shortcodes|\Mockery\MockInterface $shortcode_parser */
 		$shortcode_parser = \Mockery::mock( 'WPML_PB_Shortcodes' );
 		$shortcode_parser->shouldReceive( 'get_shortcodes' )->andReturn(

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
@@ -5,7 +5,7 @@
  *
  * @group wpmlpb-149
  */
-class Test_WPML_PB_Handle_Custom_Fields extends OTGS_TestCase {
+class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
@@ -5,7 +5,7 @@
  *
  * @group wpmlcore-5684
  */
-class Test_WPML_PB_Handle_Post_Body extends OTGS_TestCase {
+class Test_WPML_PB_Handle_Post_Body extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -5,7 +5,7 @@
  *
  * @group page-builders
  */
-class Test_WPML_TM_Page_Builders_Field_Wrapper extends OTGS_TestCase {
+class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestCase {
 
 	private $package_id;
 	private $string_id;

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-hooks.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-hooks.php
@@ -5,7 +5,7 @@
  *
  * @group page-builders
  */
-class Test_WPML_TM_Page_Builders_Hooks extends OTGS_TestCase {
+class Test_WPML_TM_Page_Builders_Hooks extends \OTGS\PHPUnit\Tools\TestCase {
 
 	private $worker;
 

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -6,7 +6,7 @@
  *
  * @group page-builders
  */
-class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
+class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 
 	function setUp() {
 		parent::setUp();
@@ -21,8 +21,6 @@ class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 				return $result;
 			}
 		) );
-
-		$this->mock_all_core_functions();
 	}
 
 	/**
@@ -480,21 +478,28 @@ class Test_WPML_TM_Page_Builders extends OTGS_TestCase {
 		$wpml_tm_translation_status->method( 'filter_translation_status' )->with( null, $trid, $lang )
 			->willReturn( $status );
 
-		$actual_link = $this->get_subject()->link_to_translation_filter( $link, $post_id, $lang, $trid );
-
-		if ( $is_link_altered ) {
-			$expected_link = add_query_arg( array(
+		$altered_link = 'altered-link';
+		WP_Mock::userFunction( 'add_query_arg', array(
+			'args'   => array(
+				array(
 					'update_needed' => 1,
 					'trid'          => $trid,
 					'language_code' => $lang,
 				),
-				$link
-			);
+				$link,
+			),
+			'return' => $altered_link,
+		) );
 
-			$this->assertEquals( $expected_link, $actual_link );
+		$actual_link = $this->get_subject()->link_to_translation_filter( $link, $post_id, $lang, $trid );
+
+		if ( $is_link_altered ) {
+			$expected_link = $altered_link;
+
 		} else {
-			$this->assertEquals( $link, $actual_link );
+			$expected_link = $link;
 		}
+		$this->assertSame( $expected_link, $actual_link );
 	}
 
 	/**

--- a/tests/phpunit/tests/utilities/test-wpml-page-builders-page-built.php
+++ b/tests/phpunit/tests/utilities/test-wpml-page-builders-page-built.php
@@ -5,7 +5,7 @@
  *
  * @group wpmlpb-148
  */
-class Test_WPML_Page_Builders_Page_Built extends OTGS_TestCase {
+class Test_WPML_Page_Builders_Page_Built extends WPML_PageBuilders_TestCase {
 
 	/**
 	 * @test

--- a/tests/phpunit/util/wpml-pb-test-case.php
+++ b/tests/phpunit/util/wpml-pb-test-case.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class WPML_PB_TestCase extends OTGS_TestCase {
+abstract class WPML_PB_TestCase extends WPML_PageBuilders_TestCase {
 
 	function setUp() {
 		parent::setUp();

--- a/tests/phpunit/util/wpml-pb-test-case2.php
+++ b/tests/phpunit/util/wpml-pb-test-case2.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class WPML_PB_TestCase2 extends OTGS_TestCase {
+abstract class WPML_PB_TestCase2 extends WPML_PageBuilders_TestCase {
 
 	function setUp() {
 		parent::setUp();

--- a/tests/phpunit/util/wpml-st-test-case.php
+++ b/tests/phpunit/util/wpml-st-test-case.php
@@ -5,7 +5,7 @@
  *
  * @author OnTheGoSystems
  */
-abstract class WPML_ST_TestCase extends OTGS_TestCase {
+abstract class WPML_ST_TestCase extends WPML_PageBuilders_TestCase {
 
 	/**
 	 * @return array


### PR DESCRIPTION
This MR started as a solution to a bunch of report issues coming from Scrutinizer and ended up as a way to mainly get rid of `otgs/unit-tests-framework` dependency (a private repository which blocks contributors from running tests and adds a lot of unneeded additional dependencies).

The library has been replaced by `otgs/phpunit-tools` (public library) which provides the minimum features (tools) to run PHPUnit tests in this kind of projects.

By doing that, I'm now able to:
- Run tests independently any private repository
- Run phpcs for checking standards as well as compatibility issues
- Get cleaner (hopefully) Scrutinizer reports