### PR TITLE
Post count is wrongly updated.

### DIFF
--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes-update.php
@@ -29,6 +29,10 @@ class WPML_Page_Builders_Media_Shortcodes_Update implements IWPML_PB_Media_Updat
 			return;
 		}
 
+		if ( ! $this->media_shortcodes->has_media_shortcode( $post->post_content ) ) {
+			return;
+		}
+
 		$element = $this->element_factory->create_post( $post->ID );
 
 		if ( ! $element->get_source_language_code() ) {

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
@@ -45,6 +45,24 @@ class WPML_Page_Builders_Media_Shortcodes {
 	}
 
 	/**
+	 * @param string $content
+	 *
+	 * @return bool
+	 */
+	public function has_media_shortcode( $content ) {
+		foreach ( $this->config as $shortcode ) {
+			$shortcode = $this->sanitize_shortcode( $shortcode );
+			$tag_name  = isset( $shortcode['tag']['name'] ) ? $shortcode['tag']['name'] : '';
+
+			if ( $tag_name && false !== strpos( $content, '[' . $tag_name ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * @param array $shortcode
 	 *
 	 * @return array

--- a/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
+++ b/src/media/shortcodes/class-wpml-page-builders-media-shortcodes.php
@@ -50,6 +50,10 @@ class WPML_Page_Builders_Media_Shortcodes {
 	 * @return bool
 	 */
 	public function has_media_shortcode( $content ) {
+		if ( false === strpos( $content, '[' ) ) {
+			return false;
+		};
+
 		foreach ( $this->config as $shortcode ) {
 			$shortcode = $this->sanitize_shortcode( $shortcode );
 			$tag_name  = isset( $shortcode['tag']['name'] ) ? $shortcode['tag']['name'] : '';

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes-update.php
@@ -104,9 +104,12 @@ class Test_WPML_Page_Builders_Media_Shortcodes_Update extends \OTGS\PHPUnit\Tool
 	}
 
 	private function get_media_shortcodes() {
-		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Shortcodes' )
-		            ->setMethods( array( 'set_target_lang', 'set_source_lang', 'translate' ) )
+		$shortcodes = $this->getMockBuilder( 'WPML_Page_Builders_Media_Shortcodes' )
+		            ->setMethods( array( 'set_target_lang', 'set_source_lang', 'translate', 'has_media_shortcode' ) )
 		            ->disableOriginalConstructor()->getMock();
+		$shortcodes->method( 'has_media_shortcode' )->willReturn( true );
+
+		return $shortcodes;
 	}
 
 	private function get_pb_media_usage() {

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -141,6 +141,166 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 		$this->assertEquals( $translated_content, $actual_content );
 	}
 
+	/**
+	 * @test
+	 * @group wpmlpb-166
+	 */
+	public function it_should_return_true_when_content_has_media_shortcodes() {
+		$original_url_1 = 'http://example.org/dog.jpg';
+		$original_url_2 = 'http://example.org/england.jpg';
+		$original_id_1  = 2;
+		$original_id_2  = 7;
+
+		$content = '
+[et_pb_section bb_built="1"][et_pb_row][et_pb_column type="4_4"]
+	[et_pb_gallery _builder_version="3.12" gallery_ids="' . $original_id_1 . '" zoom_icon_color="#2ea3f2" /]
+	[et_pb_audio _builder_version="3.12" title="Audio block One" /]
+	[et_pb_audio _builder_version="3.12" title="Audio block Two" background_image="' . $original_url_1 . '" /]
+	[et_pb_cta background_image="' . $original_url_2 . '" title="The call to action" button_text="Buy me"]
+		Do not miss this opportunity!
+	[/et_pb_cta]
+	[et_pb_gallery gallery_ids="" note="No IDs specified" /]
+	[et_pb_gallery gallery_ids="' . $original_id_1 . ',' . $original_id_2 . '" zoom_icon_color="#2ea3f2" /]
+	[et_pb_video_slider _builder_version="3.12" controls_color="light"]
+		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $original_url_2 . '" background_layout="dark" src_webm="http://wpml.local/video2.webm" /]
+		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $original_url_1 . '" background_layout="dark" src_webm="http://wpml.local/video1.webm" /]
+	[/et_pb_video_slider]
+	[et_pb_video image_src="' . $original_url_1 . '" some_image_src="Should not be translated" background_image="' . $original_url_2 . '" /]
+	[shortcode_with_single_quotes gallery_ids=\'' . $original_id_1 . '\' /]
+	[shortcode_with_url_content foo="bar"]' . $original_url_1 . '[/shortcode_with_url_content]
+	[shortcode_with_url_content]' . $original_url_2 . '[/shortcode_with_url_content]
+[/et_pb_column][/et_pb_row][/et_pb_section]
+';
+
+		$config = array(
+			array(
+				'tag'        => array( 'name' => 'et_pb_cta' ),
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_audio' ),
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_video_slider_item' ),
+				'attributes' => array(
+					'image_src' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_video' ),
+				'attributes' => array(
+					'image_src'        => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_gallery' ),
+				'attributes' => array(
+					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'shortcode_with_single_quotes' ),
+				'attributes' => array(
+					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
+				),
+			),
+			array(
+				'tag'     => array( 'name' => 'shortcode_with_url_content' ),
+				'content' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+			),
+			// Missing tag, should not alter content
+			array(
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			// No attributes, should not alter content
+			array(
+				'tag' => array( 'name' => 'et_pb_gallery' ),
+			),
+		);
+
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate, $config );
+
+		$this->assertTrue( $subject->has_media_shortcode( $content ) );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlpb-166
+	 */
+	public function it_should_return_false_when_content_has_NO_media_shortcodes() {
+		$content = '[sr]';
+
+		$config = array(
+			array(
+				'tag'        => array( 'name' => 'et_pb_cta' ),
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_audio' ),
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_video_slider_item' ),
+				'attributes' => array(
+					'image_src' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_video' ),
+				'attributes' => array(
+					'image_src'        => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'et_pb_gallery' ),
+				'attributes' => array(
+					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
+				),
+			),
+			array(
+				'tag'        => array( 'name' => 'shortcode_with_single_quotes' ),
+				'attributes' => array(
+					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
+				),
+			),
+			array(
+				'tag'     => array( 'name' => 'shortcode_with_url_content' ),
+				'content' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+			),
+			// Missing tag, should not alter content
+			array(
+				'attributes' => array(
+					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
+				),
+			),
+			// No attributes, should not alter content
+			array(
+				'tag' => array( 'name' => 'et_pb_gallery' ),
+			),
+		);
+
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate, $config );
+
+		$this->assertFalse( $subject->has_media_shortcode( $content ) );
+	}
+
 	private function get_subject( $media_translate, $config ) {
 		return new WPML_Page_Builders_Media_Shortcodes( $media_translate, $config );
 	}

--- a/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
+++ b/tests/phpunit/tests/media/shortcodes/test-wpml-page-builders-media-shortcodes.php
@@ -143,86 +143,36 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 
 	/**
 	 * @test
+	 */
+	public function it_should_return_false_when_content_has_no_shortcode() {
+		$content = 'Some content with no shortcode';
+
+		$media_translate = $this->get_media_translate();
+
+		$config = array();
+
+		$subject = $this->get_subject( $media_translate, $config );
+
+		$this->assertFalse( $subject->has_media_shortcode( $content ) );
+	}
+
+	/**
+	 * @test
 	 * @group wpmlpb-166
 	 */
 	public function it_should_return_true_when_content_has_media_shortcodes() {
-		$original_url_1 = 'http://example.org/dog.jpg';
-		$original_url_2 = 'http://example.org/england.jpg';
-		$original_id_1  = 2;
-		$original_id_2  = 7;
-
 		$content = '
 [et_pb_section bb_built="1"][et_pb_row][et_pb_column type="4_4"]
-	[et_pb_gallery _builder_version="3.12" gallery_ids="' . $original_id_1 . '" zoom_icon_color="#2ea3f2" /]
 	[et_pb_audio _builder_version="3.12" title="Audio block One" /]
-	[et_pb_audio _builder_version="3.12" title="Audio block Two" background_image="' . $original_url_1 . '" /]
-	[et_pb_cta background_image="' . $original_url_2 . '" title="The call to action" button_text="Buy me"]
-		Do not miss this opportunity!
-	[/et_pb_cta]
-	[et_pb_gallery gallery_ids="" note="No IDs specified" /]
-	[et_pb_gallery gallery_ids="' . $original_id_1 . ',' . $original_id_2 . '" zoom_icon_color="#2ea3f2" /]
-	[et_pb_video_slider _builder_version="3.12" controls_color="light"]
-		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $original_url_2 . '" background_layout="dark" src_webm="http://wpml.local/video2.webm" /]
-		[et_pb_video_slider_item _builder_version="3.12" image_src="' . $original_url_1 . '" background_layout="dark" src_webm="http://wpml.local/video1.webm" /]
-	[/et_pb_video_slider]
-	[et_pb_video image_src="' . $original_url_1 . '" some_image_src="Should not be translated" background_image="' . $original_url_2 . '" /]
-	[shortcode_with_single_quotes gallery_ids=\'' . $original_id_1 . '\' /]
-	[shortcode_with_url_content foo="bar"]' . $original_url_1 . '[/shortcode_with_url_content]
-	[shortcode_with_url_content]' . $original_url_2 . '[/shortcode_with_url_content]
 [/et_pb_column][/et_pb_row][/et_pb_section]
 ';
 
 		$config = array(
 			array(
-				'tag'        => array( 'name' => 'et_pb_cta' ),
-				'attributes' => array(
-					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-				),
-			),
-			array(
 				'tag'        => array( 'name' => 'et_pb_audio' ),
 				'attributes' => array(
 					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
 				),
-			),
-			array(
-				'tag'        => array( 'name' => 'et_pb_video_slider_item' ),
-				'attributes' => array(
-					'image_src' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-				),
-			),
-			array(
-				'tag'        => array( 'name' => 'et_pb_video' ),
-				'attributes' => array(
-					'image_src'        => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-				),
-			),
-			array(
-				'tag'        => array( 'name' => 'et_pb_gallery' ),
-				'attributes' => array(
-					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
-				),
-			),
-			array(
-				'tag'        => array( 'name' => 'shortcode_with_single_quotes' ),
-				'attributes' => array(
-					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
-				),
-			),
-			array(
-				'tag'     => array( 'name' => 'shortcode_with_url_content' ),
-				'content' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-			),
-			// Missing tag, should not alter content
-			array(
-				'attributes' => array(
-					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-				),
-			),
-			// No attributes, should not alter content
-			array(
-				'tag' => array( 'name' => 'et_pb_gallery' ),
 			),
 		);
 
@@ -242,55 +192,10 @@ class Test_WPML_Page_Builders_Media_Shortcodes extends \OTGS\PHPUnit\Tools\TestC
 
 		$config = array(
 			array(
-				'tag'        => array( 'name' => 'et_pb_cta' ),
-				'attributes' => array(
-					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-				),
-			),
-			array(
 				'tag'        => array( 'name' => 'et_pb_audio' ),
 				'attributes' => array(
 					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
 				),
-			),
-			array(
-				'tag'        => array( 'name' => 'et_pb_video_slider_item' ),
-				'attributes' => array(
-					'image_src' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-				),
-			),
-			array(
-				'tag'        => array( 'name' => 'et_pb_video' ),
-				'attributes' => array(
-					'image_src'        => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-				),
-			),
-			array(
-				'tag'        => array( 'name' => 'et_pb_gallery' ),
-				'attributes' => array(
-					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
-				),
-			),
-			array(
-				'tag'        => array( 'name' => 'shortcode_with_single_quotes' ),
-				'attributes' => array(
-					'gallery_ids' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_IDS ),
-				),
-			),
-			array(
-				'tag'     => array( 'name' => 'shortcode_with_url_content' ),
-				'content' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-			),
-			// Missing tag, should not alter content
-			array(
-				'attributes' => array(
-					'background_image' => array( 'type' => WPML_Page_Builders_Media_Shortcodes::TYPE_URL ),
-				),
-			),
-			// No attributes, should not alter content
-			array(
-				'tag' => array( 'name' => 'et_pb_gallery' ),
 			),
 		);
 


### PR DESCRIPTION
Post count is wrongly updated

Steps to reproduce:

Create post with tag 'tag1' and some PB shortcode like `[vc_text_separator]`
Duplicate it to secondary language (let say `sr`).
Post count is wrong, because duplicate got wrong tag. Not `tag1-sr`, but simply `tag1`.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5938

-----

First solution:

Check if post content has no PB tags and do not update the post.

Final solution:

Workaround in wp_update_post() call, as it is the bug in WP core.