### PR TITLE
Always run the shortcode strategy at last

### DIFF
--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -12,6 +12,17 @@ class WPML_PB_Loader {
 
 		$page_builder_strategies = array();
 
+		/**
+		 * This filter hook provide the API page builders names that need to be supported.
+		 *
+		 * For each PB name, we will create a dedicated strategy and a proper string package namespace.
+		 *
+		 * It's called in 2 places:
+		 * - `WPML_Page_Builders_Integration` for external plugins
+		 * - `WPML_Gutenberg_Integration` for WordPress Core block editor
+		 *
+		 * @param string[] Required plugin names (e.g. `Beaver Builder`, `Gutenberg`)
+		 */
 		$required = apply_filters( 'wpml_page_builder_support_required', array() );
 		foreach ( $required as $plugin ) {
 			$page_builder_strategies[] = new WPML_PB_API_Hooks_Strategy( $plugin );

--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -12,6 +12,11 @@ class WPML_PB_Loader {
 
 		$page_builder_strategies = array();
 
+		$required = apply_filters( 'wpml_page_builder_support_required', array() );
+		foreach ( $required as $plugin ) {
+			$page_builder_strategies[] = new WPML_PB_API_Hooks_Strategy( $plugin );
+		}
+
 		$page_builder_config_import = new WPML_PB_Config_Import_Shortcode( $st_settings );
 		$page_builder_config_import->add_hooks();
 		if ( $page_builder_config_import->has_settings() ) {
@@ -36,11 +41,6 @@ class WPML_PB_Loader {
 			);
 
 			$post_body_handler->add_hooks();
-		}
-
-		$required = apply_filters( 'wpml_page_builder_support_required', array() );
-		foreach ( $required as $plugin ) {
-			$page_builder_strategies[] = new WPML_PB_API_Hooks_Strategy( $plugin );
 		}
 
 		if ( $page_builder_strategies ) {

--- a/tests/phpunit/tests/st/test-wpml-pb-loader.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-loader.php
@@ -29,10 +29,18 @@ class Test_WPML_PB_Loader extends WPML_PB_TestCase {
 		new WPML_PB_Loader( $this->get_sitepress_mock(), $this->get_wpdb_mock(), $st_settings, $integration_mock );
 	}
 
-	public function test_two_strategies() {
+	/**
+	 * @group wpmlcore-6208
+	 */
+	public function test_two_strategies_and_assert_shortcode_strategy_is_the_last() {
+		\WP_Mock::userFunction( 'is_admin', array( 'return' => false ) );
+
 		$integration_mock = $this->get_pb_integration_mock();
 		$integration_mock->expects( $this->exactly( 1 ) )->method( 'add_hooks' );
-		$integration_mock->expects( $this->exactly( 2 ) )->method( 'add_strategy' );
+		$integration_mock->expects( $this->at( 1 ) )->method( 'add_strategy' )
+			->with( $this->isInstanceOf( 'WPML_PB_API_Hooks_Strategy' ) );
+		$integration_mock->expects( $this->at( 2 ) )->method( 'add_strategy' )
+			->with( $this->isInstanceOf( 'WPML_PB_Shortcode_Strategy' ) );
 		WP_Mock::onFilter( 'wpml_page_builder_support_required' )->with( array() )->reply( array( 'something' ) );
 		new WPML_PB_Loader( $this->get_sitepress_mock(),
 		                    $this->get_wpdb_mock(),


### PR DESCRIPTION
In the API strategy, we usually don't care of the post content but
Cornerstone is using both shortcodes (legacy blocks) and metadata.

When the API strategy saves the content, it also copies the post_content
from original to translation, and this was overwritting the translations
applied to the shortcodes.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6208