### PR TITLE
Exctract code from WPML_PB_Reuse_Translations and WPML_PB_String_Translation to a parent class

### DIFF
--- a/src/st/class-wpml-pb-factory.php
+++ b/src/st/class-wpml-pb-factory.php
@@ -18,7 +18,7 @@ class WPML_PB_Factory {
 	public function get_string_translations( IWPML_PB_Strategy $strategy ) {
 		$kind = $strategy->get_package_kind();
 		if ( ! array_key_exists( $kind, $this->string_translations ) ) {
-			$this->string_translations[ $kind ] = new WPML_PB_String_Translation( $this->wpdb, $this, $strategy );
+			$this->string_translations[ $kind ] = new WPML_PB_String_Translation_By_Strategy( $this->wpdb, $this, $strategy );
 		}
 
 		return $this->string_translations[ $kind ];
@@ -54,7 +54,7 @@ class WPML_PB_Factory {
 			$string_registration,
 			$strategy,
 			new WPML_PB_Shortcode_Encoding(),
-			$migration_mode ? null : new WPML_PB_Reuse_Translations( $strategy, $string_factory )
+			$migration_mode ? null : new WPML_PB_Reuse_Translations_By_Strategy( $strategy, $string_factory )
 		);
 	}
 

--- a/src/st/class-wpml-pb-reuse-translations-by-strategy.php
+++ b/src/st/class-wpml-pb-reuse-translations-by-strategy.php
@@ -1,29 +1,29 @@
 <?php
 
-class WPML_PB_Reuse_Translations_By_Strategy extends WPML_PB_Reuse_translations {
+class WPML_PB_Reuse_Translations_By_Strategy extends WPML_PB_Reuse_Translations {
 
-	/** @var  IWPML_PB_Strategy $strategy */
+	/** @var IWPML_PB_Strategy $strategy */
 	private $strategy;
 
-	/** @var  array $original_strings */
-	private $original_strings;
+	/** @var array $original_strings */
+	private $original_strings_by_strategy;
 
 	public function __construct( IWPML_PB_Strategy $strategy, WPML_ST_String_Factory $string_factory ) {
-		$this->strategy       = $strategy;
+		$this->strategy = $strategy;
 		parent::__construct( $string_factory );
 	}
 
-	/** @param string[] $strings */
+	/** @param array $strings */
 	public function set_original_strings( array $strings ) {
-		$this->original_strings = $strings;
+		$this->original_strings_by_strategy = $strings;
 	}
 
 	/**
-	 * @param int $post_id
-	 * @param string[] $leftover_strings
+	 * @param int   $post_id
+	 * @param array $leftover_strings
 	 */
 	public function find_and_reuse( $post_id, array $leftover_strings ) {
 		$current_strings = $this->strategy->get_package_strings( $this->strategy->get_package_key( $post_id ) );
-		parent::find_and_reuse_translations( $this->original_strings, $current_strings, $leftover_strings );
+		$this->find_and_reuse_translations( $this->original_strings_by_strategy, $current_strings, $leftover_strings );
 	}
 }

--- a/src/st/class-wpml-pb-reuse-translations-by-strategy.php
+++ b/src/st/class-wpml-pb-reuse-translations-by-strategy.php
@@ -1,0 +1,29 @@
+<?php
+
+class WPML_PB_Reuse_Translations_By_Strategy extends WPML_PB_Reuse_translations {
+
+	/** @var  IWPML_PB_Strategy $strategy */
+	private $strategy;
+
+	/** @var  array $original_strings */
+	private $original_strings;
+
+	public function __construct( IWPML_PB_Strategy $strategy, WPML_ST_String_Factory $string_factory ) {
+		$this->strategy       = $strategy;
+		parent::__construct( $string_factory );
+	}
+
+	/** @param string[] $strings */
+	public function set_original_strings( array $strings ) {
+		$this->original_strings = $strings;
+	}
+
+	/**
+	 * @param int $post_id
+	 * @param string[] $leftover_strings
+	 */
+	public function find_and_reuse( $post_id, array $leftover_strings ) {
+		$current_strings = $this->strategy->get_package_strings( $this->strategy->get_package_key( $post_id ) );
+		parent::find_and_reuse_translations( $this->original_strings, $current_strings, $leftover_strings );
+	}
+}

--- a/src/st/class-wpml-pb-reuse-translations.php
+++ b/src/st/class-wpml-pb-reuse-translations.php
@@ -16,9 +16,9 @@ class WPML_PB_Reuse_Translations {
 	}
 
 	/**
-	 * @param array $original_strings
-	 * @param array $current_strings
-	 * @param array $leftover_strings
+	 * @param array[] $original_strings
+	 * @param array[] $current_strings
+	 * @param array[] $leftover_strings
 	 */
 	public function find_and_reuse_translations( array $original_strings, array $current_strings, array $leftover_strings ) {
 		$this->original_strings = $original_strings;
@@ -49,8 +49,8 @@ class WPML_PB_Reuse_Translations {
 	}
 
 	/**
-	 * @param int[] $new_strings
-	 * @param array $leftover_strings
+	 * @param int[]   $new_strings
+	 * @param array[] $leftover_strings
 	 *
 	 * @return int[]
 	 */
@@ -63,10 +63,10 @@ class WPML_PB_Reuse_Translations {
 	}
 
 	/**
-	 * @param int[] $new_strings
-	 * @param array $leftover_strings
+	 * @param int[]   $new_strings
+	 * @param array[] $leftover_strings
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	private function find_by_location( array $new_strings, array $leftover_strings ) {
 		if ( ! $leftover_strings ) {
@@ -93,8 +93,8 @@ class WPML_PB_Reuse_Translations {
 	}
 
 	/**
-	 * @param int[] $new_strings
-	 * @param array $leftover_strings
+	 * @param int[]   $new_strings
+	 * @param array[] $leftover_strings
 	 *
 	 * @return int[]
 	 */
@@ -162,7 +162,8 @@ class WPML_PB_Reuse_Translations {
 						$status,
 						$translation->translator_id,
 						$translation->translation_service,
-						$translation->batch_id );
+						$translation->batch_id
+					);
 				}
 			}
 		}

