### PR TITLE
 Improve shortcodes definition structure in wpml-config.xml

### DIFF
--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
@@ -2,7 +2,6 @@
 
 class WPML_Page_Builders_Media_Shortcodes {
 
-	const ALL_TAGS = '\w+';
 	const TYPE_URL = 'media-url';
 	const TYPE_IDS = 'media-ids';
 
@@ -31,7 +30,7 @@ class WPML_Page_Builders_Media_Shortcodes {
 	public function translate( $content )  {
 		foreach ( $this->config as $shortcode ) {
 			$shortcode = $this->sanitize_shortcode( $shortcode );
-			$tag_name  = $this->get_tag_name( $shortcode );
+			$tag_name  = isset( $shortcode['tag']['name'] ) ? $shortcode['tag']['name'] : '';
 
 			if ( ! empty( $shortcode['attributes'] ) ) {
 				$content = $this->translate_attributes( $content, $tag_name, $shortcode['attributes'] );
@@ -59,16 +58,6 @@ class WPML_Page_Builders_Media_Shortcodes {
 	}
 
 	/**
-	 * @param array $shortcode
-	 *
-	 * @return string
-	 */
-	private function get_tag_name( $shortcode ) {
-		$tag_name = isset( $shortcode['tag']['name'] ) ? $shortcode['tag']['name'] : '';
-		return str_replace( '*', self::ALL_TAGS, $tag_name );
-	}
-
-	/**
 	 * @param string $content
 	 * @param string $tag
 	 * @param array  $attributes
@@ -77,7 +66,7 @@ class WPML_Page_Builders_Media_Shortcodes {
 	 */
 	private function translate_attributes( $content, $tag, array $attributes ) {
 		foreach ( $attributes as $attribute => $data ) {
-			$pattern = '/(\[(?:' . $tag . ')(?: [^\]]* | )' . $attribute . '=(?:"|\'))([^"\']*)/';
+			$pattern = '/(\[' . $tag . '(?: [^\]]* | )' . $attribute . '=(?:"|\'))([^"\']*)/';
 			$type    = isset( $data['type'] ) ? $data['type'] : '';
 			$content = preg_replace_callback( $pattern, array( $this, $this->get_callback( $type ) ), $content );
 		}

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
@@ -3,8 +3,8 @@
 class WPML_Page_Builders_Media_Shortcodes {
 
 	const ALL_TAGS = '\w+';
-	const TYPE_URL = 'url';
-	const TYPE_IDS = 'ids';
+	const TYPE_URL = 'media-url';
+	const TYPE_IDS = 'media-ids';
 
 	/** @var WPML_Page_Builders_Media_Translate $media_translate */
 	private $media_translate;

--- a/src/st/strategy/shortcode/class-wpml-pb-config-import-shortcode.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-config-import-shortcode.php
@@ -35,46 +35,24 @@ class WPML_PB_Config_Import_Shortcode {
 
 				$attributes = array();
 				if ( isset( $data['attributes']['attribute'] ) ) {
-					$single_attribute = false;
+
+					$data['attributes']['attribute'] = $this->convert_single_attribute_to_multiple_format( $data['attributes']['attribute'] );
+
 					foreach ( $data['attributes']['attribute'] as $attribute ) {
 
 						if ( $this->is_media_attribute( $attribute ) ) {
 							continue;
 						}
 
-						if ( is_string( $attribute ) ) {
-							$single_attribute   = true;
-							$attribute_value    = $attribute;
-							$attribute_encoding = '';
-							$attribute_type     = '';
-						} else if ( isset( $attribute['value'] ) ) {
-							$attribute_value = $attribute['value'];
+						if ( ! empty( $attribute['value'] ) ) {
+							$attribute_encoding = isset( $attribute['attr']['encoding'] ) ? $attribute['attr']['encoding'] : '';
+							$attribute_type     = isset( $attribute['attr']['type'] ) ? $attribute['attr']['type'] : '';
+							$attributes[]       = array(
+								'value'    => $attribute['value'],
+								'encoding' => $attribute_encoding,
+								'type'     => $attribute_type,
+							);
 						}
-						if ( $attribute_value ) {
-							if ( $single_attribute ) {
-								if ( isset( $attribute['encoding'] ) ) {
-									$attribute_encoding = $attribute['encoding'];
-								}
-								if ( isset( $attribute['type'] ) ) {
-									$attribute_type = $attribute['type'];
-								}
-							} else {
-								$attribute_encoding = isset( $attribute['attr']['encoding'] ) ? $attribute['attr']['encoding'] : '';
-								$attribute_type     = isset( $attribute['attr']['type'] ) ? $attribute['attr']['type'] : '';
-								$attributes[]       = array(
-									'value'    => $attribute_value,
-									'encoding' => $attribute_encoding,
-									'type'     => $attribute_type,
-								);
-							}
-						}
-					}
-					if ( $single_attribute ) {
-						$attributes[] = array(
-							'value'    => $attribute_value,
-							'encoding' => $attribute_encoding,
-							'type'     => $attribute_type,
-						);
 					}
 				}
 
@@ -146,7 +124,7 @@ class WPML_PB_Config_Import_Shortcode {
 		}
 	}
 
-	private function is_media_attribute( $attribute ) {
+	private function is_media_attribute( array $attribute ) {
 		$media_attribute_types = array(
 			WPML_Page_Builders_Media_Shortcodes::TYPE_URL,
 			WPML_Page_Builders_Media_Shortcodes::TYPE_IDS,

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -66,15 +66,28 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 
 		$config = array(
 			array(
-				'tag'        => array( 'name' => '*' ),
+				'tag'        => array( 'name' => 'et_pb_cta' ),
 				'attributes' => array(
 					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
 				),
 			),
 			array(
-				'tag'        => array( 'name' => 'et_pb_video_slider_item|et_pb_video' ),
+				'tag'        => array( 'name' => 'et_pb_audio' ),
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_video_slider_item' ),
 				'attributes' => array(
 					'image_src' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_video' ),
+				'attributes' => array(
+					'image_src' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
 				),
 			),
 			array(

--- a/tests/phpunit/tests/st/test-wpml-pb-config-import.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-config-import.php
@@ -114,9 +114,38 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 					'attributes' => array(),
 				),
 			),
-			'tag with media only'  => array(
+			'tag only with ignore content'  => array(
 				array(
-					'tag'        => array( 'value' => 'tag1', 'attr' => array( 'media-only' => '1' ) ),
+					'tag'        => array( 'value' => 'tag1', 'attr' => array( 'ignore-content' => '1' ) ),
+				),
+				array(),
+			),
+			'tag with ignore content and 1 media attribute'  => array(
+				array(
+					'tag'        => array( 'value' => 'tag1', 'attr' => array( 'ignore-content' => '1' ) ),
+					'attributes' => array(
+						'attribute' => array(
+							'value' => 'attribute4',
+							'attr'  => array( 'type' => 'media-url' ),
+						)
+					),
+				),
+				array(),
+			),
+			'tag with ignore content and 2 media attributes'  => array(
+				array(
+					'tag'        => array( 'value' => 'tag1', 'attr' => array( 'ignore-content' => '1' ) ),
+					'attributes' => array(
+						'attribute' => array(
+							array(
+								'value' => 'attribute4',
+								'attr'  => array( 'type' => 'media-url' ),
+							),array(
+								'value' => 'attribute5',
+								'attr'  => array( 'type' => 'media-ids' ),
+							)
+						)
+					),
 				),
 				array(),
 			),
@@ -167,10 +196,10 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 				array(
 					array(
 						'tag'        => array( 'value' => 'tag1' ),
-						'media-attributes' => array(
-							'media-attribute' => array(
+						'attributes' => array(
+							'attribute' => array(
 								'value' => 'attribute1',
-								'attr' => array( 'type' => 'url' ),
+								'attr'  => array( 'type' => 'media-url' ),
 							),
 						),
 					),
@@ -179,7 +208,7 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 					array(
 						'tag'        => array( 'name' => 'tag1' ),
 						'attributes' => array(
-							'attribute1' => array( 'type' => 'url' ),
+							'attribute1' => array( 'type' => 'media-url' ),
 						),
 					),
 				),
@@ -188,10 +217,10 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 				array(
 					array(
 						'tag'        => array( 'value' => 'tag1' ),
-						'media-attributes' => array(
-							'media-attribute' => array(
-								array( 'value' => 'attribute1', 'attr' => array( 'type' => 'url' ) ),
-								array( 'value' => 'attribute2', 'attr' => array( 'type' => 'ids' ) ),
+						'attributes' => array(
+							'attribute' => array(
+								array( 'value' => 'attribute1', 'attr' => array( 'type' => 'media-url' ) ),
+								array( 'value' => 'attribute2', 'attr' => array( 'type' => 'media-ids' ) ),
 							),
 						),
 					),
@@ -200,8 +229,8 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 					array(
 						'tag'        => array( 'name' => 'tag1' ),
 						'attributes' => array(
-							'attribute1' => array( 'type' => 'url' ),
-							'attribute2' => array( 'type' => 'ids' ),
+							'attribute1' => array( 'type' => 'media-url' ),
+							'attribute2' => array( 'type' => 'media-ids' ),
 						),
 					),
 				),
@@ -211,12 +240,12 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 					array(
 						'tag'        => array(
 							'value' => 'tag1',
-							'attr'  => array( 'content-type' => 'media-url' ),
+							'attr'  => array( 'type' => 'media-url' ),
 						),
-						'media-attributes' => array(
-							'media-attribute' => array(
+						'attributes' => array(
+							'attribute' => array(
 								'value' => 'attribute1',
-								'attr' => array( 'type' => 'url' ),
+								'attr' => array( 'type' => 'media-url' ),
 							),
 						),
 					),
@@ -225,9 +254,9 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 					array(
 						'tag'        => array( 'name' => 'tag1' ),
 						'attributes' => array(
-							'attribute1' => array( 'type' => 'url' ),
+							'attribute1' => array( 'type' => 'media-url' ),
 						),
-						'content'    => array( 'type' => 'url' ),
+						'content'    => array( 'type' => 'media-url' ),
 					),
 				),
 			),
@@ -236,9 +265,9 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 					array(
 						'tag'        => array(
 							'value' => 'tag1',
-							'attr'  => array( 'content-type' => 'not-related-to-media' ),
+							'attr'  => array( 'type' => 'not-related-to-media' ),
 						),
-						'media-attributes' => array(),
+						'attributes' => array(),
 					),
 					array(
 						'tag' => array( 'value' => 'tag1' ),
@@ -258,7 +287,7 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 			array(
 				'tag'        => array( 'name' => 'tag1' ),
 				'attributes' => array(
-					'attribute1' => array( 'type' => 'url' ),
+					'attribute1' => array( 'type' => 'media-url' ),
 				),
 			),
 		);
@@ -269,10 +298,10 @@ class Test_WPML_PB_Config_Import extends \OTGS\PHPUnit\Tools\TestCase {
 					'shortcode' => array(
 						array(
 							'tag'        => array( 'value' => 'tag1' ),
-							'media-attributes' => array(
-								'media-attribute' => array(
+							'attributes' => array(
+								'attribute' => array(
 									'value' => 'attribute1',
-									'attr' => array( 'type' => 'url' ),
+									'attr' => array( 'type' => 'media-url' ),
 								),
 							),
 						),


### PR DESCRIPTION
The improve structure is as below:

```xml
<!-- Existing shortcodes definition (for backward compatibility)-->
<shortcode>
    <!-- Translate string in the content -->
    <!-- Only in strings settings -->
    <tag>et_pb_foo</tag>
</shortcode>
<shortcode>
    <!-- Translate link attribute as a string, translate string in the content -->
    <!-- Only in strings settings -->
    <tag>et_pb_bar</tag>
    <attributes>
        <attribute type="link">link</media-attribute>
    </attributes>
</shortcode>

<!-- New shortcodes definition -->
<shortcode>
    <!-- Convert media IDs in `gallery_ids` attribute, and ignore the shortcode content -->
    <!-- Only in media settings -->
    <tag ignore-content="1">et_pb_gallery</tag>
    <attributes>
        <attribute type="media-ids">gallery_ids</media-attribute>
    <attributes>
</shortcode>
<shortcode>
    <!-- Convert the media URL in the content, translate some string attributes, convert media IDs in `src` attribute -->
    <!-- Both in strings and media settings -->
    <tag type="media-url">et_pb_image</tag>
    <attributes>
        <attribute>title_text</attribute>
        <attribute>alt</attribute>
        <attribute type="link">link</attribute>
        <attribute type="media-ids">src</attribute>
    </attributes>
</shortcode>
```

I added as second commit to simplify the code in the strings settings. Indeed we were having 2 separate logics for single and multiple attributes which was making the code hard to follow and debug.

This goes with some changes in the XSD file: https://git.onthegosystems.com/wpml/sitepress-multilingual-cms/merge_requests/2081.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5867