### PR TITLE
Add media usage of non-translatable blocks of shortcodes page builders

### DIFF
--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update-factory.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update-factory.php
@@ -5,34 +5,51 @@ class WPML_Page_Builders_Media_Shortcodes_Update_Factory implements IWPML_PB_Med
 	/** @var WPML_PB_Config_Import_Shortcode WPML_PB_Config_Import_Shortcode */
 	private $page_builder_config_import;
 
+	/** @var WPML_Translation_Element_Factory $element_factory */
+	private $element_factory;
+
+	/** @var WPML_Page_Builders_Media_Translate $media_translate */
+	private $media_translate;
+
 	public function __construct( WPML_PB_Config_Import_Shortcode $page_builder_config_import ) {
 		$this->page_builder_config_import = $page_builder_config_import;
 	}
 
 	public function create() {
-		global $sitepress;
-
-		$element_factory  = new WPML_Translation_Element_Factory( $sitepress );
-		$media_shortcodes = $this->get_media_shortcodes( $element_factory, $sitepress );
-
-		return new WPML_Page_Builders_Media_Shortcodes_Update( $element_factory, $media_shortcodes );
-	}
-
-	/**
-	 * @param $element_factory
-	 * @param $sitepress
-	 *
-	 * @return WPML_Page_Builders_Media_Shortcodes
-	 */
-	private function get_media_shortcodes( $element_factory, $sitepress ) {
-		$media_translate = new WPML_Page_Builders_Media_Translate(
-			$element_factory,
-			new WPML_Media_Image_Translate( $sitepress, new WPML_Media_Attachment_By_URL_Factory() )
-		);
-
-		return new WPML_Page_Builders_Media_Shortcodes(
-			$media_translate,
+		$media_shortcodes = new WPML_Page_Builders_Media_Shortcodes(
+			$this->get_media_translate(),
 			$this->page_builder_config_import->get_media_settings()
 		);
+
+		return new WPML_Page_Builders_Media_Shortcodes_Update(
+			$this->get_element_factory(),
+			$media_shortcodes,
+			new WPML_Page_Builders_Media_Usage( $this->get_media_translate(), new WPML_Media_Usage_Factory() )
+		);
+	}
+
+	/** @return WPML_Translation_Element_Factory */
+	private function get_element_factory() {
+		global $sitepress;
+
+		if ( ! $this->element_factory ) {
+			$this->element_factory = new WPML_Translation_Element_Factory( $sitepress );
+		}
+
+		return $this->element_factory;
+	}
+
+	/** @return WPML_Page_Builders_Media_Translate */
+	private function get_media_translate() {
+		global $sitepress;
+
+		if ( ! $this->media_translate ) {
+			$this->media_translate = new WPML_Page_Builders_Media_Translate(
+				$this->get_element_factory(),
+				new WPML_Media_Image_Translate( $sitepress, new WPML_Media_Attachment_By_URL_Factory() )
+			);
+		}
+
+		return $this->media_translate;
 	}
 }

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update.php
@@ -8,12 +8,17 @@ class WPML_Page_Builders_Media_Shortcodes_Update implements IWPML_PB_Media_Updat
 	/** @var WPML_Page_Builders_Media_Shortcodes $media_shortcodes*/
 	private $media_shortcodes;
 
+	/** @var WPML_Page_Builders_Media_Usage $media_usage */
+	private $media_usage;
+
 	public function __construct(
 		WPML_Translation_Element_Factory $element_factory,
-		WPML_Page_Builders_Media_Shortcodes $media_shortcodes
+		WPML_Page_Builders_Media_Shortcodes $media_shortcodes,
+		WPML_Page_Builders_Media_Usage $media_usage
 	) {
 		$this->element_factory  = $element_factory;
 		$this->media_shortcodes = $media_shortcodes;
+		$this->media_usage      = $media_usage;
 	}
 
 	/**
@@ -33,6 +38,8 @@ class WPML_Page_Builders_Media_Shortcodes_Update implements IWPML_PB_Media_Updat
 		$post->post_content = $this->media_shortcodes->set_target_lang( $element->get_language_code() )
 		                                             ->set_source_lang( $element->get_source_language_code() )
 		                                             ->translate( $post->post_content );
+
+		$this->media_usage->update( $element->get_source_element()->get_id() );
 
 		wp_update_post( $post );
 	}

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update-factory.php
@@ -10,6 +10,7 @@ class Test_WPML_Page_Builders_Media_Shortcodes_Update_Factory extends \OTGS\PHPU
 		$this->getMockBuilder( 'WPML_Translation_Element_Factory' )->disableOriginalConstructor()->getMock();
 		$this->getMockBuilder( 'WPML_Media_Attachment_By_URL_Factory' )->disableOriginalConstructor()->getMock();
 		$this->getMockBuilder( 'WPML_Media_Image_Translate' )->disableOriginalConstructor()->getMock();
+		$this->getMockBuilder( 'WPML_Media_Usage_Factory' )->disableOriginalConstructor()->getMock();
 	}
 
 	/**


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5834

Note: This is already implemented in the same way for metadata page builders (https://github.com/OnTheGoSystems/wpml-page-builders/commit/6fdd8ca811250e663186cf0b8998c6f84a2028a7#diff-c6b5d5c2c50413da4633cc843e7faa55R49).