### PR TITLE
Include $matches argument in preg_match_all in order to be fully compatible with PHP 5.3.x

### DIFF
--- a/src/utilities/class-wpml-page-builders-page-built-with-built.php
+++ b/src/utilities/class-wpml-page-builders-page-built-with-built.php
@@ -19,7 +19,7 @@ class WPML_Page_Builders_Page_Built {
 
 		if ( is_array( $config_data ) ) {
 			foreach ( $config_data as $pattern ) {
-				$result = (bool) preg_match_all( $pattern, $post->post_content );
+				$result = (bool) preg_match_all( $pattern, $post->post_content, $matches );
 
 				if ( $result ) {
 					break;


### PR DESCRIPTION
This parameter became optional from PHP 5.4.0.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6269