### PR TITLE
Implement action hook to resave a post translation

### DIFF
--- a/src/st/class-wpml-pb-factory.php
+++ b/src/st/class-wpml-pb-factory.php
@@ -69,4 +69,8 @@ class WPML_PB_Factory {
 	public function get_api_hooks_content_updater( IWPML_PB_Strategy $strategy ) {
 		return new WPML_PB_Update_API_Hooks_In_Content( $strategy );
 	}
+
+	public function get_package_strings_resave() {
+		return new WPML_PB_Package_Strings_Resave( new WPML_ST_String_Factory( $this->wpdb ) );
+	}
 }

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -58,6 +58,28 @@ class WPML_PB_Integration {
 		$this->rescan = $rescan;
 	}
 
+	public function resave_post_translation_in_shutdown( WPML_Post_Element $post_element ) {
+		if ( ! $post_element->get_source_element()
+			 || did_action( 'shutdown' )
+			 || array_key_exists( $post_element->get_id(), $this->save_post_queue )
+		) {
+			return;
+		}
+
+		$updated_packages = $this->factory->get_package_strings_resave()->from_element( $post_element );
+
+		foreach ( $this->strategies as $strategy ) {
+
+			foreach ( $updated_packages as $package ) {
+				$this->factory->get_string_translations( $strategy )
+					->add_package_to_update_list( $package, $post_element->get_language_code() );
+			}
+		}
+
+		$this->new_translations_recieved = true;
+		$this->queue_save_post_actions( $post_element->get_id(), $post_element->get_wp_object() );
+	}
+
 	/**
 	 * @param $post_id
 	 * @param $post
@@ -101,6 +123,7 @@ class WPML_PB_Integration {
 	public function add_hooks() {
 		add_action( 'pre_post_update', array( $this, 'migrate_location' ), 10, 2 );
 		add_action( 'save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
+		add_action( 'wpml_pb_resave_post_translation', array( $this, 'resave_post_translation_in_shutdown' ), 10, 1 );
 		add_action( 'icl_st_add_string_translation', array( $this, 'new_translation' ), 10, 1 );
 		add_action( 'shutdown', array( $this, 'do_shutdown_action' ) );
 		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'save_translations_to_post' ) );

--- a/src/st/class-wpml-pb-package-strings-resave.php
+++ b/src/st/class-wpml-pb-package-strings-resave.php
@@ -1,0 +1,62 @@
+<?php
+
+class WPML_PB_Package_Strings_Resave {
+
+	/** @var WPML_ST_String_Factory $string_factory */
+	private $string_factory;
+
+	public function __construct( WPML_ST_String_Factory $string_factory ) {
+		$this->string_factory = $string_factory;
+	}
+
+	/**
+	 * @param WPML_Post_Element $post_element
+	 *
+	 * @return WPML_Package[]
+	 */
+	public function from_element( WPML_Post_Element $post_element ) {
+		if ( ! $post_element->get_source_element() ) {
+			return array();
+		}
+
+		$target_lang      = $post_element->get_language_code();
+		$original_post_id = $post_element->get_source_element()->get_id();
+
+		/** @var WPML_Package[] $string_packages */
+		$string_packages =  apply_filters( 'wpml_st_get_post_string_packages', array(), $original_post_id );
+
+		foreach ( $string_packages as $string_package ) {
+
+			/** @var stdClass[] $strings */
+			$strings = $string_package->get_package_strings();
+
+			foreach ( $strings as $string ) {
+				$this->resave_string_translation( $string->id, $target_lang );
+			}
+		}
+
+		return $string_packages;
+	}
+
+	/**
+	 * @param int    $string_id
+	 * @param string $target_lang
+	 */
+	private function resave_string_translation( $string_id, $target_lang ) {
+		$string       = $this->string_factory->find_by_id( $string_id );
+		$translations = wp_list_filter( $string->get_translations(), array( 'language' => $target_lang ) );
+
+		if ( $translations ) {
+			$translation = reset( $translations );
+
+			$string->set_translation(
+				$target_lang,
+				$translation->value,
+				$translation->status,
+				$translation->translator_id,
+				$translation->translation_service,
+				$translation->batch_id
+			);
+		}
+	}
+}

