### PR TITLE
Add media usage for non-translatable blocks

### DIFF
--- a/src/media/class-wpml-page-builders-media-translate.php
+++ b/src/media/class-wpml-page-builders-media-translate.php
@@ -14,6 +14,9 @@ class WPML_Page_Builders_Media_Translate {
 	/** @var WP_Post[] $translated_posts */
 	protected $translated_posts = array();
 
+	/** @var array $translated_ids */
+	private $translated_ids = array();
+
 	public function __construct(
 		WPML_Translation_Element_Factory $element_factory,
 		WPML_Media_Image_Translate $image_translate
@@ -33,11 +36,18 @@ class WPML_Page_Builders_Media_Translate {
 		$key = $url . $lang . $source_lang;
 
 		if ( ! array_key_exists( $key, $this->translated_urls ) ) {
-			$translated_url = $this->image_translate->get_translated_image_by_url( $url, $source_lang, $lang );
 			$this->translated_urls[ $key ] = $url;
 
-			if ( $translated_url ) {
-				$this->translated_urls[ $key ] = $translated_url;
+			$attachment_id = $this->image_translate->get_attachment_id_by_url( $url, $source_lang );
+
+			if ( $attachment_id ) {
+				$this->add_translated_id( $attachment_id );
+				$translated_url = $this->image_translate->get_translated_image_by_url( $url, $source_lang, $lang );
+				$this->translated_urls[ $key ] = $url;
+
+				if ( $translated_url ) {
+					$this->translated_urls[ $key ] = $translated_url;
+				}
 			}
 		}
 
@@ -51,6 +61,7 @@ class WPML_Page_Builders_Media_Translate {
 	 * @return int
 	 */
 	public function translate_id( $id, $lang ) {
+		$this->add_translated_id( $id );
 		$translated_attachment = $this->get_translated_attachment( $id, $lang );
 
 		if ( isset( $translated_attachment->ID ) ) {
@@ -81,5 +92,21 @@ class WPML_Page_Builders_Media_Translate {
 
 
 		return $this->translated_posts[ $key ];
+	}
+
+	/** @param int */
+	private function add_translated_id( $id ) {
+		if ( ! in_array( $id, $this->translated_ids, true ) ) {
+			$this->translated_ids[] = $id;
+		}
+	}
+
+	public function reset_translated_ids() {
+		$this->translated_ids = array();
+	}
+
+	/** @return array */
+	public function get_translated_ids() {
+		return $this->translated_ids;
 	}
 }

--- a/src/media/class-wpml-page-builders-media-usage.php
+++ b/src/media/class-wpml-page-builders-media-usage.php
@@ -1,0 +1,29 @@
+<?php
+
+class WPML_Page_Builders_Media_Usage {
+
+	/** @var WPML_Page_Builders_Media_Translate $media_translate */
+	private $media_translate;
+
+	/** @var WPML_Media_Usage_Factory $media_usage_factory */
+	private $media_usage_factory;
+
+	public function __construct(
+		WPML_Page_Builders_Media_Translate $media_translate,
+		WPML_Media_Usage_Factory $media_usage_factory
+	) {
+		$this->media_translate = $media_translate;
+		$this->media_usage_factory = $media_usage_factory;
+	}
+
+	/** @param int $post_id */
+	public function update( $post_id ) {
+		$media_ids = $this->media_translate->get_translated_ids();
+
+		foreach ( $media_ids as $media_id ) {
+			$this->media_usage_factory->create( $media_id )->add_post( $post_id );
+		}
+
+		$this->media_translate->reset_translated_ids();
+	}
+}

--- a/src/media/class-wpml-page-builders-update-media.php
+++ b/src/media/class-wpml-page-builders-update-media.php
@@ -11,14 +11,19 @@ class WPML_Page_Builders_Update_Media implements IWPML_PB_Media_Update {
 	/** @var IWPML_PB_Media_Nodes_Iterator $node_iterator */
 	protected $node_iterator;
 
+	/** @var WPML_Page_Builders_Media_Usage $media_usage */
+	protected $media_usage;
+
 	public function __construct(
 		WPML_Page_Builders_Update $pb_update,
 		WPML_Translation_Element_Factory $element_factory,
-		IWPML_PB_Media_Nodes_Iterator $node_iterator
+		IWPML_PB_Media_Nodes_Iterator $node_iterator,
+		WPML_Page_Builders_Media_Usage $media_usage = null
 	) {
 		$this->pb_update       = $pb_update;
 		$this->element_factory = $element_factory;
 		$this->node_iterator   = $node_iterator;
+		$this->media_usage     = $media_usage;
 	}
 
 	/**
@@ -37,6 +42,11 @@ class WPML_Page_Builders_Update_Media implements IWPML_PB_Media_Update {
 		$original_post_id = $source_element->get_id();
 		$converted_data   = $this->pb_update->get_converted_data( $post->ID );
 		$converted_data   = $this->node_iterator->translate( $converted_data, $lang, $source_lang );
+
 		$this->pb_update->save( $post->ID, $original_post_id, $converted_data );
+
+		if ( $this->media_usage ) {
+			$this->media_usage->update( $original_post_id );
+		}
 	}
 }

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-translate.php
@@ -10,11 +10,13 @@ class Test_WPML_Page_Builders_Media_Translate extends \OTGS\PHPUnit\Tools\TestCa
 	 */
 	public function it_should_translate_image_url_and_cache_it() {
 		$url            = 'http://example/dog.jpg';
+		$image_id       = mt_rand( 1, 100 );
 		$translated_url = 'http://exemple/chien.jpg';
 		$lang           = 'fr';
 		$source_lang    = 'en';
 
 		$image_translate = $this->get_image_translate();
+		$image_translate->method( 'get_attachment_id_by_url' )->with( $url )->willReturn( $image_id );
 		$image_translate->expects( $this->once() )
 			->method( 'get_translated_image_by_url' )
 			->with( $url, $source_lang, $lang )
@@ -28,13 +30,36 @@ class Test_WPML_Page_Builders_Media_Translate extends \OTGS\PHPUnit\Tools\TestCa
 
 	/**
 	 * @test
+	 * @group wpmlcore-5834
 	 */
-	public function it_should_return_the_same_url_if_no_translation_is_found() {
+	public function it_should_return_the_same_url_if_no_attachment_id_is_found() {
 		$url         = 'http://example/dog.jpg';
+		$image_id    = 0;
 		$lang        = 'fr';
 		$source_lang = 'en';
 
 		$image_translate = $this->get_image_translate();
+		$image_translate->expects( $this->once() )
+		                ->method( 'get_attachment_id_by_url' )->with( $url )->willReturn( $image_id );
+		$image_translate->expects( $this->never() )->method( 'get_translated_image_by_url' );
+
+		$subject = $this->get_subject( null, $image_translate );
+
+		$this->assertSame( $url, $subject->translate_image_url( $url, $lang, $source_lang ) );
+		$this->assertSame( $url, $subject->translate_image_url( $url, $lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_the_same_url_if_no_translation_is_found() {
+		$url         = 'http://example/dog.jpg';
+		$image_id    = mt_rand( 1, 100 );
+		$lang        = 'fr';
+		$source_lang = 'en';
+
+		$image_translate = $this->get_image_translate();
+		$image_translate->method( 'get_attachment_id_by_url' )->with( $url )->willReturn( $image_id );
 		$image_translate->expects( $this->once() )
 		                ->method( 'get_translated_image_by_url' )
 		                ->with( $url, $source_lang, $lang )
@@ -89,6 +114,53 @@ class Test_WPML_Page_Builders_Media_Translate extends \OTGS\PHPUnit\Tools\TestCa
 		$this->assertSame( $id, $subject->translate_id( $id, $lang ) );
 	}
 
+	/**
+	 * @test
+	 * @group wpmlcore-5834
+	 */
+	public function it_should_get_and_reset_translated_media_ids() {
+		$url               = 'http://example/dog.jpg';
+		$image_id          = mt_rand( 1, 100 );
+		$translated_url    = 'http://exemple/chien.jpg';
+		$image_id_2        = mt_rand( 101, 200 );
+		$translated_id_2   = mt_rand( 1101, 1200 );
+		$lang              = 'fr';
+		$source_lang       = 'en';
+
+		$image_translate = $this->get_image_translate();
+		$image_translate->method( 'get_attachment_id_by_url' )->with( $url )->willReturn( $image_id );
+		$image_translate->method( 'get_translated_image_by_url' )
+		                ->with( $url, $source_lang, $lang )
+		                ->willReturn( $translated_url );
+
+		$translated_attachment = $this->get_wp_object( $translated_id_2 );
+
+		$translated_element = $this->get_element();
+		$translated_element->method( 'get_wp_object' )->willReturn( $translated_attachment );
+
+		$element = $this->get_element();
+		$element->method( 'get_translation' )->with( $lang )->willReturn( $translated_element );
+
+		$element_factory = $this->get_element_factory();
+		$element_factory->method( 'create_post' )->with( $image_id_2 )->willReturn( $element );
+
+		$subject = $this->get_subject( $element_factory, $image_translate );
+
+		$this->assertEquals( array(), $subject->get_translated_ids() );
+
+		$subject->translate_image_url( $url, $lang, $source_lang );
+		$subject->translate_id( $image_id_2, $lang );
+
+		$this->assertEquals(
+			array( $image_id, $image_id_2 ),
+			$subject->get_translated_ids()
+		);
+
+		$subject->reset_translated_ids();
+
+		$this->assertEquals( array(), $subject->get_translated_ids() );
+	}
+
 	private function get_subject( $factory = null, $image_translate = null ) {
 		$factory         = $factory ? $factory : $this->get_element_factory();
 		$image_translate = $image_translate ? $image_translate : $this->get_image_translate();
@@ -115,7 +187,7 @@ class Test_WPML_Page_Builders_Media_Translate extends \OTGS\PHPUnit\Tools\TestCa
 
 	private function get_image_translate() {
 		return $this->getMockBuilder( 'WPML_Media_Image_Translate' )
-			->setMethods( array( 'get_translated_image_by_url' ) )
+			->setMethods( array( 'get_translated_image_by_url', 'get_attachment_id_by_url' ) )
 			->disableOriginalConstructor()->getMock();
 	}
 }

--- a/tests/phpunit/tests/media/test-wpml-page-builders-media-usage.php
+++ b/tests/phpunit/tests/media/test-wpml-page-builders-media-usage.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Page_Builders_Media_Usage extends \OTGS\PHPUnit\Tools\TestCase {
+
+	/**
+	 * @test
+	 * @group wpmlcore-5834
+	 */
+	public function it_should_update() {
+		$post_id  = mt_rand( 1, 100 );
+		$media_id = mt_rand( 101, 200 );
+
+		$media_translate = $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+			->setMethods( array( 'get_translated_ids', 'reset_translated_ids' ) )
+			->disableOriginalConstructor()->getMock();
+		$media_translate->method( 'get_translated_ids' )->willReturn( array( $media_id ) );
+		$media_translate->expects( $this->once() )->method( 'reset_translated_ids' );
+
+		$media_usage = $this->getMockBuilder( 'WPML_Media_Usage_Factory' )
+			->setMethods( array( 'add_post' ) )->disableOriginalConstructor()->getMock();
+		$media_usage->expects( $this->once() )->method( 'add_post' )->with( $post_id );
+
+		$media_usage_factory = $this->getMockBuilder( 'WPML_Media_Usage_Factory' )
+			->setMethods( array( 'create' ) )->disableOriginalConstructor()->getMock();
+		$media_usage_factory->method( 'create' )->with( $media_id )->willReturn( $media_usage );
+
+		$subject = new WPML_Page_Builders_Media_Usage( $media_translate, $media_usage_factory );
+
+		$subject->update( $post_id );
+	}
+}


### PR DESCRIPTION
This is the first part and now it will have to be implemented by the
metadata page builders that uses `WPML_Page_Builders_Update_Media`.

Goes with https://git.onthegosystems.com/wpml/wpml-media-translation/merge_requests/263.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5834