--- a/src/st/class-wpml-pb-reuse-translations.php
+++ b/src/st/class-wpml-pb-reuse-translations.php
@@ -1,6 +1,6 @@
 <?php
 
-class WPML_PB_Reuse_translations {
+class WPML_PB_Reuse_Translations {
 
 	/** @var WPML_ST_String_Factory $string_factory */
 	private $string_factory;
@@ -16,9 +16,9 @@ class WPML_PB_Reuse_translations {
 	}
 
 	/**
-	 * @param stdClass[] $original_strings
-	 * @param stdClass[] $current_strings
-	 * @param stdClass[] $leftover_strings
+	 * @param array $original_strings
+	 * @param array $current_strings
+	 * @param array $leftover_strings
 	 */
 	public function find_and_reuse_translations( array $original_strings, array $current_strings, array $leftover_strings ) {
 		$this->original_strings = $original_strings;
@@ -49,8 +49,8 @@ class WPML_PB_Reuse_translations {
 	}
 
 	/**
-	 * @param int[]    $new_strings
-	 * @param string[] $leftover_strings
+	 * @param int[] $new_strings
+	 * @param array $leftover_strings
 	 *
 	 * @return int[]
 	 */
@@ -63,8 +63,8 @@ class WPML_PB_Reuse_translations {
 	}
 
 	/**
-	 * @param int[]    $new_strings
-	 * @param string[] $leftover_strings
+	 * @param int[] $new_strings
+	 * @param array $leftover_strings
 	 *
 	 * @return array
 	 */
@@ -93,8 +93,8 @@ class WPML_PB_Reuse_translations {
 	}
 
 	/**
-	 * @param int[]    $new_strings
-	 * @param string[] $leftover_strings
+	 * @param int[] $new_strings
+	 * @param array $leftover_strings
 	 *
 	 * @return int[]
 	 */
@@ -129,9 +129,8 @@ class WPML_PB_Reuse_translations {
 	 * @return bool
 	 */
 	private function is_same_location_and_different_ids( array $current_string, array $leftover_string ) {
-		return $current_string['location'] == $leftover_string['location']
-		       && $current_string['id']
-		          != $leftover_string['id'];
+		return $current_string['location'] === $leftover_string['location']
+		       && $current_string['id'] !== $leftover_string['id'];
 	}
 
 	/**
@@ -157,12 +156,13 @@ class WPML_PB_Reuse_translations {
 
 				foreach ( $translations as $translation ) {
 					$status = $translation->status == ICL_TM_COMPLETE ? ICL_TM_NEEDS_UPDATE : $translation->status;
-					$new_string->set_translation( $translation->language,
-					                              $translation->value,
-					                              $status,
-					                              $translation->translator_id,
-					                              $translation->translation_service,
-					                              $translation->batch_id );
+					$new_string->set_translation(
+						$translation->language,
+						$translation->value,
+						$status,
+						$translation->translator_id,
+						$translation->translation_service,
+						$translation->batch_id );
 				}
 			}
 		}

--- a/src/st/class-wpml-pb-reuse-translations.php
+++ b/src/st/class-wpml-pb-reuse-translations.php
@@ -1,39 +1,34 @@
 <?php
 
-class WPML_PB_Reuse_Translations {
+class WPML_PB_Reuse_translations {
 
-	/** @var  IWPML_PB_Strategy $strategy */
-	private $strategy;
 	/** @var WPML_ST_String_Factory $string_factory */
 	private $string_factory;
 
 	/** @var  array $original_strings */
 	private $original_strings;
+
 	/** @var  array $current_strings */
 	private $current_strings;
 
-	public function __construct( IWPML_PB_Strategy $strategy, WPML_ST_String_Factory $string_factory ) {
-		$this->strategy       = $strategy;
+	public function __construct( WPML_ST_String_Factory $string_factory ) {
 		$this->string_factory = $string_factory;
 	}
 
-	/** @param string[] $strings */
-	public function set_original_strings( array $strings ) {
-		$this->original_strings = $strings;
-	}
-
 	/**
-	 * @param int $post_id
-	 * @param string[] $leftover_strings
+	 * @param stdClass[] $original_strings
+	 * @param stdClass[] $current_strings
+	 * @param stdClass[] $leftover_strings
 	 */
-	public function find_and_reuse( $post_id, array $leftover_strings ) {
-		$this->current_strings = $this->strategy->get_package_strings( $this->strategy->get_package_key( $post_id ) );
-
-		$new_strings           = $this->find_new_strings();
-		$new_strings_to_update = $this->find_existing_strings_for_new_strings( $new_strings, $leftover_strings );
+	public function find_and_reuse_translations( array $original_strings, array $current_strings, array $leftover_strings ) {
+		$this->original_strings = $original_strings;
+		$this->current_strings  = $current_strings;
+		$new_strings            = $this->find_new_strings();
+		$new_strings_to_update  = $this->find_existing_strings_for_new_strings( $new_strings, $leftover_strings );
 		$this->reuse_translations( $new_strings_to_update );
 	}
 
+	/** @return array */
 	private function find_new_strings() {
 		$new_strings = array();
 
@@ -54,7 +49,7 @@ class WPML_PB_Reuse_Translations {
 	}
 
 	/**
-	 * @param int[] $new_strings
+	 * @param int[]    $new_strings
 	 * @param string[] $leftover_strings
 	 *
 	 * @return int[]
@@ -68,7 +63,7 @@ class WPML_PB_Reuse_Translations {
 	}
 
 	/**
-	 * @param int[] $new_strings
+	 * @param int[]    $new_strings
 	 * @param string[] $leftover_strings
 	 *
 	 * @return array
@@ -86,8 +81,7 @@ class WPML_PB_Reuse_Translations {
 			foreach ( $this->current_strings as $current_string ) {
 				if ( isset( $new_strings[ $current_string['id'] ] ) ) {
 					if ( $this->is_same_location_and_different_ids( $current_string, $leftover_string )
-						 && $this->is_similar_text( $leftover_string['value'], $current_string['value'] )
-					) {
+					     && $this->is_similar_text( $leftover_string['value'], $current_string['value'] ) ) {
 						$new_strings[ $current_string['id'] ] = $leftover_string['id'];
 						unset( $leftover_strings[ $key ] );
 					}
@@ -99,7 +93,7 @@ class WPML_PB_Reuse_Translations {
 	}
 
 	/**
-	 * @param int[] $new_strings
+	 * @param int[]    $new_strings
 	 * @param string[] $leftover_strings
 	 *
 	 * @return int[]
@@ -135,7 +129,9 @@ class WPML_PB_Reuse_Translations {
 	 * @return bool
 	 */
 	private function is_same_location_and_different_ids( array $current_string, array $leftover_string ) {
-		return $current_string['location'] == $leftover_string['location'] && $current_string['id'] != $leftover_string['id'];
+		return $current_string['location'] == $leftover_string['location']
+		       && $current_string['id']
+		          != $leftover_string['id'];
 	}
 
 	/**
@@ -161,17 +157,14 @@ class WPML_PB_Reuse_Translations {
 
 				foreach ( $translations as $translation ) {
 					$status = $translation->status == ICL_TM_COMPLETE ? ICL_TM_NEEDS_UPDATE : $translation->status;
-					$new_string->set_translation(
-						$translation->language,
-						$translation->value,
-						$status,
-						$translation->translator_id,
-						$translation->translation_service,
-						$translation->batch_id
-					);
+					$new_string->set_translation( $translation->language,
+					                              $translation->value,
+					                              $status,
+					                              $translation->translator_id,
+					                              $translation->translation_service,
+					                              $translation->batch_id );
 				}
 			}
 		}
 	}
-
 }

--- a/src/st/class-wpml-pb-reuse-translations.php
+++ b/src/st/class-wpml-pb-reuse-translations.php
@@ -16,6 +16,21 @@ class WPML_PB_Reuse_Translations {
 	}
 
 	/**
+	 * We receive arrays of strings with this structure:
+	 *
+	 * array(
+	 *  'gf4544ds454sds542122sd' => array(
+	 *      'value'      => 'The string value',
+	 *      'context'    => 'the-string-context',
+	 *      'name'       => 'the-string-name',
+	 *      'id'         => 123,
+	 *      'package_id' => 123,
+	 *      'location'   => 123,
+	 *     ),
+	 *  )
+	 *
+	 * The key is the string hash.
+	 *
 	 * @param array[] $original_strings
 	 * @param array[] $current_strings
 	 * @param array[] $leftover_strings

--- a/src/st/class-wpml-pb-string-translation-by-strategy.php
+++ b/src/st/class-wpml-pb-string-translation-by-strategy.php
@@ -2,20 +2,22 @@
 
 class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation {
 
-	/** @var  WPML_PB_Factory $factory */
+	/** @var WPML_PB_Factory $factory */
 	private $factory;
-	/** @var  WPML_PB_Shortcode_Strategy $strategy */
+
+	/** @var IWPML_PB_Strategy $strategy */
 	private $strategy;
 
 	/** @var array $packages_to_update */
 	private $packages_to_update = array();
 
 	public function __construct( wpdb $wpdb, WPML_PB_Factory $factory, IWPML_PB_Strategy $strategy ) {
-		$this->factory = $factory;
+		$this->factory  = $factory;
 		$this->strategy = $strategy;
 		parent::__construct( $wpdb );
 	}
 
+	/** @param int $translated_string_id */
 	public function new_translation( $translated_string_id ) {
 		list( $package_id, $string_id, $language ) = $this->get_package_for_translated_string( $translated_string_id );
 		if ( $package_id ) {
@@ -35,6 +37,11 @@ class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation 
 		}
 	}
 
+	/**
+	 * @param int $translated_string_id
+	 *
+	 * @return array
+	 */
 	private function get_package_for_translated_string( $translated_string_id ) {
 		$sql    = $this->wpdb->prepare(
 			"SELECT s.string_package_id, s.id, t.language

--- a/src/st/class-wpml-pb-string-translation-by-strategy.php
+++ b/src/st/class-wpml-pb-string-translation-by-strategy.php
@@ -1,0 +1,69 @@
+<?php
+
+class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation {
+
+	/** @var  WPML_PB_Factory $factory */
+	private $factory;
+	/** @var  WPML_PB_Shortcode_Strategy $strategy */
+	private $strategy;
+
+	/** @var array $packages_to_update */
+	private $packages_to_update = array();
+
+	public function __construct( wpdb $wpdb, WPML_PB_Factory $factory, IWPML_PB_Strategy $strategy ) {
+		$this->factory = $factory;
+		$this->strategy = $strategy;
+		parent::__construct( $wpdb );
+	}
+
+	public function new_translation( $translated_string_id ) {
+		list( $package_id, $string_id, $language ) = $this->get_package_for_translated_string( $translated_string_id );
+		if ( $package_id ) {
+			$package = $this->factory->get_wpml_package( $package_id );
+			if ( $package->post_id && $this->strategy->get_package_kind() === $package->kind ) {
+				$this->add_package_to_update_list( $package, $language );
+			}
+		}
+	}
+
+	public function save_translations_to_post() {
+		foreach ( $this->packages_to_update as $package_data ) {
+			if ( $package_data['package']->kind == $this->strategy->get_package_kind() ) {
+				$update_post = $this->strategy->get_update_post( $package_data );
+				$update_post->update();
+			}
+		}
+	}
+
+	private function get_package_for_translated_string( $translated_string_id ) {
+		$sql    = $this->wpdb->prepare(
+			"SELECT s.string_package_id, s.id, t.language
+			FROM {$this->wpdb->prefix}icl_strings s
+			LEFT JOIN {$this->wpdb->prefix}icl_string_translations t
+			ON s.id = t.string_id
+			WHERE t.id = %d", $translated_string_id );
+		$result = $this->wpdb->get_row( $sql );
+
+		if ( $result ) {
+			return array( $result->string_package_id, $result->id, $result->language );
+		} else {
+			return array( null, null, null );
+		}
+	}
+
+	/**
+	 * @param WPML_Package $package
+	 * @param string       $language
+	 */
+	public function add_package_to_update_list( WPML_Package $package, $language ) {
+		if ( ! isset( $this->packages_to_update[ $package->ID ] ) ) {
+			$this->packages_to_update[ $package->ID ] = array( 'package'   => $package,
+			                                                   'languages' => array( $language )
+			);
+		} else {
+			if ( ! in_array( $language, $this->packages_to_update[ $package->ID ]['languages'] ) ) {
+				$this->packages_to_update[ $package->ID ]['languages'][] = $language;
+			}
+		}
+	}
+}

--- a/src/st/class-wpml-pb-string-translation.php
+++ b/src/st/class-wpml-pb-string-translation.php
@@ -21,7 +21,8 @@ class WPML_PB_String_Translation {
 			$sql_to_get_strings_with_package_id = $this->wpdb->prepare( "SELECT *
 			FROM {$this->wpdb->prefix}icl_strings s
 			WHERE s.string_package_id=%d",
-			                                                            $package_id );
+			$package_id );
+
 			$package_strings = $this->wpdb->get_results( $sql_to_get_strings_with_package_id );
 
 			if ( ! empty( $package_strings ) ) {
@@ -78,8 +79,10 @@ class WPML_PB_String_Translation {
 		$sql_to_get_package_id = $this->wpdb->prepare( "SELECT s.ID
 		FROM {$this->wpdb->prefix}icl_string_packages s
 		WHERE s.kind=%s AND s.name=%s AND s.title=%s AND s.post_id=%s",
-		                                               $package_data['kind'], $package_data['name'], $package_data['title'], $package_data['post_id'] );
+		$package_data['kind'], $package_data['name'], $package_data['title'], $package_data['post_id'] );
+
 		$result = $this->wpdb->get_row( $sql_to_get_package_id );
+
 		if ( $result ) {
 			$package_id = $result->ID;
 		}

--- a/src/st/class-wpml-pb-string-translation.php
+++ b/src/st/class-wpml-pb-string-translation.php
@@ -1,85 +1,27 @@
 <?php
 
-/**
- * Class WPML_PB_String_Translation
- */
 class WPML_PB_String_Translation {
 
 	/** @var  wpdb $wpdb */
-	private $wpdb;
-	/** @var  WPML_PB_Factory $factory */
-	private $factory;
-	/** @var  WPML_PB_Shortcode_Strategy $strategy */
-	private $strategy;
+	protected $wpdb;
 
-	/** @var array $packages_to_update */
-	private $packages_to_update = array();
-
-	public function __construct( wpdb $wpdb, WPML_PB_Factory $factory, IWPML_PB_Strategy $strategy ) {
-		$this->wpdb    = $wpdb;
-		$this->factory = $factory;
-		$this->strategy = $strategy;
-	}
-
-	public function new_translation( $translated_string_id ) {
-		list( $package_id, $string_id, $language ) = $this->get_package_for_translated_string( $translated_string_id );
-		if ( $package_id ) {
-			$package = $this->factory->get_wpml_package( $package_id );
-			if ( $package->post_id && $this->strategy->get_package_kind() === $package->kind ) {
-				$this->add_package_to_update_list( $package, $language );
-			}
-		}
-	}
-
-	public function save_translations_to_post() {
-		foreach ( $this->packages_to_update as $package_data ) {
-			if ( $package_data['package']->kind == $this->strategy->get_package_kind() ) {
-				$update_post = $this->strategy->get_update_post( $package_data );
-				$update_post->update();
-			}
-		}
-	}
-
-	private function get_package_for_translated_string( $translated_string_id ) {
-		$sql    = $this->wpdb->prepare(
-			"SELECT s.string_package_id, s.id, t.language
-			FROM {$this->wpdb->prefix}icl_strings s
-			LEFT JOIN {$this->wpdb->prefix}icl_string_translations t
-			ON s.id = t.string_id
-			WHERE t.id = %d", $translated_string_id );
-		$result = $this->wpdb->get_row( $sql );
-
-		if ( $result ) {
-			return array( $result->string_package_id, $result->id, $result->language );
-		} else {
-			return array( null, null, null );
-		}
+	public function __construct( wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
 	}
 
 	/**
-	 * @param WPML_Package $package
-	 * @param string       $language
+	 * @param array $package_data
+	 *
+	 * @return array
 	 */
-	public function add_package_to_update_list( WPML_Package $package, $language ) {
-		if ( ! isset( $this->packages_to_update[ $package->ID ] ) ) {
-			$this->packages_to_update[ $package->ID ] = array( 'package'   => $package,
-			                                                   'languages' => array( $language )
-			);
-		} else {
-			if ( ! in_array( $language, $this->packages_to_update[ $package->ID ]['languages'] ) ) {
-				$this->packages_to_update[ $package->ID ]['languages'][] = $language;
-			}
-		}
-	}
-
-	public function get_package_strings( $package_data ) {
+	public function get_package_strings( array $package_data ) {
 		$strings = array();
 		$package_id = $this->get_package_id( $package_data );
 		if ( $package_id ) {
 			$sql_to_get_strings_with_package_id = $this->wpdb->prepare( "SELECT *
 			FROM {$this->wpdb->prefix}icl_strings s
 			WHERE s.string_package_id=%d",
-			$package_id );
+			                                                            $package_id );
 			$package_strings = $this->wpdb->get_results( $sql_to_get_strings_with_package_id );
 
 			if ( ! empty( $package_strings ) ) {
@@ -98,7 +40,7 @@ class WPML_PB_String_Translation {
 		return $strings;
 	}
 
-	public function remove_string( $string_data ) {
+	public function remove_string( array $string_data ) {
 		icl_unregister_string( $string_data['context'], $string_data['name'] );
 
 		$field_type = 'package-string-' . $string_data['package_id'] . '-' . $string_data['id'];
@@ -126,12 +68,17 @@ class WPML_PB_String_Translation {
 		return ! (bool) $this->wpdb->get_var( $this->wpdb->prepare( "SELECT translated FROM {$this->wpdb->prefix}icl_translate_job WHERE job_id = %d", $job_id ) );
 	}
 
-	private function get_package_id( $package_data ) {
+	/**
+	 * @param array $package_data
+	 *
+	 * @return bool
+	 */
+	private function get_package_id( array $package_data ) {
 		$package_id = false;
 		$sql_to_get_package_id = $this->wpdb->prepare( "SELECT s.ID
 		FROM {$this->wpdb->prefix}icl_string_packages s
 		WHERE s.kind=%s AND s.name=%s AND s.title=%s AND s.post_id=%s",
-			$package_data['kind'], $package_data['name'], $package_data['title'], $package_data['post_id'] );
+		                                               $package_data['kind'], $package_data['name'], $package_data['title'], $package_data['post_id'] );
 		$result = $this->wpdb->get_row( $sql_to_get_package_id );
 		if ( $result ) {
 			$package_id = $result->ID;

--- a/src/st/class-wpml-pb-string-translation.php
+++ b/src/st/class-wpml-pb-string-translation.php
@@ -27,7 +27,7 @@ class WPML_PB_String_Translation {
 
 			if ( ! empty( $package_strings ) ) {
 				foreach ( $package_strings as $string ) {
-					$strings[ md5( $string->value ) ] = array(
+					$strings[ $this->get_string_hash( $string->value ) ] = array(
 						'value'      => $string->value,
 						'context'    => $string->context,
 						'name'       => $string->name,
@@ -88,5 +88,14 @@ class WPML_PB_String_Translation {
 		}
 
 		return $package_id;
+	}
+
+	/**
+	 * @param string $string_value
+	 *
+	 * @return string
+	 */
+	public function get_string_hash( $string_value ) {
+		return md5( $string_value );
 	}
 }

--- a/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
@@ -10,7 +10,7 @@ class WPML_PB_Register_Shortcodes {
 	private $shortcode_strategy;
 	/** @var  WPML_PB_Shortcode_Encoding $encoding */
 	private $encoding;
-	/** @var WPML_PB_Reuse_Translations_By_Strategy $reuse_translations */
+	/** @var WPML_PB_Reuse_Translations_By_Strategy|null $reuse_translations */
 	private $reuse_translations;
 
 	private $existing_package_strings;
@@ -18,12 +18,10 @@ class WPML_PB_Register_Shortcodes {
 	private $location_index;
 
 	/**
-	 * WPML_Add_Wrapper_Shortcodes constructor.
-	 *
-	 * @param WPML_PB_String_Registration            $handle_strings
-	 * @param WPML_PB_Shortcode_Strategy             $shortcode_strategy,
-	 * @param WPML_PB_Shortcode_Encoding             $encoding,
-	 * @param WPML_PB_Reuse_Translations_By_Strategy $reuse_translations
+	 * @param WPML_PB_String_Registration                 $handle_strings
+	 * @param WPML_PB_Shortcode_Strategy                  $shortcode_strategy ,
+	 * @param WPML_PB_Shortcode_Encoding                  $encoding           ,
+	 * @param WPML_PB_Reuse_Translations_By_Strategy|null $reuse_translations
 	 */
 	public function __construct(
 		WPML_PB_String_Registration $handle_strings,

--- a/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
@@ -19,8 +19,8 @@ class WPML_PB_Register_Shortcodes {
 
 	/**
 	 * @param WPML_PB_String_Registration                 $handle_strings
-	 * @param WPML_PB_Shortcode_Strategy                  $shortcode_strategy ,
-	 * @param WPML_PB_Shortcode_Encoding                  $encoding           ,
+	 * @param WPML_PB_Shortcode_Strategy                  $shortcode_strategy
+	 * @param WPML_PB_Shortcode_Encoding                  $encoding
 	 * @param WPML_PB_Reuse_Translations_By_Strategy|null $reuse_translations
 	 */
 	public function __construct(

--- a/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
@@ -10,7 +10,7 @@ class WPML_PB_Register_Shortcodes {
 	private $shortcode_strategy;
 	/** @var  WPML_PB_Shortcode_Encoding $encoding */
 	private $encoding;
-	/** @var WPML_PB_Reuse_Translations $reuse_translations */
+	/** @var WPML_PB_Reuse_Translations_By_Strategy $reuse_translations */
 	private $reuse_translations;
 
 	private $existing_package_strings;
@@ -20,16 +20,16 @@ class WPML_PB_Register_Shortcodes {
 	/**
 	 * WPML_Add_Wrapper_Shortcodes constructor.
 	 *
-	 * @param WPML_PB_String_Registration $handle_strings
-	 * @param WPML_PB_Shortcode_Strategy $shortcode_strategy,
-	 * @param WPML_PB_Shortcode_Encoding $encoding,
-	 * @param WPML_PB_Reuse_Translations $reuse_translations
+	 * @param WPML_PB_String_Registration            $handle_strings
+	 * @param WPML_PB_Shortcode_Strategy             $shortcode_strategy,
+	 * @param WPML_PB_Shortcode_Encoding             $encoding,
+	 * @param WPML_PB_Reuse_Translations_By_Strategy $reuse_translations
 	 */
 	public function __construct(
 		WPML_PB_String_Registration $handle_strings,
 		WPML_PB_Shortcode_Strategy $shortcode_strategy,
 		WPML_PB_Shortcode_Encoding $encoding,
-		WPML_PB_Reuse_Translations $reuse_translations = null
+		WPML_PB_Reuse_Translations_By_Strategy $reuse_translations = null
 	) {
 		$this->handle_strings         = $handle_strings;
 		$this->shortcode_strategy     = $shortcode_strategy;

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-register-shortcodes.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-register-shortcodes.php
@@ -73,7 +73,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$factory  = $this->get_factory( $wpdb, $sitepress_mock );
 		$strategy = $this->get_shortcode_strategy( $factory, $encode ? WPML_PB_Shortcode_Encoding::ENCODE_TYPES_BASE64 : '' );
 
-		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations' );
+		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations_By_Strategy' );
 		$reuse_translations_mock->shouldReceive( 'set_original_strings' );
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
@@ -119,7 +119,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 			                    $this->equalTo( 'VISUAL' )
 		                    );
 
-		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations' );
+		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations_By_Strategy' );
 		$reuse_translations_mock->shouldReceive( 'set_original_strings' );
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
@@ -187,7 +187,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$strategy->method( 'get_shortcode_attribute_encoding' )->willReturn( WPML_PB_Shortcode_Encoding::ENCODE_TYPES_BASE64 );
 		$strategy->expects( $this->once() )->method( 'remove_string' )->with( $string_data['dummy_data'] );
 
-		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations' );
+		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations_By_Strategy' );
 		$reuse_translations_mock->shouldReceive( 'set_original_strings' );
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
@@ -211,7 +211,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$strategy_mock->shouldReceive( 'get_package_strings' )->andReturn( $strings );
 		$strategy_mock->shouldReceive( 'remove_string' );
 
-		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations' );
+		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations_By_Strategy' );
 		$reuse_translations_mock->shouldReceive( 'set_original_strings' )->once()->with( $strings );
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' )->once()->with( $post_id, $strings );
 

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-reuse-translations.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-reuse-translations.php
@@ -89,7 +89,7 @@ class Test_WPML_PB_Reuse_Translations extends WPML_PB_TestCase {
 		                         ->with( $string_id_old_content )
 		                         ->andReturn( $string_old_content );
 
-		$subject = new WPML_PB_Reuse_Translations( $strategy_mock, $string_registration_mock );
+		$subject = new WPML_PB_Reuse_Translations_By_Strategy( $strategy_mock, $string_registration_mock );
 
 		$subject->set_original_strings( $original_strings );
 		$subject->find_and_reuse( $post_id, $leftover_strings );
@@ -160,7 +160,7 @@ class Test_WPML_PB_Reuse_Translations extends WPML_PB_TestCase {
 		                         ->with( $string_id_updated )
 		                         ->andReturn( $string_updated );
 
-		$subject = new WPML_PB_Reuse_Translations( $strategy_mock, $string_registration_mock );
+		$subject = new WPML_PB_Reuse_Translations_By_Strategy( $strategy_mock, $string_registration_mock );
 
 		$subject->set_original_strings( $original_strings );
 

--- a/tests/phpunit/tests/st/test-wpml-pb-factory.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-factory.php
@@ -30,7 +30,7 @@ class Test_WPML_PB_Factory extends WPML_PB_TestCase {
 	public function test_get_string_translations() {
 		$factory            = $this->get_factory_with_mocks();
 		$string_translation = $factory->get_string_translations( $this->get_shortcode_strategy( $factory ) );
-		$this->assertInstanceOf( 'WPML_PB_String_Translation', $string_translation );
+		$this->assertInstanceOf( 'WPML_PB_String_Translation_By_Strategy', $string_translation );
 	}
 
 	/**

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -234,7 +234,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$updated_package = $this->getMockBuilder( 'WPML_Package' )
 								->disableOriginalConstructor()->getMock();
 
-		$string_translation = $this->getMockBuilder( 'WPML_PB_String_Translation' )
+		$string_translation = $this->getMockBuilder( 'WPML_PB_String_Translation_By_Strategy' )
 		                           ->setMethods( array( 'save_translations_to_post', 'add_package_to_update_list' ) )
 		                           ->disableOriginalConstructor()
 		                           ->getMock();
@@ -326,7 +326,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$updated_package = $this->getMockBuilder( 'WPML_Package' )
 								->disableOriginalConstructor()->getMock();
 
-		$string_translation = $this->getMockBuilder( 'WPML_PB_String_Translation' )
+		$string_translation = $this->getMockBuilder( 'WPML_PB_String_Translation_By_Strategy' )
 		                           ->disableOriginalConstructor()
 		                           ->getMock();
 
@@ -799,7 +799,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	}
 
 	private function get_factory_mock_for_register_translations( $translated_string_id ) {
-		$string_translation_mock = $this->getMockBuilder( 'WPML_PB_String_Translation' )
+		$string_translation_mock = $this->getMockBuilder( 'WPML_PB_String_Translation_By_Strategy' )
 		                                ->setMethods( array( 'new_translation', 'save_translations_to_post' ) )
 		                                ->disableOriginalConstructor()
 		                                ->getMock();

--- a/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
@@ -26,7 +26,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 
 		$wpdb_mock = $this->get_wpdb_mock( $string_package_id, $language_1, $language_2 );
 
-		$pb_string_translation = new WPML_PB_String_Translation( $wpdb_mock, $factory_mock, $strategy_mock );
+		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb_mock, $factory_mock, $strategy_mock );
 		$pb_string_translation->new_translation( $translated_string_id );
 		$pb_string_translation->new_translation( $translated_string_id );
 		$pb_string_translation->save_translations_to_post();
@@ -45,7 +45,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		list( $factory_mock, $strategy_mock, $package ) = $this->get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2 );
 		$wpdb_mock = $this->get_wpdb_mock( $string_package_id, $language_1, $language_2 );
 
-		$pb_string_translation = new WPML_PB_String_Translation( $wpdb_mock, $factory_mock, $strategy_mock );
+		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb_mock, $factory_mock, $strategy_mock );
 		$pb_string_translation->add_package_to_update_list( $package, $language_1 );
 		$pb_string_translation->add_package_to_update_list( $package, $language_2 );
 		$pb_string_translation->save_translations_to_post();
@@ -143,7 +143,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		$field_type = 'package-string-' . $string_package_id . '-' . $translated_string_id;
 		$wpdb->expects( $this->exactly( 2 ) )->method( 'get_var' )->willReturnOnConsecutiveCalls( $job_id, $job_translated );
 		$wpdb->expects( $this->exactly( $delete_count ) )->method( 'delete' )->with( $wpdb->prefix . 'icl_translate', array( 'field_type' => $field_type ), array( '%s' ) );
-		$pb_string_translation = new WPML_PB_String_Translation( $wpdb, $factory_mock, $strategy_mock );
+		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb, $factory_mock, $strategy_mock );
 		$string_data = array(
 			'context'    => $context,
 			'name'       => $name,
@@ -183,7 +183,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		$field_type = 'package-string-' . $string_package_id . '-' . $translated_string_id;
 		$wpdb->expects( $this->exactly( 1 ) )->method( 'get_var' )->willReturn( $job_id );
 		$wpdb->expects( $this->exactly( 1 ) )->method( 'delete' )->with( $wpdb->prefix . 'icl_translate', array( 'field_type' => $field_type ), array( '%s' ) );
-		$pb_string_translation = new WPML_PB_String_Translation( $wpdb, $factory_mock, $strategy_mock );
+		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb, $factory_mock, $strategy_mock );
 		$string_data = array(
 			'context'    => $context,
 			'name'       => $name,

--- a/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
@@ -71,7 +71,7 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 		$string_handler->shouldReceive( 'get_string_id_from_package' )->andReturn( 'anything' );
 		$string_handler->shouldReceive( 'get_string_title' )->andReturn( 'anything' );
 
-		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations' );
+		$reuse_translations_mock = Mockery::mock( 'WPML_PB_Reuse_Translations_By_Strategy' );
 		$reuse_translations_mock->shouldReceive( 'set_original_strings' );
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 


### PR DESCRIPTION
This change is required for the Gutenberg package (https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/pull/27).

Actually, I did as follow:
- Rename the existing classes with '_By_Strategy'
- Create new classes with the original names
- Move base code to the new classes
- Make '_By_Strategy' classes extend the new classes

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6326