### PR TITLE
Scrutinizer php analysis upgrade

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,8 +5,9 @@ checks:
         duplication: true
 filter:
     excluded_paths:
-    - "tests/"
-    - "vendor/"
+        - "tests/"
+    dependency_paths:
+        - "vendor/"
 coding_style:
     php:
         indentation:
@@ -23,13 +24,13 @@ build:
         - vendor/
     nodes:
 
-        php-coding-standards:
+        analysis:
             environment:
                 php: 7.1
             tests:
                 override:
                 - idle_timeout: 4800
-                  command: "phpcs-run ./"
+                  command: php-scrutinizer-run
 
         phpunit:
             environment:


### PR DESCRIPTION
This MR uses a more modern tool in Scrutinizer to run analysis and which should allow hiding issues we don't want to fix (though, I would prefer if we fix all of them).

Please have a look at the changes, then apply them to all the PB projects.


When you want to hide an issue (again, please, don't just hide them because you don't want to fix them!), go to Scrutinizer and find the corresponding inspection (*).

Search the inspection you want to hide and click the arrow on the top-right of the issue:

![image](https://user-images.githubusercontent.com/181780/49597494-d9321880-f97c-11e8-9ddd-0f996f14da1a.png)


Select "Hide just this issue" or "Hide more issues like this".
The latter opens a dialog where you can define the criteria to use for hiding similar issues.

Just one more thing, in case you missed it before: I'd instead prefer if we address all the reported issues, as they are valid 99% of the times.  
We don't like them to be there because they address non-breaking problems.
But missing PHPDoc or similar issues are important. Especially, but not only, with public projects like these.