### PR TITLE
Prevent re-saving the post translation if it was lastly updated with the native editor.

### DIFF
--- a/src/st/class-wpml-pb-factory.php
+++ b/src/st/class-wpml-pb-factory.php
@@ -81,4 +81,13 @@ class WPML_PB_Factory {
 			)
 		);
 	}
+
+	public function get_last_translation_edit_mode() {
+		return new WPML_PB_Last_Translation_Edit_Mode();
+	}
+
+	public function get_post_element( $post_id ) {
+		$factory = new WPML_Translation_Element_Factory( $this->sitepress );
+		return $factory->create_post( $post_id );
+	}
 }

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -67,6 +67,10 @@ class WPML_PB_Integration {
 			return;
 		}
 
+		if ( $this->factory->get_last_translation_edit_mode()->is_native_editor( $post_element->get_id() ) ) {
+			return;
+		}
+
 		$updated_packages = $this->factory->get_package_strings_resave()->from_element( $post_element );
 
 		if ( ! $updated_packages ) {
@@ -94,7 +98,29 @@ class WPML_PB_Integration {
 	 * @param $post
 	 */
 	public function queue_save_post_actions( $post_id, $post ) {
+		$this->update_last_editor_mode( $post_id );
 		$this->save_post_queue[ $post_id ] = $post;
+	}
+
+	/** @param int $post_id */
+	private function update_last_editor_mode( $post_id ) {
+		$post_element = $this->factory->get_post_element( $post_id );
+
+		if ( ! $post_element->get_source_language_code() ) {
+			return;
+		}
+
+		$last_edit_mode = $this->factory->get_last_translation_edit_mode();
+
+		if ( $this->is_editing_translation_with_native_editor() ) {
+			$last_edit_mode->set_native_editor( $post_id );
+		} else {
+			$last_edit_mode->set_translation_editor( $post_id );
+		}
+	}
+
+	private function is_editing_translation_with_native_editor() {
+		return isset( $_POST['action'] ) && 'editpost' === $_POST['action'];
 	}
 
 	/**

--- a/src/st/class-wpml-pb-last-translation-edit-mode.php
+++ b/src/st/class-wpml-pb-last-translation-edit-mode.php
@@ -1,0 +1,57 @@
+<?php
+
+class WPML_PB_Last_Translation_Edit_Mode {
+
+	const POST_META_KEY      = '_last_translation_edit_mode';
+	const NATIVE_EDITOR      = 'native-editor';
+	const TRANSLATION_EDITOR = 'translation-editor';
+
+	/**
+	 * @param int $post_id
+	 *
+	 * @return bool
+	 */
+	public function is_native_editor( $post_id ) {
+		return $this->get_last_mode( $post_id ) === self::NATIVE_EDITOR;
+	}
+
+	/**
+	 * @param int $post_id
+	 *
+	 * @return bool
+	 */
+	public function is_translation_editor( $post_id ) {
+		return $this->get_last_mode( $post_id ) === self::TRANSLATION_EDITOR;
+	}
+
+	/**
+	 * @param int $post_id
+	 *
+	 * @return mixed
+	 */
+	private function get_last_mode( $post_id ) {
+		return get_post_meta( $post_id, self::POST_META_KEY, true );
+	}
+
+	/**
+	 * @param int $post_id
+	 */
+	public function set_native_editor( $post_id ) {
+		$this->set_mode( $post_id, self::NATIVE_EDITOR );
+	}
+
+	/**
+	 * @param int $post_id
+	 */
+	public function set_translation_editor( $post_id ) {
+		$this->set_mode( $post_id, self::TRANSLATION_EDITOR );
+	}
+
+	/**
+	 * @param int    $post_id
+	 * @param string $mode
+	 */
+	private function set_mode( $post_id, $mode ) {
+		update_post_meta( $post_id, self::POST_META_KEY, $mode );
+	}
+}

--- a/tests/phpunit/tests/st/test-wpml-pb-factory.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-factory.php
@@ -74,6 +74,15 @@ class Test_WPML_PB_Factory extends WPML_PB_TestCase {
 		$this->assertInstanceOf( 'WPML_PB_Handle_Post_Body', $handle_post_body );
 	}
 
+	/**
+	 * @test
+	 * @group wpmlcore-6120
+	 */
+	public function test_get_last_translation_edit_mode() {
+		$factory = $this->get_factory_with_mocks();
+		$this->assertInstanceOf( 'WPML_PB_Last_Translation_Edit_Mode', $factory->get_last_translation_edit_mode() );
+	}
+
 	private function get_factory_with_mocks() {
 		global $wpdb;
 

--- a/tests/phpunit/tests/st/test-wpml-pb-last-edit-mode.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-last-edit-mode.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @group wpmlcore-6120
+ */
+class Test_WPML_PB_Last_Edit_Mode extends \OTGS\PHPUnit\Tools\TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_verify_native_editor() {
+		$post_id = 123;
+
+		\WP_Mock::userFunction( 'get_post_meta', array(
+			'args'   => array( $post_id, WPML_PB_Last_Translation_Edit_Mode::POST_META_KEY, true ),
+			'return' => WPML_PB_Last_Translation_Edit_Mode::NATIVE_EDITOR,
+		));
+
+		$subject = $this->get_subject();
+
+		$this->assertTrue( $subject->is_native_editor( $post_id ) );
+		$this->assertFalse( $subject->is_translation_editor( $post_id ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_verify_translation_editor() {
+		$post_id = 123;
+
+		\WP_Mock::userFunction( 'get_post_meta', array(
+			'args'   => array( $post_id, WPML_PB_Last_Translation_Edit_Mode::POST_META_KEY, true ),
+			'return' => WPML_PB_Last_Translation_Edit_Mode::TRANSLATION_EDITOR,
+		));
+
+		$subject = $this->get_subject();
+
+		$this->assertFalse( $subject->is_native_editor( $post_id ) );
+		$this->assertTrue( $subject->is_translation_editor( $post_id ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_set_native_editor() {
+		$post_id = 123;
+
+		\WP_Mock::userFunction( 'update_post_meta', array(
+			'times' => 1,
+			'args'  => array(
+				$post_id,
+				WPML_PB_Last_Translation_Edit_Mode::POST_META_KEY,
+				WPML_PB_Last_Translation_Edit_Mode::NATIVE_EDITOR,
+			),
+		));
+
+		$subject = $this->get_subject();
+
+		$subject->set_native_editor( $post_id );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_set_translation_editor() {
+		$post_id = 123;
+
+		\WP_Mock::userFunction( 'update_post_meta', array(
+			'times' => 1,
+			'args'  => array(
+				$post_id,
+				WPML_PB_Last_Translation_Edit_Mode::POST_META_KEY,
+				WPML_PB_Last_Translation_Edit_Mode::TRANSLATION_EDITOR,
+			),
+		));
+
+		$subject = $this->get_subject();
+
+		$subject->set_translation_editor( $post_id );
+	}
+
+	private function get_subject() {
+		return new WPML_PB_Last_Translation_Edit_Mode();
+	}
+}


### PR DESCRIPTION
It means that the package strings are out of sync and we risk overwritting the translation content with outdated package strings.

This scenario is possible if a user edit a PB translation with the native editor, and later "translate" an image of this PB content in WPML > Media translations.

I created a class `WPML_PB_Last_Translation_Edit_Mode` which will store/retrieve information about which translation mode was used ultimately for a post translation.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6120