### PR TITLE
Check if original post is set before copying the content of it

### DIFF
--- a/src/tm/class-wpml-pb-handle-post-body.php
+++ b/src/tm/class-wpml-pb-handle-post-body.php
@@ -30,7 +30,7 @@ class WPML_PB_Handle_Post_Body {
 	 */
 	public function copy( $new_post_id, $original_post_id, array $fields ) {
 		$original_post = get_post( $original_post_id );
-		if ( $this->page_builders_built->is_page_builder_page( $original_post ) && ! $this->job_has_packages( $fields ) ) {
+		if ( $original_post && $this->page_builders_built->is_page_builder_page( $original_post ) && ! $this->job_has_packages( $fields ) ) {
 			wp_update_post( array( 'ID' => $new_post_id, 'post_content' => $original_post->post_content ) );
 			do_action( 'wpml_pb_after_page_without_elements_post_content_copy', $new_post_id, $original_post_id );
 		}

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
@@ -194,4 +194,42 @@ class Test_WPML_PB_Handle_Post_Body extends \OTGS\PHPUnit\Tools\TestCase {
 		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
 		$subject->copy( $new_post_id, $original_post_id, $fields );
 	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6222
+	 */
+	public function it_does_not_copy_post_body_if_post_object_is_not_set() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+		                            ->disableOriginalConstructor()
+		                            ->getMock();
+
+		$new_post_id                 = 2;
+		$original_post_id            = 1;
+		$original_post               = null;
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $original_post )
+		                    ->willReturn( true );
+
+		$fields = array(
+			'package-something' => 'something',
+		);
+
+		\WP_Mock::wpFunction( 'get_post', array(
+			'args'   => $original_post_id,
+			'return' => $original_post,
+		) );
+
+		\WP_Mock::wpFunction( 'wp_update_post', array(
+			'times' => 0,
+		) );
+
+		$page_builders_built->method( 'is_page_builder_page' )
+		                    ->with( $original_post )
+		                    ->willReturn( true );
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+		$subject->copy( $new_post_id, $original_post_id, $fields );
+	}
 }


### PR DESCRIPTION
In certain situations `wpml_translation_job_saved` can receive `false` value as first argument, so no post will be found and cause an error.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6222