--- a/src/st/class-wpml-pb-string-translation.php
+++ b/src/st/class-wpml-pb-string-translation.php
@@ -43,9 +43,9 @@ class WPML_PB_String_Translation {
 	private function get_package_for_translated_string( $translated_string_id ) {
 		$sql    = $this->wpdb->prepare(
 			"SELECT s.string_package_id, s.id, t.language
-			FROM {$this->wpdb->prefix}icl_strings s 
-			LEFT JOIN {$this->wpdb->prefix}icl_string_translations t 
-			ON s.id = t.string_id 
+			FROM {$this->wpdb->prefix}icl_strings s
+			LEFT JOIN {$this->wpdb->prefix}icl_string_translations t
+			ON s.id = t.string_id
 			WHERE t.id = %d", $translated_string_id );
 		$result = $this->wpdb->get_row( $sql );
 
@@ -56,7 +56,11 @@ class WPML_PB_String_Translation {
 		}
 	}
 
-	private function add_package_to_update_list( $package, $language ) {
+	/**
+	 * @param WPML_Package $package
+	 * @param string       $language
+	 */
+	public function add_package_to_update_list( WPML_Package $package, $language ) {
 		if ( ! isset( $this->packages_to_update[ $package->ID ] ) ) {
 			$this->packages_to_update[ $package->ID ] = array( 'package'   => $package,
 			                                                   'languages' => array( $language )

--- a/tests/phpunit/tests/st/test-wpml-pb-factory.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-factory.php
@@ -52,6 +52,17 @@ class Test_WPML_PB_Factory extends WPML_PB_TestCase {
 		$this->assertInstanceOf( 'WPML_Package', $package );
 	}
 
+	/**
+	 * @test
+	 * @group wpmlcore-5765
+	 */
+	public function test_get_package_strings_resave() {
+		$this->getMockBuilder( 'WPML_ST_String_Factory' )->disableOriginalConstructor()->getMock();
+		$factory = $this->get_factory_with_mocks();
+		$package = $factory->get_package_strings_resave();
+		$this->assertInstanceOf( 'WPML_PB_Package_Strings_Resave', $package );
+	}
+
 	private function get_factory_with_mocks() {
 		global $wpdb;
 

--- a/tests/phpunit/tests/st/test-wpml-pb-package-strings-resave.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-package-strings-resave.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * @group media
+ * @group wpmlcore-5765
+ */
+class Test_WPML_PB_Package_Strings_Resave extends \OTGS\PHPUnit\Tools\TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_resave_if_post_element_is_source() {
+		$post_element = $this->get_post_element();
+		$post_element->method( 'get_source_element' )->willReturn( null );
+
+		$factory = $this->get_string_factory();
+
+		$subject = $this->get_subject( $factory );
+
+		$this->assertEquals(
+			array(),
+			$subject->from_element( $post_element )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_resave() {
+		$source_id   = 49;
+		$target_lang = 'fr';
+		$string_id   = 1025;
+
+		$source_element = $this->get_post_element();
+		$source_element->method( 'get_id' )->willReturn( $source_id );
+
+		$post_element = $this->get_post_element();
+		$post_element->method( 'get_source_element' )->willReturn( $source_element );
+		$post_element->method( 'get_language_code' )->willReturn( $target_lang );
+
+		$raw_string = (object) array(
+			'id' => $string_id,
+		);
+
+		$package = $this->get_package();
+		$package->method( 'get_package_strings' )->willReturn( array( $raw_string ) );
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( array(), $source_id )->reply( array( $package ) );
+
+		$string_translation = (object) array(
+			'language'            => 'fr',
+			'value'               => 'La Traduction',
+			'status'              => '5',
+			'translator_id'       => '3',
+			'translation_service' => '12',
+			'batch_id'            => '49',
+		);
+
+		$string = $this->get_string();
+		$string->method( 'get_translations' )->willReturn( array( $string_translation ) );
+		$string->expects( $this->once() )->method( 'set_translation' )
+			->with(
+				$target_lang,
+				$string_translation->value,
+				$string_translation->status,
+				$string_translation->translator_id,
+				$string_translation->translation_service,
+				$string_translation->batch_id
+			);
+
+		$factory = $this->get_string_factory();
+		$factory->method( 'find_by_id' )->with( $string_id )->willReturn( $string );
+
+		\WP_Mock::userFunction( 'wp_list_filter', array(
+			'args'   => array( array( $string_translation ), array( 'language' => $target_lang ) ),
+			'return' => array( $string_translation )
+		));
+
+		$subject = $this->get_subject( $factory );
+
+		$this->assertEquals(
+			array( $package ),
+			$subject->from_element( $post_element )
+		);
+	}
+
+	private function get_subject( $string_factory ) {
+		return new WPML_PB_Package_Strings_Resave( $string_factory );
+	}
+
+	private function get_string_factory() {
+		return $this->getMockBuilder( 'WPML_ST_String_Factory' )
+			->setMethods( array( 'find_by_id' ) )
+			->disableArgumentCloning()->getMock();
+	}
+
+	private function get_string() {
+		return $this->getMockBuilder( 'WPML_ST_String' )
+			->setMethods( array( 'get_translations', 'set_translation' ) )
+			->disableArgumentCloning()->getMock();
+	}
+
+	private function get_string_translation( $lang ) {
+		return (object) array(
+			'language'            => $lang,
+			'value'               => rand_str(),
+			'status'              => rand_str(),
+			'translator_id'       => rand_str(),
+			'translation_service' => rand_str(),
+			'batch_id'            => rand_str(),
+		);
+	}
+
+	private function get_post_element() {
+		return $this->getMockBuilder( 'WPML_Post_Element' )
+	        ->setMethods( array( 'get_source_element', 'get_language_code', 'get_id' ) )
+	        ->disableArgumentCloning()->getMock();
+	}
+
+	private function get_package() {
+		return $this->getMockBuilder( 'WPML_Package' )
+	        ->setMethods( array( 'get_package_strings' ) )
+	        ->disableArgumentCloning()->getMock();
+	}
+}

--- a/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
@@ -8,15 +8,22 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	 * @dataProvider new_translations_data_provider
 	 */
 	public function test_new_translations( $post_id ) {
-		$translated_string_id = mt_rand();
-		$string_package_id    = mt_rand();
-		$language_1           = rand_str( 4 );
-		$language_2           = rand_str( 4 );
-		while ( $language_2 == $language_1 ) {
-			$language_2 = rand_str( 4 );
-		}
+		$translated_string_id = 1025;
+		$string_package_id    = 89;
+		$language_1           = 'de';
+		$language_2           = 'es';
 
-		list( $factory_mock, $strategy_mock ) = $this->get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2, $post_id );
+		list( $factory_mock, $strategy_mock, $package ) = $this->get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2, $post_id );
+
+		$factory_mock->expects( $this->exactly( 2 ) )
+		        ->method( 'get_wpml_package' )
+		        ->with( $this->equalTo( $string_package_id ) )
+		        ->willReturn( $package );
+
+		$strategy_mock->expects( $this->exactly( $post_id ? 3 : 0 ) )
+		         ->method( 'get_package_kind' )
+		         ->willReturn( $package->kind );
+
 		$wpdb_mock = $this->get_wpdb_mock( $string_package_id, $language_1, $language_2 );
 
 		$pb_string_translation = new WPML_PB_String_Translation( $wpdb_mock, $factory_mock, $strategy_mock );
@@ -25,14 +32,33 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		$pb_string_translation->save_translations_to_post();
 	}
 
+	/**
+	 * @test
+	 * @group wpmlcore-5765
+	 */
+	public function test_add_package_to_update_list() {
+		$translated_string_id = 1025;
+		$string_package_id    = 89;
+		$language_1           = 'de';
+		$language_2           = 'es';
+
+		list( $factory_mock, $strategy_mock, $package ) = $this->get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2 );
+		$wpdb_mock = $this->get_wpdb_mock( $string_package_id, $language_1, $language_2 );
+
+		$pb_string_translation = new WPML_PB_String_Translation( $wpdb_mock, $factory_mock, $strategy_mock );
+		$pb_string_translation->add_package_to_update_list( $package, $language_1 );
+		$pb_string_translation->add_package_to_update_list( $package, $language_2 );
+		$pb_string_translation->save_translations_to_post();
+	}
+
 	public function new_translations_data_provider() {
 		return array(
 			'package with post id'    => array( mt_rand( 1, 100 ) ),
-			'package with no post id' => array( 0),
+			'package with no post id' => array( 0 ),
 		);
 	}
 
-	private function get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2, $post_id ) {
+	private function get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2, $post_id = null ) {
 		$package_kind = rand_str( 32 );
 
 		$factory       = $this->getMockBuilder( 'WPML_PB_Factory' )
@@ -45,10 +71,6 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		                      ->getMock();
 		$package->kind = $package_kind;
 		$package->post_id = $post_id;
-		$factory->expects( $this->exactly( 2 ) )
-		        ->method( 'get_wpml_package' )
-		        ->with( $this->equalTo( $string_package_id ) )
-		        ->willReturn( $package );
 		$update = $this->getMockBuilder( 'WPML_PB_Update_Post' )
 		               ->setMethods( array( 'update' ) )
 		               ->disableOriginalConstructor()
@@ -61,9 +83,6 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		                 ->setMethods( array( 'get_package_kind', 'get_update_post' ) )
 		                 ->disableOriginalConstructor()
 		                 ->getMock();
-		$strategy->expects( $this->exactly( $post_id ? 3 : 0 ) )
-		         ->method( 'get_package_kind' )
-		         ->willReturn( $package_kind );
 		$package_data = array( 'package' => $package, 'languages' => array( $language_1, $language_2 ) );
 		$strategy->expects( $post_id ? $this->once() : $this->never() )
 		         ->method( 'get_update_post' )
@@ -71,7 +90,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		         ->willReturn( $update );
 
 
-		return array( $factory, $strategy );
+		return array( $factory, $strategy, $package );
 	}
 
 	private function get_wpdb_mock( $string_package_id, $language_1, $language_2 ) {


### PR DESCRIPTION
The action hook will be called by WPML Media (see https://git.onthegosystems.com/wpml/wpml-media-translation/merge_requests/265).

Steps:
1. Resave the string translation (so media can filter the translation)
2. Add the post package to the update list
3. Add the post to the shutdown update queue

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5765