### PR TITLE
Fix attribute value replacement when it's wrapped with single quotes

### DIFF
--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
@@ -61,7 +61,7 @@ class WPML_Page_Builders_Media_Shortcodes {
 
 	private function translate_attributes( $content, $tag, $attributes ) {
 		foreach ( $attributes as $attribute => $data ) {
-			$pattern = '/(\[(?:' . $tag . ')(?: [^\]]* | )' . $attribute . '=")([^"]*)/';
+			$pattern = '/(\[(?:' . $tag . ')(?: [^\]]* | )' . $attribute . '=(?:"|\'))([^"\']*)/';
 			$type    = isset( $data['type'] ) ? $data['type'] : '';
 			$content = preg_replace_callback( $pattern, array( $this, $this->get_callback( $type ) ), $content );
 		}

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -7,6 +7,7 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 
 	/**
 	 * @test
+	 * @group wpmlcore-5861
 	 */
 	public function it_should_translate() {
 		$target_lang = 'fr';
@@ -36,6 +37,7 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $original_url_1 . '" background_layout="dark" src_webm="http://wpml.local/video1.webm" /]
 	[/et_pb_video_slider]
 	[et_pb_video image_src="' . $original_url_1 . '" some_image_src="Should not be translated" background_image="' . $original_url_2 . '" /]
+	[shortcode_with_single_quotes gallery_ids=\'' . $original_id_1 . '\' /]
 [/et_pb_column][/et_pb_row][/et_pb_section]
 ';
 
@@ -54,6 +56,7 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $translated_url_1 . '" background_layout="dark" src_webm="http://wpml.local/video1.webm" /]
 	[/et_pb_video_slider]
 	[et_pb_video image_src="' . $translated_url_1 . '" some_image_src="Should not be translated" background_image="' . $translated_url_2 . '" /]
+	[shortcode_with_single_quotes gallery_ids=\'' . $translated_id_1 . '\' /]
 [/et_pb_column][/et_pb_row][/et_pb_section]
 ';
 
@@ -72,6 +75,12 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 			),
 			array(
 				'tag'        => array( 'name' => 'et_pb_gallery' ),
+				'attributes' => array(
+					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'shortcode_with_single_quotes' ),
 				'attributes' => array(
 					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
 				),


### PR DESCRIPTION
I tried to use the backreference in regex without success (to make sure the opening quote is the same as the closing one). Anyway, it should not cause problems because we are expecting URL or IDs (so no inner quote).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5861