### PR TITLE
Mark headings in XLIFFs so that ATE can indicate that these fields have SEO significance.

### DIFF
--- a/src/st/class-wpml-pb-string-registration.php
+++ b/src/st/class-wpml-pb-string-registration.php
@@ -65,16 +65,19 @@ class WPML_PB_String_Registration {
 	}
 
 	/**
-	 * @param int $post_id
-	 * @param string $content
-	 * @param string $type
-	 * @param string $title
-	 * @param string $name
-	 * @param int $location
+	 * Register string.
+	 *
+	 * @param int    $post_id  Post Id.
+	 * @param string $content  String content.
+	 * @param string $type     String editor type.
+	 * @param string $title    String title.
+	 * @param string $name     String name.
+	 * @param int    $location String location.
+	 * @param string $wrap     String wrap.
 	 *
 	 * @return int $string_id
 	 */
-	public function register_string( $post_id, $content = '', $type = 'LINE', $title = '', $name = '', $location = 0 ) {
+	public function register_string( $post_id, $content = '', $type = 'LINE', $title = '', $name = '', $location = 0, $wrap = '' ) {
 
 		$string_id = 0;
 
@@ -86,6 +89,7 @@ class WPML_PB_String_Registration {
 
 				$string_id = $this->get_string_id_from_package( $post_id, $content, $string_name );
 				$this->set_location( $string_id, $location );
+				$this->set_wrap( $string_id, $wrap );
 
 			} else {
 
@@ -100,6 +104,7 @@ class WPML_PB_String_Registration {
 
 				$string_id = $this->get_string_id_from_package( $post_id, $content, $string_name );
 				$this->set_location( $string_id, $location );
+				$this->set_wrap( $string_id, $wrap );
 
 				if ( 'LINK' === $type ) {
 					$this->set_link_translations( $string_id );
@@ -117,6 +122,17 @@ class WPML_PB_String_Registration {
 	private function set_location( $string_id, $location ) {
 		$string = $this->string_factory->find_by_id( $string_id );
 		$string->set_location( $location );
+	}
+
+	/**
+	 * Set string wrap.
+	 *
+	 * @param int $string_id String id.
+	 * @param int $wrap String wrap.
+	 */
+	private function set_wrap( $string_id, $wrap ) {
+		$string = $this->string_factory->find_by_id( $string_id );
+		$string->set_wrap( $wrap );
 	}
 
 	private function set_link_translations( $string_id ) {

--- a/src/st/class-wpml-pb-string.php
+++ b/src/st/class-wpml-pb-string.php
@@ -12,11 +12,28 @@ class WPML_PB_String {
 	/** @var  string $editor_type */
 	private $editor_type;
 
-	public function __construct( $value, $name, $title, $editor_type ) {
+	/**
+	 * String wrap tag.
+	 *
+	 * @var  string $wrap
+	 */
+	private $wrap;
+
+	/**
+	 * WPML_PB_String constructor.
+	 *
+	 * @param string $value       String value.
+	 * @param string $name        String name.
+	 * @param string $title       String title.
+	 * @param string $editor_type Editor type used.
+	 * @param string $wrap        String wrap tag.
+	 */
+	public function __construct( $value, $name, $title, $editor_type, $wrap = '' ) {
 		$this->value       = $value;
 		$this->name        = $name;
 		$this->title       = $title;
 		$this->editor_type = $editor_type;
+		$this->wrap        = $wrap;
 	}
 
 	/**
@@ -54,4 +71,12 @@ class WPML_PB_String {
 		return $this->editor_type;
 	}
 
+	/**
+	 * Get string wrap tag.
+	 *
+	 * @return string
+	 */
+	public function get_wrap() {
+		return $this->wrap;
+	}
 }

--- a/src/st/compatibility/class-wpml-page-builders-register-strings.php
+++ b/src/st/compatibility/class-wpml-page-builders-register-strings.php
@@ -71,7 +71,9 @@ abstract class WPML_Page_Builders_Register_Strings {
 				$string->get_value(),
 				$string->get_editor_type(),
 				$string->get_title(),
-				$string->get_name()
+				$string->get_name(),
+				0,
+				$string->get_wrap()
 			);
 		}
 	}

--- a/src/tm/class-wpml-tm-page-builders-field-wrapper.php
+++ b/src/tm/class-wpml-tm-page-builders-field-wrapper.php
@@ -94,20 +94,14 @@ class WPML_TM_Page_Builders_Field_Wrapper {
 	}
 
 	/**
-	 * @param string $string_name
+	 * Get string wrap.
+	 *
+	 * @param stdClass $string WPML string.
 	 *
 	 * @return string
 	 */
-	public static function get_wrap( $string_name ) {
-		$heading = '';
-		if ( strpos( $string_name, '-heading-' ) ) {
-			$name_arr = explode( '-', $string_name );
-			if ( isset( $name_arr[3] ) ) {
-				$heading = $name_arr[3];
-			}
-		}
-
-		return $heading;
+	public static function get_wrap( $string ) {
+		return isset( $string->wrap ) ? $string->wrap : '';
 	}
 
 	/**
@@ -117,11 +111,7 @@ class WPML_TM_Page_Builders_Field_Wrapper {
 	 * @return string
 	 */
 	public static function generate_field_slug( $package_id, $string ) {
-		$wrap = self::get_wrap( $string->name );
-		if ( '' !== $wrap ) {
-			$wrap = '-' . $wrap;
-		}
-		return self::SLUG_BASE . $package_id . '-' . $string->id . $wrap;
+		return self::SLUG_BASE . $package_id . '-' . $string->id;
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders-field-wrapper.php
+++ b/src/tm/class-wpml-tm-page-builders-field-wrapper.php
@@ -94,13 +94,34 @@ class WPML_TM_Page_Builders_Field_Wrapper {
 	}
 
 	/**
-	 * @param int $package_id
-	 * @param int $string_id
+	 * @param string $string_name
 	 *
 	 * @return string
 	 */
-	public static function generate_field_slug( $package_id, $string_id ) {
-		return self::SLUG_BASE . $package_id . '-' . $string_id;
+	public static function get_wrap( $string_name ) {
+		$heading = '';
+		if ( strpos( $string_name, '-heading-' ) ) {
+			$name_arr = explode( '-', $string_name );
+			if ( isset( $name_arr[3] ) ) {
+				$heading = $name_arr[3];
+			}
+		}
+
+		return $heading;
+	}
+
+	/**
+	 * @param int $package_id
+	 * @param stdClass $string
+	 *
+	 * @return string
+	 */
+	public static function generate_field_slug( $package_id, $string ) {
+		$wrap = self::get_wrap( $string->name );
+		if ( '' !== $wrap ) {
+			$wrap = '-' . $wrap;
+		}
+		return self::SLUG_BASE . $package_id . '-' . $string->id . $wrap;
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders-hooks.php
+++ b/src/tm/class-wpml-tm-page-builders-hooks.php
@@ -57,7 +57,13 @@ class WPML_TM_Page_Builders_Hooks {
 	public function adjust_translation_fields_filter( array $fields, $job ) {
 		$worker = $this->get_worker();
 
-		return $worker->adjust_translation_fields_filter( $fields, $job );
+		$fields = $worker->adjust_translation_fields_filter( $fields, $job );
+		foreach ( $fields as &$field ) {
+			if ( isset( $field['field_wrap_tag'] ) && $field['field_wrap_tag'] ) {
+				$field['title'] = $field['field_wrap_tag'];
+			}
+		}
+		return $fields;
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -45,7 +45,7 @@ class WPML_TM_Page_Builders {
 					/* @var WPML_Package $string_package */
 					$strings             = $string_package->get_package_strings();
 					$string_translations = array();
-					
+
 					if ( $job_source_is_not_post_source ) {
 						$string_translations = $string_package->get_translated_strings( array() );
 					}
@@ -64,7 +64,7 @@ class WPML_TM_Page_Builders {
 							$translation_package['contents'][ $field_name ] = array(
 								'translate' => 1,
 								'data'      => base64_encode( $string_value ),
-								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string->name ),
+								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string ),
 								'format'    => 'base64',
 							);
 						}

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -59,11 +59,12 @@ class WPML_TM_Page_Builders {
 								$string_value = $string_translations[ $string->name ][ $job_lang_from ]['value'];
 							}
 
-							$field_name = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string->id );
+							$field_name = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
 
 							$translation_package['contents'][ $field_name ] = array(
 								'translate' => 1,
 								'data'      => base64_encode( $string_value ),
+								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string->name ),
 								'format'    => 'base64',
 							);
 						}

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -9,6 +9,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 
 	private $package_id;
 	private $string_id;
+	private $string;
 	private $string_title;
 
 	function setUp() {
@@ -26,7 +27,12 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 		) );
 
 		$this->package_id = 10;
-		$this->string_id = 12;
+		$this->string_id  = 12;
+
+		$this->string       = new stdClass();
+		$this->string->id   = $this->string_id;
+		$this->string->name = 'string_name';
+
 		$this->string_title = rand_str( 10 );
 
 		\WP_Mock::onFilter( 'wpml_string_title_from_id' )
@@ -91,6 +97,11 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	function it_validates_without_checking_of_package( $package_id, $string_id, $expected_result ) {
 		$this->package_id = $package_id;
 		$this->string_id = $string_id;
+
+		$this->string       = new stdClass();
+		$this->string->id   = $this->string_id;
+		$this->string->name = 'string_name';
+
 		$subject = $this->create_subject();
 
 		$this->assertEquals( $expected_result, $subject->is_valid() );
@@ -138,7 +149,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @test
 	 */
 	function it_gets_field_slug() {
-		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string_id );
+		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string );
 		$subject = new WPML_TM_Page_Builders_Field_Wrapper( $slug );
 
 		$this->assertEquals( $slug, $subject->get_field_slug() );
@@ -197,7 +208,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @return WPML_TM_Page_Builders_Field_Wrapper
 	 */
 	private function create_subject() {
-		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string_id );
+		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string );
 		return new WPML_TM_Page_Builders_Field_Wrapper( $slug );
 	}
 }

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -205,6 +205,32 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	}
 
 	/**
+	 * @test
+	 * @dataProvider get_wrap_data_provider
+	 * @group wpmltm-3081
+	 *
+	 * @param string $string_name
+	 * @param string $expected
+	 */
+	public function get_wrap( $string_name, $expected ) {
+		$wrap = WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string_name );
+		$this->assertEquals( $expected, $wrap );
+	}
+
+	/**
+	 * @return array
+	 */
+	function get_wrap_data_provider() {
+		return array(
+			'Empty string'       => array( '', '' ),
+			'Normal string'      => array( 'title-heading-f327e9c', '' ),
+			'Text editor string' => array( 'editor-text-editor-c12e1e6', '' ),
+			'Heading'            => array( 'title-heading-8e0908e', '' ),
+			'Heading h2'         => array( 'title-heading-8e0908e-h2', 'h2' ),
+		);
+	}
+
+	/**
 	 * @return WPML_TM_Page_Builders_Field_Wrapper
 	 */
 	private function create_subject() {

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -105,11 +105,12 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$expected_translation_package = $translation_package;
 		$expected_translation_package['contents']['body']['translate'] = 0;
 		foreach ( $strings as $string ) {
-			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string->id );
+			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
 			$expected_translation_package['contents'][ $key ] = array(
 				'translate' => 1,
 				'data'      => base64_encode( $string->value ),
 				'format'    => 'base64',
+				'wrap_tag'  => '',
 			);
 		}
 
@@ -166,11 +167,12 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$expected_translation_package['contents']['body']['translate'] = 0;
 		foreach ( $strings as $string ) {
 			$string_value = $string_translations[ $string->name ][ $job_lang_from ]['value'];
-			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string->id );
+			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
 			$expected_translation_package['contents'][ $key ] = array(
 				'translate' => 1,
 				'data'      => base64_encode( $string_value ),
 				'format'    => 'base64',
+				'wrap_tag'  => '',
 			);
 		}
 
@@ -336,10 +338,12 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 	 */
 	public function pro_translation_completed_action_data_provider() {
 		$data['string_package_id']  = rand( 1, 50 );
+
 		$data['string1_id']         = rand( 1, 50 );
 		$data['string2_id']         = rand( 51, 100 );
-		$data['string1_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $data['string1_id'] );
-		$data['string2_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $data['string2_id'] );
+
+		$data['string1_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $this->get_string( $data[ 'string1_id' ]  ) );
+		$data['string2_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $this->get_string( $data[ 'string2_id' ] ) );
 
 		$local_fields = array(
 			'title'                     => array(
@@ -431,9 +435,9 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 	 */
 	function it_adjusts_translation_fields_filter() {
 		$slugs = array(
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 1, 11 ),
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 2, 12 ),
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 3, 13 ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 1, $this->get_string( 11 ) ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 2, $this->get_string( 12 ) ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 3, $this->get_string( 13 ) ),
 		);
 
 		$fields = array_map( function ( $slug ) {
@@ -546,5 +550,19 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$post->ID        = rand( 1, 100 );
 		$post->post_type = rand_str();
 		return $post;
+	}
+
+	/**
+	 * @param string $id
+	 * @param string $name
+	 *
+	 * @return stdClass
+	 */
+	private function get_string( $id, $name = 'string_name' ) {
+		$string       = new stdClass();
+		$string->id   = $id;
+		$string->name = $name;
+
+		return $string;
 	}
 }


### PR DESCRIPTION
Changes in wpml-page-builders to support task of the ticket.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmltm-3081