### PR TITLE
Improve diff analysis for strings containing HTML tags

### DIFF
--- a/src/utilities/class-wpml-st-diff.php
+++ b/src/utilities/class-wpml-st-diff.php
@@ -46,6 +46,9 @@ class WPML_ST_Diff {
 	 */
 	public static function get_sameness_percent( $old_text, $new_text ) {
 		if ( $old_text ) {
+			$old_text = strip_tags( $old_text );
+			$new_text = strip_tags( $new_text );
+
 			$diff = self::diff( preg_split( '/[\s]+/', $old_text ), preg_split( '/[\s]+/', $new_text ) );
 
 			$common_length = 0;

--- a/tests/phpunit/tests/utilities/test-wpml-st-diff.php
+++ b/tests/phpunit/tests/utilities/test-wpml-st-diff.php
@@ -45,13 +45,15 @@ class Test_WPML_ST_Diff extends WPML_PB_TestCase {
 	/**
 	 * @dataProvider sameness_provider
 	 *
+	 * @group wpmlcore-6189
+	 *
 	 * @param $old_text
 	 * @param $new_text
 	 * @param $expected
 	 */
 	public function test_sameness( $old_text, $new_text, $expected ) {
 		$percent = WPML_ST_Diff::get_sameness_percent( $old_text, $new_text, $expected );
-		$this->assertLessThan( 0.5, abs( $expected - $percent ) );
+		$this->assertLessThan( 0.5, abs( $expected - $percent ), 'Actual percentage: ' . $percent );
 	}
 
 	public function sameness_provider() {
@@ -60,6 +62,8 @@ class Test_WPML_ST_Diff extends WPML_PB_TestCase {
 			array( 'This is the original string', 'This string is updated', 22.22 ),
 			array( 'This is the original string that will be modified', 'This is the original string that has been modified', 71.42 ),
 			array( 'This is the original string that will be modified', 'The original string that has been modified', 53.06 ),
+			array( 'This is the original string that will be modified', 'The original string that has been modified', 53.06 ),
+			array( "<p>Hello there</p>\n", "<p>Updated Hello there</p>\n", 83.33 ),
 		);
 	}
 }


### PR DESCRIPTION
The HTML tags are disrupting our text diff analysis and it looks like it
affects mostly small string (e.g. `<p>Hello there</p>`).

Stripping HTML tags allows to run a comparison on pure words.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6189