### PR TITLE
Escape false backward references in replacement string

### DIFF
--- a/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
@@ -91,18 +91,32 @@ class WPML_PB_Update_Shortcodes_In_Content {
 				$this->new_content = str_replace( $block, $new_block, $this->new_content );
 			} else {
 				if ( $is_attribute && $attr ) {
-					$pattern   = '/' . $attr . '=(["\'])' . preg_quote( $original, '/' ) . '(["\'])/';
-					$new_block = preg_replace( $pattern, $attr . '=${1}' . $translation . '${2}', $block );
+					$pattern     = '/' . $attr . '=(["\'])' . preg_quote( $original, '/' ) . '(["\'])/';
+					$replacement = $attr . '=${1}' . $this->escape_backward_reference_on_replacement_string( $translation ) . '${2}';
 				} else {
-					$pattern   = '/(]\s*)' . preg_quote( trim( $original ), '/' ) . '(\s*\[)/';
-					$new_block = preg_replace( $pattern, '${1}' . trim( $translation ) . '${2}', $block );
+					$pattern     = '/(]\s*)' . preg_quote( trim( $original ), '/' ) . '(\s*\[)/';
+					$replacement = '${1}' . $this->escape_backward_reference_on_replacement_string( trim( $translation ) ) . '${2}';
 				}
 
-				$this->new_content = preg_replace( '/'. preg_quote( $block, '/' ) . '/', $new_block, $this->new_content, 1 );
+				$new_block         = preg_replace( $pattern, $replacement, $block );
+				$replacement       = $this->escape_backward_reference_on_replacement_string( $new_block );
+				$this->new_content = preg_replace( '/' . preg_quote( $block, '/' ) . '/', $replacement, $this->new_content, 1 );
 			}
 		}
 
 		return $new_block;
+	}
+
+	/**
+	 * We need to escape backward references that could be included in the replacement text
+	 * e.g. '$1999.each' => '$19' is considered as a backward reference
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
+	private function escape_backward_reference_on_replacement_string( $string ) {
+		return preg_replace( '/\$([\d]{1,2})/', '\\\$' . '${1}', $string );
 	}
 
 	/**

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-update-shortcodes-in-content.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-update-shortcodes-in-content.php
@@ -266,6 +266,34 @@ class Test_WPML_PB_Update_Shortcodes_In_Content extends WPML_PB_TestCase {
 					),
 				),
 			),
+			'Backward reference in translation - https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5291' => array(
+				'[et_pb_tab title="$25.each"]$1999.each[/et_pb_tab]',
+				'[et_pb_tab title="$4.each"]$123.each[/et_pb_tab]',
+				array( 'et_pb_tab' ),
+				array( 'et_pb_tab' => array( 'title' ) ),
+				array(
+					array(
+						'block'      => '[et_pb_tab title="$25.each"]$1999.each[/et_pb_tab]',
+						'tag'        => 'et_pb_tab',
+						'attributes' => ' title="$25.each"',
+						'content'    => '$1999.each',
+					),
+				),
+				array(
+					md5( '$25.each' ) => array(
+						'fr' => array(
+							'status' => ICL_TM_COMPLETE,
+							'value'  => '$4.each',
+						),
+					),
+					md5( '$1999.each' ) => array(
+						'fr' => array(
+							'status' => ICL_TM_COMPLETE,
+							'value'  => '$123.each',
+						),
+					),
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
Note that we cannot use `preg_quote` on the replacement string because we would have other special chars (e.g. `.`) quoted in the final string.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5291