### PR TITLE
Translate media shortcode content as a URL

### DIFF
--- a/src/st/strategy/shortcode/class-wpml-pb-config-import-shortcode.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-config-import-shortcode.php
@@ -94,15 +94,16 @@ class WPML_PB_Config_Import_Shortcode {
 
 	/** @param array $config_data */
 	private function update_media_shortcodes_config( $config_data ) {
-		$old_shortcode_data = $this->get_media_settings();
-		$shortcode_data     = array();
+		$old_shortcodes_data = $this->get_media_settings();
+		$shortcodes_data     = array();
 
 		if ( isset ( $config_data['wpml-config']['shortcodes']['shortcode'] ) ) {
 
 			foreach ( $config_data['wpml-config']['shortcodes']['shortcode'] as $data ) {
-				$attributes = array();
+				$shortcode_data = array();
 
 				if ( isset( $data['media-attributes']['media-attribute'] ) ) {
+					$attributes       = array();
 					$single_attribute = false;
 
 					foreach ( $data['media-attributes']['media-attribute'] as $attribute ) {
@@ -132,17 +133,25 @@ class WPML_PB_Config_Import_Shortcode {
 					if ( $single_attribute ) {
 						$attributes[ $attribute_value ] = array( 'type' => $attribute_type );
 					}
+
+					$shortcode_data['attributes'] = $attributes;
 				}
 
-				$shortcode_data[] = array(
-					'tag'        => array( 'name' => $data['tag']['value'] ),
-					'attributes' => $attributes,
-				);
+				if ( isset( $data['tag']['attr']['content-type'] )
+				     && 'media-url' === $data['tag']['attr']['content-type']
+				) {
+					$shortcode_data['content'] = array( 'type' => 'url' );
+				}
+
+				if ( $shortcode_data ) {
+					$shortcode_data['tag'] = array( 'name' => $data['tag']['value'] );
+					$shortcodes_data[]     = $shortcode_data;
+				}
 			}
 		}
 
-		if ( $shortcode_data != $old_shortcode_data ) {
-			update_option( self::PB_MEDIA_SHORTCODE_SETTING, $shortcode_data, true );
+		if ( $shortcodes_data != $old_shortcodes_data ) {
+			update_option( self::PB_MEDIA_SHORTCODE_SETTING, $shortcodes_data, true );
 		}
 	}
 

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -38,6 +38,8 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 	[/et_pb_video_slider]
 	[et_pb_video image_src="' . $original_url_1 . '" some_image_src="Should not be translated" background_image="' . $original_url_2 . '" /]
 	[shortcode_with_single_quotes gallery_ids=\'' . $original_id_1 . '\' /]
+	[shortcode_with_url_content foo="bar"]' . $original_url_1 . '[/shortcode_with_url_content]
+	[shortcode_with_url_content]' . $original_url_2 . '[/shortcode_with_url_content]
 [/et_pb_column][/et_pb_row][/et_pb_section]
 ';
 
@@ -57,6 +59,8 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 	[/et_pb_video_slider]
 	[et_pb_video image_src="' . $translated_url_1 . '" some_image_src="Should not be translated" background_image="' . $translated_url_2 . '" /]
 	[shortcode_with_single_quotes gallery_ids=\'' . $translated_id_1 . '\' /]
+	[shortcode_with_url_content foo="bar"]' . $translated_url_1 . '[/shortcode_with_url_content]
+	[shortcode_with_url_content]' . $translated_url_2 . '[/shortcode_with_url_content]
 [/et_pb_column][/et_pb_row][/et_pb_section]
 ';
 
@@ -84,6 +88,10 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 				'attributes' => array(
 					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
 				),
+			),
+			array(
+				'tag'     => array( 'name' => 'shortcode_with_url_content' ),
+				'content' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
 			),
 			// Missing tag, should not alter content
 			array(

--- a/tests/phpunit/tests/st/test-wpml-pb-config-import.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-config-import.php
@@ -163,7 +163,7 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 
 	public function dp_update_media_shortcodes_config() {
 		return array(
-			'tag with 1 attributes' => array(
+			'tag with 1 attribute' => array(
 				array(
 					array(
 						'tag'        => array( 'value' => 'tag1' ),
@@ -205,6 +205,46 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 						),
 					),
 				),
+			),
+			'tag with 1 attribute and media content' => array(
+				array(
+					array(
+						'tag'        => array(
+							'value' => 'tag1',
+							'attr'  => array( 'content-type' => 'media-url' ),
+						),
+						'media-attributes' => array(
+							'media-attribute' => array(
+								'value' => 'attribute1',
+								'attr' => array( 'type' => 'url' ),
+							),
+						),
+					),
+				),
+				array(
+					array(
+						'tag'        => array( 'name' => 'tag1' ),
+						'attributes' => array(
+							'attribute1' => array( 'type' => 'url' ),
+						),
+						'content'    => array( 'type' => 'url' ),
+					),
+				),
+			),
+			'tags with no media' => array(
+				array(
+					array(
+						'tag'        => array(
+							'value' => 'tag1',
+							'attr'  => array( 'content-type' => 'not-related-to-media' ),
+						),
+						'media-attributes' => array(),
+					),
+					array(
+						'tag' => array( 'value' => 'tag1' ),
+					),
+				),
+				array(),
 			),
 		);
 	}


### PR DESCRIPTION
- Extend configuration from the config file.
- Convert the URL in shortcode content.

Here's an example of the shortcode:

```php
[fusion_imageframe image_id="7"]http://wpml.local/wp-content/uploads/2018/08/Categorie-Chien-Nourriture-300x189.jpg[/fusion_imageframe]
```

*Additional notes:*
- We can have shortcodes having some media attributes but the content can be a simple string to translate. So we must define when the content must be "media translated" in the configuration of the shortcode (and it cannot be a general rule).
- This is different than shortcode content containing a string with one or more `<img>` tags. This case is already handled with the filter in `WPML_Media_String_Images_Translation`.
- So far, we've just seen shortcode content with a media URL, but we can also imagine (even if it's ugly) that we could find media IDs there... So we should define which type of media content we should translate (URL or IDs).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5858

Please check how I extended the xsd file https://git.onthegosystems.com/wpml/sitepress-multilingual-cms/merge_requests/2073.