### PR TITLE
Mark headings in XLIFFs so that ATE can indicate that these fields have SEO significance.

### DIFF
--- a/src/st/class-wpml-pb-string-registration.php
+++ b/src/st/class-wpml-pb-string-registration.php
@@ -65,16 +65,19 @@ class WPML_PB_String_Registration {
 	}
 
 	/**
-	 * @param int $post_id
-	 * @param string $content
-	 * @param string $type
-	 * @param string $title
-	 * @param string $name
-	 * @param int $location
+	 * Register string.
+	 *
+	 * @param int    $post_id  Post Id.
+	 * @param string $content  String content.
+	 * @param string $type     String editor type.
+	 * @param string $title    String title.
+	 * @param string $name     String name.
+	 * @param int    $location String location.
+	 * @param string $wrap     String wrap.
 	 *
 	 * @return int $string_id
 	 */
-	public function register_string( $post_id, $content = '', $type = 'LINE', $title = '', $name = '', $location = 0 ) {
+	public function register_string( $post_id, $content = '', $type = 'LINE', $title = '', $name = '', $location = 0, $wrap = '' ) {
 
 		$string_id = 0;
 
@@ -86,6 +89,7 @@ class WPML_PB_String_Registration {
 
 				$string_id = $this->get_string_id_from_package( $post_id, $content, $string_name );
 				$this->set_location( $string_id, $location );
+				$this->set_wrap( $string_id, $wrap );
 
 			} else {
 
@@ -100,6 +104,7 @@ class WPML_PB_String_Registration {
 
 				$string_id = $this->get_string_id_from_package( $post_id, $content, $string_name );
 				$this->set_location( $string_id, $location );
+				$this->set_wrap( $string_id, $wrap );
 
 				if ( 'LINK' === $type ) {
 					$this->set_link_translations( $string_id );
@@ -117,6 +122,17 @@ class WPML_PB_String_Registration {
 	private function set_location( $string_id, $location ) {
 		$string = $this->string_factory->find_by_id( $string_id );
 		$string->set_location( $location );
+	}
+
+	/**
+	 * Set string wrap.
+	 *
+	 * @param int $string_id String id.
+	 * @param int $wrap String wrap.
+	 */
+	private function set_wrap( $string_id, $wrap ) {
+		$string = $this->string_factory->find_by_id( $string_id );
+		$string->set_wrap( $wrap );
 	}
 
 	private function set_link_translations( $string_id ) {

--- a/src/st/class-wpml-pb-string-registration.php
+++ b/src/st/class-wpml-pb-string-registration.php
@@ -77,7 +77,15 @@ class WPML_PB_String_Registration {
 	 *
 	 * @return int $string_id
 	 */
-	public function register_string( $post_id, $content = '', $type = 'LINE', $title = '', $name = '', $location = 0, $wrap_tag = '' ) {
+	public function register_string(
+		$post_id,
+		$content = '',
+		$type = 'LINE',
+		$title = '',
+		$name = '',
+		$location = 0,
+		$wrap_tag = ''
+	) {
 
 		$string_id = 0;
 
@@ -88,8 +96,7 @@ class WPML_PB_String_Registration {
 			if ( $this->migration_mode ) {
 
 				$string_id = $this->get_string_id_from_package( $post_id, $content, $string_name );
-				$this->set_location( $string_id, $location );
-				$this->set_wrap_tag( $string_id, $wrap_tag );
+				$this->update_string_data( $string_id, $location, $wrap_tag );
 
 			} else {
 
@@ -103,8 +110,7 @@ class WPML_PB_String_Registration {
 				do_action( 'wpml_register_string', $string_value, $string_name, $package, $string_title, $type );
 
 				$string_id = $this->get_string_id_from_package( $post_id, $content, $string_name );
-				$this->set_location( $string_id, $location );
-				$this->set_wrap_tag( $string_id, $wrap_tag );
+				$this->update_string_data( $string_id, $location, $wrap_tag );
 
 				if ( 'LINK' === $type ) {
 					$this->set_link_translations( $string_id );
@@ -116,23 +122,16 @@ class WPML_PB_String_Registration {
 	}
 
 	/**
-	 * @param int $string_id
-	 * @param int $location
-	 */
-	private function set_location( $string_id, $location ) {
-		$string = $this->string_factory->find_by_id( $string_id );
-		$string->set_location( $location );
-	}
-
-	/**
-	 * Set string wrap tag.
-	 * Used for SEO significance, can contain values as h1 ... h6, etc.
+	 * Update string data: location and wrap tag.
+	 * Wrap tag is used for SEO significance, can contain values as h1 ... h6, etc.
 	 *
 	 * @param int    $string_id String id.
-	 * @param string $wrap_tag  String wrap tag.
+	 * @param string $location  String location inside of the page builder content.
+	 * @param string $wrap_tag  String wrap tag for SEO significance.
 	 */
-	private function set_wrap_tag( $string_id, $wrap_tag ) {
+	private function update_string_data( $string_id, $location, $wrap_tag ) {
 		$string = $this->string_factory->find_by_id( $string_id );
+		$string->set_location( $location );
 		$string->set_wrap_tag( $wrap_tag );
 	}
 

--- a/src/st/class-wpml-pb-string-registration.php
+++ b/src/st/class-wpml-pb-string-registration.php
@@ -73,11 +73,11 @@ class WPML_PB_String_Registration {
 	 * @param string $title    String title.
 	 * @param string $name     String name.
 	 * @param int    $location String location.
-	 * @param string $wrap     String wrap.
+	 * @param string $wrap_tag String wrap tag.
 	 *
 	 * @return int $string_id
 	 */
-	public function register_string( $post_id, $content = '', $type = 'LINE', $title = '', $name = '', $location = 0, $wrap = '' ) {
+	public function register_string( $post_id, $content = '', $type = 'LINE', $title = '', $name = '', $location = 0, $wrap_tag = '' ) {
 
 		$string_id = 0;
 
@@ -89,7 +89,7 @@ class WPML_PB_String_Registration {
 
 				$string_id = $this->get_string_id_from_package( $post_id, $content, $string_name );
 				$this->set_location( $string_id, $location );
-				$this->set_wrap( $string_id, $wrap );
+				$this->set_wrap_tag( $string_id, $wrap_tag );
 
 			} else {
 
@@ -104,7 +104,7 @@ class WPML_PB_String_Registration {
 
 				$string_id = $this->get_string_id_from_package( $post_id, $content, $string_name );
 				$this->set_location( $string_id, $location );
-				$this->set_wrap( $string_id, $wrap );
+				$this->set_wrap_tag( $string_id, $wrap_tag );
 
 				if ( 'LINK' === $type ) {
 					$this->set_link_translations( $string_id );
@@ -125,14 +125,15 @@ class WPML_PB_String_Registration {
 	}
 
 	/**
-	 * Set string wrap.
+	 * Set string wrap tag.
+	 * Used for SEO significance, can contain values as h1 ... h6, etc.
 	 *
-	 * @param int $string_id String id.
-	 * @param int $wrap String wrap.
+	 * @param int    $string_id String id.
+	 * @param string $wrap_tag  String wrap tag.
 	 */
-	private function set_wrap( $string_id, $wrap ) {
+	private function set_wrap_tag( $string_id, $wrap_tag ) {
 		$string = $this->string_factory->find_by_id( $string_id );
-		$string->set_wrap( $wrap );
+		$string->set_wrap_tag( $wrap_tag );
 	}
 
 	private function set_link_translations( $string_id ) {

--- a/src/st/class-wpml-pb-string-registration.php
+++ b/src/st/class-wpml-pb-string-registration.php
@@ -75,7 +75,7 @@ class WPML_PB_String_Registration {
 	 * @param int    $location String location.
 	 * @param string $wrap_tag String wrap tag.
 	 *
-	 * @return int $string_id
+	 * @return null|integer $string_id
 	 */
 	public function register_string(
 		$post_id,

--- a/src/st/class-wpml-pb-string.php
+++ b/src/st/class-wpml-pb-string.php
@@ -12,11 +12,28 @@ class WPML_PB_String {
 	/** @var  string $editor_type */
 	private $editor_type;
 
-	public function __construct( $value, $name, $title, $editor_type ) {
+	/**
+	 * String wrap tag.
+	 *
+	 * @var  string $wrap
+	 */
+	private $wrap;
+
+	/**
+	 * WPML_PB_String constructor.
+	 *
+	 * @param string $value       String value.
+	 * @param string $name        String name.
+	 * @param string $title       String title.
+	 * @param string $editor_type Editor type used.
+	 * @param string $wrap        String wrap tag.
+	 */
+	public function __construct( $value, $name, $title, $editor_type, $wrap = '' ) {
 		$this->value       = $value;
 		$this->name        = $name;
 		$this->title       = $title;
 		$this->editor_type = $editor_type;
+		$this->wrap        = $wrap;
 	}
 
 	/**
@@ -54,4 +71,12 @@ class WPML_PB_String {
 		return $this->editor_type;
 	}
 
+	/**
+	 * Get string wrap tag.
+	 *
+	 * @return string
+	 */
+	public function get_wrap() {
+		return $this->wrap;
+	}
 }

--- a/src/st/class-wpml-pb-string.php
+++ b/src/st/class-wpml-pb-string.php
@@ -15,9 +15,9 @@ class WPML_PB_String {
 	/**
 	 * String wrap tag.
 	 *
-	 * @var  string $wrap
+	 * @var  string $wrap_tag
 	 */
-	private $wrap;
+	private $wrap_tag;
 
 	/**
 	 * WPML_PB_String constructor.
@@ -26,14 +26,14 @@ class WPML_PB_String {
 	 * @param string $name        String name.
 	 * @param string $title       String title.
 	 * @param string $editor_type Editor type used.
-	 * @param string $wrap        String wrap tag.
+	 * @param string $wrap_tag    String wrap tag.
 	 */
-	public function __construct( $value, $name, $title, $editor_type, $wrap = '' ) {
+	public function __construct( $value, $name, $title, $editor_type, $wrap_tag = '' ) {
 		$this->value       = $value;
 		$this->name        = $name;
 		$this->title       = $title;
 		$this->editor_type = $editor_type;
-		$this->wrap        = $wrap;
+		$this->wrap_tag    = $wrap_tag;
 	}
 
 	/**
@@ -76,7 +76,7 @@ class WPML_PB_String {
 	 *
 	 * @return string
 	 */
-	public function get_wrap() {
-		return $this->wrap;
+	public function get_wrap_tag() {
+		return $this->wrap_tag;
 	}
 }

--- a/src/st/compatibility/class-wpml-page-builders-register-strings.php
+++ b/src/st/compatibility/class-wpml-page-builders-register-strings.php
@@ -78,7 +78,7 @@ abstract class WPML_Page_Builders_Register_Strings {
 				$string->get_title(),
 				$string->get_name(),
 				$this->string_location,
-				$string->get_wrap()
+				$string->get_wrap_tag()
 			);
 
 			$this->string_location++;

--- a/src/st/compatibility/class-wpml-page-builders-register-strings.php
+++ b/src/st/compatibility/class-wpml-page-builders-register-strings.php
@@ -77,7 +77,8 @@ abstract class WPML_Page_Builders_Register_Strings {
 				$string->get_editor_type(),
 				$string->get_title(),
 				$string->get_name(),
-				$this->string_location
+				$this->string_location,
+				$string->get_wrap()
 			);
 
 			$this->string_location++;

--- a/src/tm/class-wpml-tm-page-builders-field-wrapper.php
+++ b/src/tm/class-wpml-tm-page-builders-field-wrapper.php
@@ -94,20 +94,14 @@ class WPML_TM_Page_Builders_Field_Wrapper {
 	}
 
 	/**
-	 * @param string $string_name
+	 * Get string wrap.
+	 *
+	 * @param stdClass $string WPML string.
 	 *
 	 * @return string
 	 */
-	public static function get_wrap( $string_name ) {
-		$heading = '';
-		if ( strpos( $string_name, '-heading-' ) ) {
-			$name_arr = explode( '-', $string_name );
-			if ( isset( $name_arr[3] ) ) {
-				$heading = $name_arr[3];
-			}
-		}
-
-		return $heading;
+	public static function get_wrap( $string ) {
+		return isset( $string->wrap ) ? $string->wrap : '';
 	}
 
 	/**
@@ -117,11 +111,7 @@ class WPML_TM_Page_Builders_Field_Wrapper {
 	 * @return string
 	 */
 	public static function generate_field_slug( $package_id, $string ) {
-		$wrap = self::get_wrap( $string->name );
-		if ( '' !== $wrap ) {
-			$wrap = '-' . $wrap;
-		}
-		return self::SLUG_BASE . $package_id . '-' . $string->id . $wrap;
+		return self::SLUG_BASE . $package_id . '-' . $string->id;
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders-field-wrapper.php
+++ b/src/tm/class-wpml-tm-page-builders-field-wrapper.php
@@ -94,13 +94,34 @@ class WPML_TM_Page_Builders_Field_Wrapper {
 	}
 
 	/**
-	 * @param int $package_id
-	 * @param int $string_id
+	 * @param string $string_name
 	 *
 	 * @return string
 	 */
-	public static function generate_field_slug( $package_id, $string_id ) {
-		return self::SLUG_BASE . $package_id . '-' . $string_id;
+	public static function get_wrap( $string_name ) {
+		$heading = '';
+		if ( strpos( $string_name, '-heading-' ) ) {
+			$name_arr = explode( '-', $string_name );
+			if ( isset( $name_arr[3] ) ) {
+				$heading = $name_arr[3];
+			}
+		}
+
+		return $heading;
+	}
+
+	/**
+	 * @param int $package_id
+	 * @param stdClass $string
+	 *
+	 * @return string
+	 */
+	public static function generate_field_slug( $package_id, $string ) {
+		$wrap = self::get_wrap( $string->name );
+		if ( '' !== $wrap ) {
+			$wrap = '-' . $wrap;
+		}
+		return self::SLUG_BASE . $package_id . '-' . $string->id . $wrap;
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders-field-wrapper.php
+++ b/src/tm/class-wpml-tm-page-builders-field-wrapper.php
@@ -94,14 +94,14 @@ class WPML_TM_Page_Builders_Field_Wrapper {
 	}
 
 	/**
-	 * Get string wrap.
+	 * Get string wrap tag.
 	 *
 	 * @param stdClass $string WPML string.
 	 *
 	 * @return string
 	 */
-	public static function get_wrap( $string ) {
-		return isset( $string->wrap ) ? $string->wrap : '';
+	public static function get_wrap_tag( $string ) {
+		return isset( $string->wrap_tag ) ? $string->wrap_tag : '';
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders-field-wrapper.php
+++ b/src/tm/class-wpml-tm-page-builders-field-wrapper.php
@@ -105,13 +105,15 @@ class WPML_TM_Page_Builders_Field_Wrapper {
 	}
 
 	/**
-	 * @param int $package_id
-	 * @param stdClass $string
+	 * Generate field slug.
+	 *
+	 * @param int $package_id Package id.
+	 * @param int $string_id String id.
 	 *
 	 * @return string
 	 */
-	public static function generate_field_slug( $package_id, $string ) {
-		return self::SLUG_BASE . $package_id . '-' . $string->id;
+	public static function generate_field_slug( $package_id, $string_id ) {
+		return self::SLUG_BASE . $package_id . '-' . $string_id;
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders-hooks.php
+++ b/src/tm/class-wpml-tm-page-builders-hooks.php
@@ -57,7 +57,13 @@ class WPML_TM_Page_Builders_Hooks {
 	public function adjust_translation_fields_filter( array $fields, $job ) {
 		$worker = $this->get_worker();
 
-		return $worker->adjust_translation_fields_filter( $fields, $job );
+		$fields = $worker->adjust_translation_fields_filter( $fields, $job );
+		foreach ( $fields as &$field ) {
+			if ( isset( $field['field_wrap_tag'] ) && $field['field_wrap_tag'] ) {
+				$field['title'] = $field['field_wrap_tag'];
+			}
+		}
+		return $fields;
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders-hooks.php
+++ b/src/tm/class-wpml-tm-page-builders-hooks.php
@@ -59,7 +59,13 @@ class WPML_TM_Page_Builders_Hooks {
 	public function adjust_translation_fields_filter( array $fields, $job ) {
 		$worker = $this->get_worker();
 
-		return $worker->adjust_translation_fields_filter( $fields, $job );
+		$fields = $worker->adjust_translation_fields_filter( $fields, $job );
+		foreach ( $fields as &$field ) {
+			if ( isset( $field['field_wrap_tag'] ) && $field['field_wrap_tag'] ) {
+				$field['title'] = $field['field_wrap_tag'];
+			}
+		}
+		return $fields;
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders-hooks.php
+++ b/src/tm/class-wpml-tm-page-builders-hooks.php
@@ -60,7 +60,7 @@ class WPML_TM_Page_Builders_Hooks {
 		$fields = $worker->adjust_translation_fields_filter( $fields, $job );
 		foreach ( $fields as &$field ) {
 			if ( isset( $field['field_wrap_tag'] ) && $field['field_wrap_tag'] ) {
-				$field['title'] = $field['field_wrap_tag'];
+				$field['title'] .= ' (' . $field['field_wrap_tag'] . ')';
 			}
 		}
 		return $fields;

--- a/src/tm/class-wpml-tm-page-builders-hooks.php
+++ b/src/tm/class-wpml-tm-page-builders-hooks.php
@@ -58,13 +58,8 @@ class WPML_TM_Page_Builders_Hooks {
 	 */
 	public function adjust_translation_fields_filter( array $fields, $job ) {
 		$worker = $this->get_worker();
-
 		$fields = $worker->adjust_translation_fields_filter( $fields, $job );
-		foreach ( $fields as &$field ) {
-			if ( isset( $field['field_wrap_tag'] ) && $field['field_wrap_tag'] ) {
-				$field['title'] = $field['field_wrap_tag'];
-			}
-		}
+
 		return $fields;
 	}
 

--- a/src/tm/class-wpml-tm-page-builders-hooks.php
+++ b/src/tm/class-wpml-tm-page-builders-hooks.php
@@ -49,8 +49,10 @@ class WPML_TM_Page_Builders_Hooks {
 	}
 
 	/**
-	 * @param array    $fields
-	 * @param stdClass $job
+	 * Filter translation fields.
+	 *
+	 * @param array    $fields Translation fields.
+	 * @param stdClass $job    Translation job.
 	 *
 	 * @return array
 	 */
@@ -58,11 +60,7 @@ class WPML_TM_Page_Builders_Hooks {
 		$worker = $this->get_worker();
 
 		$fields = $worker->adjust_translation_fields_filter( $fields, $job );
-		foreach ( $fields as &$field ) {
-			if ( isset( $field['field_wrap_tag'] ) && $field['field_wrap_tag'] ) {
-				$field['title'] .= ' (' . $field['field_wrap_tag'] . ')';
-			}
-		}
+
 		return $fields;
 	}
 

--- a/src/tm/class-wpml-tm-page-builders-hooks.php
+++ b/src/tm/class-wpml-tm-page-builders-hooks.php
@@ -59,9 +59,7 @@ class WPML_TM_Page_Builders_Hooks {
 	public function adjust_translation_fields_filter( array $fields, $job ) {
 		$worker = $this->get_worker();
 
-		$fields = $worker->adjust_translation_fields_filter( $fields, $job );
-
-		return $fields;
+		return $worker->adjust_translation_fields_filter( $fields, $job );
 	}
 
 	/**

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -45,7 +45,7 @@ class WPML_TM_Page_Builders {
 					/* @var WPML_Package $string_package */
 					$strings             = $string_package->get_package_strings();
 					$string_translations = array();
-					
+
 					if ( $job_source_is_not_post_source ) {
 						$string_translations = $string_package->get_translated_strings( array() );
 					}
@@ -64,7 +64,7 @@ class WPML_TM_Page_Builders {
 							$translation_package['contents'][ $field_name ] = array(
 								'translate' => 1,
 								'data'      => base64_encode( $string_value ),
-								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string->name ),
+								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string ),
 								'format'    => 'base64',
 							);
 						}

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -59,11 +59,12 @@ class WPML_TM_Page_Builders {
 								$string_value = $string_translations[ $string->name ][ $job_lang_from ]['value'];
 							}
 
-							$field_name = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string->id );
+							$field_name = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
 
 							$translation_package['contents'][ $field_name ] = array(
 								'translate' => 1,
 								'data'      => base64_encode( $string_value ),
+								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string->name ),
 								'format'    => 'base64',
 							);
 						}

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -16,8 +16,10 @@ class WPML_TM_Page_Builders {
 	}
 
 	/**
-	 * @param array $translation_package
-	 * @param mixed $post
+	 * Filter translation job data.
+	 *
+	 * @param array $translation_package Translation package.
+	 * @param mixed $post                Post.
 	 *
 	 * @return array
 	 */
@@ -42,7 +44,11 @@ class WPML_TM_Page_Builders {
 
 				foreach ( $string_packages as $package_id => $string_package ) {
 
-					/* @var WPML_Package $string_package */
+					/**
+					 * String package.
+					 *
+					 * @var WPML_Package $string_package
+					 */
 					$strings             = $string_package->get_package_strings();
 					$string_translations = array();
 
@@ -52,18 +58,23 @@ class WPML_TM_Page_Builders {
 
 					foreach ( $strings as $string ) {
 
-						if ( $string->type != self::FIELD_STYLE_LINK ) {
+						if ( self::FIELD_STYLE_LINK !== $string->type ) {
 							$string_value = $string->value;
 
 							if ( isset( $string_translations[ $string->name ][ $job_lang_from ]['value'] ) ) {
 								$string_value = $string_translations[ $string->name ][ $job_lang_from ]['value'];
 							}
 
-							$field_name = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
+							$field_name = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug(
+								$package_id,
+								$string->id
+							);
 
 							$translation_package['contents'][ $field_name ] = array(
 								'translate' => 1,
+								// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 								'data'      => base64_encode( $string_value ),
+								// phpcs:enable
 								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap_tag( $string ),
 								'format'    => 'base64',
 							);

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -118,8 +118,10 @@ class WPML_TM_Page_Builders {
 	}
 
 	/**
-	 * @param array    $fields
-	 * @param stdClass $job
+	 * Adjust translation fields.
+	 *
+	 * @param array    $fields Translation fields.
+	 * @param stdClass $job    Translation job.
 	 *
 	 * @return array
 	 */
@@ -131,6 +133,12 @@ class WPML_TM_Page_Builders {
 
 			if ( $string_title ) {
 				$field['title'] = $string_title;
+			}
+
+			if ( isset( $field['field_wrap_tag'] ) && $field['field_wrap_tag'] ) {
+				$field['title'] = isset( $field['title'] ) ? $field['title'] : '';
+
+				$field['title'] .= ' (' . $field['field_wrap_tag'] . ')';
 			}
 
 			if ( false !== $type ) {

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -64,7 +64,7 @@ class WPML_TM_Page_Builders {
 							$translation_package['contents'][ $field_name ] = array(
 								'translate' => 1,
 								'data'      => base64_encode( $string_value ),
-								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string ),
+								'wrap_tag'  => WPML_TM_Page_Builders_Field_Wrapper::get_wrap_tag( $string ),
 								'format'    => 'base64',
 							);
 						}

--- a/tests/phpunit/tests/st/test-wpml-pb-string-registration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-registration.php
@@ -17,6 +17,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$post->ID        = $post_id;
 		$post->post_type = 'page';
 		$location        = mt_rand( 1, 100 );
+		$wrap            = '';
 
 		$expected_package_data = $this->get_expected_package( $post_id );
 		$shortcode_content     = rand_long_str( 10 );
@@ -38,6 +39,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string_factory = $this->get_string_factory_mock();
 		$string         = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'set_location' )->once()->with( $location );
+		$string->shouldReceive( 'set_wrap' )->once()->with( $wrap );
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
 
 		$string_handler = new WPML_PB_String_Registration( $strategy,
@@ -45,12 +47,15 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		                                                   $this->get_package_factory_mock(),
 		                                                   Mockery::mock( 'WPML_Translate_Link_Targets' ),
 		                                                   array() );
-		$string_handler->register_string( $post_id,
-		                                  $shortcode_content,
-		                                  'VISUAL',
-		                                  $string_title,
-		                                  $string_name,
-		                                  $location );
+		$string_handler->register_string(
+			$post_id,
+			$shortcode_content,
+			'VISUAL',
+			$string_title,
+			$string_name,
+			$location,
+			$wrap
+		);
 		unset( $post );
 	}
 
@@ -83,6 +88,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$post->ID        = $post_id;
 		$post->post_type = 'page';
 		$location        = mt_rand();
+		$wrap            = '';
 
 		$expected_package_data = $this->get_expected_package( $post_id );
 		$shortcode_content     = 'http://somelink.com';
@@ -111,6 +117,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string->shouldReceive( 'get_value' )->andReturn( $shortcode_content );
 		$string->shouldReceive( 'set_translation' )->once()->with( 'fr', $shortcode_content );
 		$string->shouldReceive( 'set_location' )->once()->with( $location );
+		$string->shouldReceive( 'set_wrap' )->once()->with( $wrap );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
@@ -123,7 +130,15 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		                                                   $package_factory,
 		                                                   $translate_link_targets,
 		                                                   array( array( 'code' => 'fr' ) ) );
-		$string_handler->register_string( $post_id, $shortcode_content, 'LINK', '', '', $location );
+		$string_handler->register_string(
+			$post_id,
+			$shortcode_content,
+			'LINK',
+			'',
+			'',
+			$location,
+			$wrap
+		);
 		unset( $post );
 	}
 
@@ -137,6 +152,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$offsite_link_url = 'http://www.google.com';
 		$title            = rand_str();
 		$location         = mt_rand();
+		$wrap             = '';
 
 		$translate_link_targets = \Mockery::mock( 'WPML_Translate_Link_Targets' );
 		$translate_link_targets->shouldReceive( 'is_internal_url' )->with( $offsite_link_url )->andReturn( false );
@@ -152,6 +168,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'get_translation_statuses' )->andReturn( array() );
 		$string->shouldReceive( 'set_location' )->times( 2 )->with( $location );
+		$string->shouldReceive( 'set_wrap' )->times( 2 )->with( $wrap );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
@@ -168,7 +185,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		                        $strategy->get_package_key( $post_id ),
 		                        $title,
 		                        'LINK' );
-		$string_handler->register_string( $post_id, $local_link_url, 'LINK', $title, '', $location );
+		$string_handler->register_string( $post_id, $local_link_url, 'LINK', $title, '', $location, $wrap );
 
 		\WP_Mock::expectAction( 'wpml_register_string',
 		                        $offsite_link_url,
@@ -177,7 +194,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		                        $title,
 		                        'LINE'  // Offsite links should be changed to LINE
 		);
-		$string_handler->register_string( $post_id, $offsite_link_url, 'LINK', $title, '', $location );
+		$string_handler->register_string( $post_id, $offsite_link_url, 'LINK', $title, '', $location, $wrap );
 	}
 
 	/**
@@ -193,6 +210,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 
 		$post_id  = mt_rand();
 		$location = mt_rand();
+		$wrap     = '';
 
 		$sitepress_mock = $this->get_sitepress_mock();
 		$wpdb           = null;
@@ -201,6 +219,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 
 		$string = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'set_location' )->times( 1 )->with( $location );
+		$string->shouldReceive( 'set_wrap' )->times( 1 )->with( $wrap );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
@@ -225,7 +244,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		} else {
 			\WP_Mock::expectAction( 'wpml_register_string', $content, $string_name, $package, $title, $type );
 		}
-		$string_handler->register_string( $post_id, $content, $type, $title, '', $location );
+		$string_handler->register_string( $post_id, $content, $type, $title, '', $location, $wrap );
 	}
 
 	public function on_wpml_register_string_action() {

--- a/tests/phpunit/tests/st/test-wpml-pb-string-registration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-registration.php
@@ -17,7 +17,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$post->ID        = $post_id;
 		$post->post_type = 'page';
 		$location        = mt_rand( 1, 100 );
-		$wrap            = '';
+		$wrap_tag            = 'h2';
 
 		$expected_package_data = $this->get_expected_package( $post_id );
 		$shortcode_content     = rand_long_str( 10 );
@@ -39,7 +39,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string_factory = $this->get_string_factory_mock();
 		$string         = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'set_location' )->once()->with( $location );
-		$string->shouldReceive( 'set_wrap_tag' )->once()->with( $wrap );
+		$string->shouldReceive( 'set_wrap_tag' )->once()->with( $wrap_tag );
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
 
 		$string_handler = new WPML_PB_String_Registration( $strategy,
@@ -54,7 +54,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 			$string_title,
 			$string_name,
 			$location,
-			$wrap
+			$wrap_tag
 		);
 		unset( $post );
 	}
@@ -88,7 +88,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$post->ID        = $post_id;
 		$post->post_type = 'page';
 		$location        = mt_rand();
-		$wrap            = '';
+		$wrap_tag            = 'h2';
 
 		$expected_package_data = $this->get_expected_package( $post_id );
 		$shortcode_content     = 'http://somelink.com';
@@ -117,7 +117,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string->shouldReceive( 'get_value' )->andReturn( $shortcode_content );
 		$string->shouldReceive( 'set_translation' )->once()->with( 'fr', $shortcode_content );
 		$string->shouldReceive( 'set_location' )->once()->with( $location );
-		$string->shouldReceive( 'set_wrap_tag' )->once()->with( $wrap );
+		$string->shouldReceive( 'set_wrap_tag' )->once()->with( $wrap_tag );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
@@ -137,7 +137,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 			'',
 			'',
 			$location,
-			$wrap
+			$wrap_tag
 		);
 		unset( $post );
 	}
@@ -152,7 +152,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$offsite_link_url = 'http://www.google.com';
 		$title            = rand_str();
 		$location         = mt_rand();
-		$wrap             = '';
+		$wrap_tag             = 'h2';
 
 		$translate_link_targets = \Mockery::mock( 'WPML_Translate_Link_Targets' );
 		$translate_link_targets->shouldReceive( 'is_internal_url' )->with( $offsite_link_url )->andReturn( false );
@@ -168,7 +168,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'get_translation_statuses' )->andReturn( array() );
 		$string->shouldReceive( 'set_location' )->times( 2 )->with( $location );
-		$string->shouldReceive( 'set_wrap_tag' )->times( 2 )->with( $wrap );
+		$string->shouldReceive( 'set_wrap_tag' )->times( 2 )->with( $wrap_tag );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
@@ -185,7 +185,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		                        $strategy->get_package_key( $post_id ),
 		                        $title,
 		                        'LINK' );
-		$string_handler->register_string( $post_id, $local_link_url, 'LINK', $title, '', $location, $wrap );
+		$string_handler->register_string( $post_id, $local_link_url, 'LINK', $title, '', $location, $wrap_tag );
 
 		\WP_Mock::expectAction( 'wpml_register_string',
 		                        $offsite_link_url,
@@ -194,7 +194,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		                        $title,
 		                        'LINE'  // Offsite links should be changed to LINE
 		);
-		$string_handler->register_string( $post_id, $offsite_link_url, 'LINK', $title, '', $location, $wrap );
+		$string_handler->register_string( $post_id, $offsite_link_url, 'LINK', $title, '', $location, $wrap_tag );
 	}
 
 	/**
@@ -210,7 +210,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 
 		$post_id  = mt_rand();
 		$location = mt_rand();
-		$wrap     = '';
+		$wrap_tag     = 'h2';
 
 		$sitepress_mock = $this->get_sitepress_mock();
 		$wpdb           = null;
@@ -219,7 +219,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 
 		$string = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'set_location' )->times( 1 )->with( $location );
-		$string->shouldReceive( 'set_wrap_tag' )->times( 1 )->with( $wrap );
+		$string->shouldReceive( 'set_wrap_tag' )->times( 1 )->with( $wrap_tag );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
@@ -244,7 +244,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		} else {
 			\WP_Mock::expectAction( 'wpml_register_string', $content, $string_name, $package, $title, $type );
 		}
-		$string_handler->register_string( $post_id, $content, $type, $title, '', $location, $wrap );
+		$string_handler->register_string( $post_id, $content, $type, $title, '', $location, $wrap_tag );
 	}
 
 	public function on_wpml_register_string_action() {

--- a/tests/phpunit/tests/st/test-wpml-pb-string-registration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-registration.php
@@ -39,7 +39,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string_factory = $this->get_string_factory_mock();
 		$string         = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'set_location' )->once()->with( $location );
-		$string->shouldReceive( 'set_wrap' )->once()->with( $wrap );
+		$string->shouldReceive( 'set_wrap_tag' )->once()->with( $wrap );
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
 
 		$string_handler = new WPML_PB_String_Registration( $strategy,
@@ -117,7 +117,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string->shouldReceive( 'get_value' )->andReturn( $shortcode_content );
 		$string->shouldReceive( 'set_translation' )->once()->with( 'fr', $shortcode_content );
 		$string->shouldReceive( 'set_location' )->once()->with( $location );
-		$string->shouldReceive( 'set_wrap' )->once()->with( $wrap );
+		$string->shouldReceive( 'set_wrap_tag' )->once()->with( $wrap );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
@@ -168,7 +168,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'get_translation_statuses' )->andReturn( array() );
 		$string->shouldReceive( 'set_location' )->times( 2 )->with( $location );
-		$string->shouldReceive( 'set_wrap' )->times( 2 )->with( $wrap );
+		$string->shouldReceive( 'set_wrap_tag' )->times( 2 )->with( $wrap );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );
@@ -219,7 +219,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 
 		$string = \Mockery::mock( 'WPML_ST_String' );
 		$string->shouldReceive( 'set_location' )->times( 1 )->with( $location );
-		$string->shouldReceive( 'set_wrap' )->times( 1 )->with( $wrap );
+		$string->shouldReceive( 'set_wrap_tag' )->times( 1 )->with( $wrap );
 
 		$string_factory = $this->get_string_factory_mock();
 		$string_factory->shouldReceive( 'find_by_id' )->andReturn( $string );

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -209,11 +209,11 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @dataProvider get_wrap_data_provider
 	 * @group wpmltm-3081
 	 *
-	 * @param string $string_name
+	 * @param stdClass $string
 	 * @param string $expected
 	 */
-	public function get_wrap( $string_name, $expected ) {
-		$wrap = WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string_name );
+	public function get_wrap( $string, $expected ) {
+		$wrap = WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string );
 		$this->assertEquals( $expected, $wrap );
 	}
 
@@ -222,11 +222,11 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 */
 	function get_wrap_data_provider() {
 		return array(
-			'Empty string'       => array( '', '' ),
-			'Normal string'      => array( 'title-heading-f327e9c', '' ),
-			'Text editor string' => array( 'editor-text-editor-c12e1e6', '' ),
-			'Heading'            => array( 'title-heading-8e0908e', '' ),
-			'Heading h2'         => array( 'title-heading-8e0908e-h2', 'h2' ),
+			'Empty string'       => array( $this->get_string( 10, '', '' ), '' ),
+			'Normal string'      => array( $this->get_string( 10, 'title-heading-f327e9c', '' ), '' ),
+			'Text editor string' => array( $this->get_string( 10, 'editor-text-editor-c12e1e6', '' ), '' ),
+			'Heading'            => array( $this->get_string( 10, 'title-heading-8e0908e', '' ), '' ),
+			'Heading h2'         => array( $this->get_string( 10, 'title-heading-8e0908e', 'h2' ), 'h2' ),
 		);
 	}
 
@@ -236,5 +236,20 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	private function create_subject() {
 		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string );
 		return new WPML_TM_Page_Builders_Field_Wrapper( $slug );
+	}
+
+	/**
+	 * @param string $id
+	 * @param string $name
+	 * @param string $wrap
+	 *
+	 * @return stdClass
+	 */
+	private function get_string( $id, $name = 'string_name', $wrap = '' ) {
+		$string       = new stdClass();
+		$string->id   = $id;
+		$string->name = $name;
+		$string->wrap = $wrap;
+		return $string;
 	}
 }

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -9,6 +9,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 
 	private $package_id;
 	private $string_id;
+	private $string;
 	private $string_title;
 
 	function setUp() {
@@ -26,7 +27,12 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 		) );
 
 		$this->package_id = 10;
-		$this->string_id = 12;
+		$this->string_id  = 12;
+
+		$this->string       = new stdClass();
+		$this->string->id   = $this->string_id;
+		$this->string->name = 'string_name';
+
 		$this->string_title = rand_str( 10 );
 
 		\WP_Mock::onFilter( 'wpml_string_title_from_id' )
@@ -91,6 +97,11 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	function it_validates_without_checking_of_package( $package_id, $string_id, $expected_result ) {
 		$this->package_id = $package_id;
 		$this->string_id = $string_id;
+
+		$this->string       = new stdClass();
+		$this->string->id   = $this->string_id;
+		$this->string->name = 'string_name';
+
 		$subject = $this->create_subject();
 
 		$this->assertEquals( $expected_result, $subject->is_valid() );
@@ -138,7 +149,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @test
 	 */
 	function it_gets_field_slug() {
-		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string_id );
+		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string );
 		$subject = new WPML_TM_Page_Builders_Field_Wrapper( $slug );
 
 		$this->assertEquals( $slug, $subject->get_field_slug() );
@@ -197,7 +208,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @return WPML_TM_Page_Builders_Field_Wrapper
 	 */
 	private function create_subject() {
-		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string_id );
+		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string );
 		return new WPML_TM_Page_Builders_Field_Wrapper( $slug );
 	}
 }

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -205,6 +205,32 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	}
 
 	/**
+	 * @test
+	 * @dataProvider get_wrap_data_provider
+	 * @group wpmltm-3081
+	 *
+	 * @param string $string_name
+	 * @param string $expected
+	 */
+	public function get_wrap( $string_name, $expected ) {
+		$wrap = WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string_name );
+		$this->assertEquals( $expected, $wrap );
+	}
+
+	/**
+	 * @return array
+	 */
+	function get_wrap_data_provider() {
+		return array(
+			'Empty string'       => array( '', '' ),
+			'Normal string'      => array( 'title-heading-f327e9c', '' ),
+			'Text editor string' => array( 'editor-text-editor-c12e1e6', '' ),
+			'Heading'            => array( 'title-heading-8e0908e', '' ),
+			'Heading h2'         => array( 'title-heading-8e0908e-h2', 'h2' ),
+		);
+	}
+
+	/**
 	 * @return WPML_TM_Page_Builders_Field_Wrapper
 	 */
 	private function create_subject() {

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -212,7 +212,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @param stdClass $string
 	 * @param string $expected
 	 */
-	public function get_wrap( $string, $expected ) {
+	public function get_wrap_tag( $string, $expected ) {
 		$wrap = WPML_TM_Page_Builders_Field_Wrapper::get_wrap_tag( $string );
 		$this->assertEquals( $expected, $wrap );
 	}

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -149,7 +149,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @test
 	 */
 	function it_gets_field_slug() {
-		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string );
+		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string->id );
 		$subject = new WPML_TM_Page_Builders_Field_Wrapper( $slug );
 
 		$this->assertEquals( $slug, $subject->get_field_slug() );
@@ -234,7 +234,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @return WPML_TM_Page_Builders_Field_Wrapper
 	 */
 	private function create_subject() {
-		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string );
+		$slug    = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $this->package_id, $this->string->id );
 		return new WPML_TM_Page_Builders_Field_Wrapper( $slug );
 	}
 

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-field-wrapper.php
@@ -213,7 +213,7 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	 * @param string $expected
 	 */
 	public function get_wrap( $string, $expected ) {
-		$wrap = WPML_TM_Page_Builders_Field_Wrapper::get_wrap( $string );
+		$wrap = WPML_TM_Page_Builders_Field_Wrapper::get_wrap_tag( $string );
 		$this->assertEquals( $expected, $wrap );
 	}
 
@@ -241,15 +241,16 @@ class Test_WPML_TM_Page_Builders_Field_Wrapper extends \OTGS\PHPUnit\Tools\TestC
 	/**
 	 * @param string $id
 	 * @param string $name
-	 * @param string $wrap
+	 * @param string $wrap_tag
 	 *
 	 * @return stdClass
 	 */
-	private function get_string( $id, $name = 'string_name', $wrap = '' ) {
-		$string       = new stdClass();
-		$string->id   = $id;
-		$string->name = $name;
-		$string->wrap = $wrap;
+	private function get_string( $id, $name = 'string_name', $wrap_tag = '' ) {
+		$string           = new stdClass();
+		$string->id       = $id;
+		$string->name     = $name;
+		$string->wrap_tag = $wrap_tag;
+
 		return $string;
 	}
 }

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-hooks.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-hooks.php
@@ -79,15 +79,12 @@ class Test_WPML_TM_Page_Builders_Hooks extends \OTGS\PHPUnit\Tools\TestCase {
 	 * Test adjust_translation_fields_filter().
 	 *
 	 * @test
-	 * @dataProvider adjust_translation_fields_filter_data_provider
-	 *
-	 * @group        page-builders
-	 *
-	 * @param array $input_array  Test input.
-	 * @param array $output_array Test output.
+	 * @group page-builders
 	 */
-	public function adjust_translation_fields_filter( $input_array, $output_array ) {
-		$job = new stdClass();
+	public function adjust_translation_fields_filter() {
+		$input_array  = array( rand_str( 12 ) );
+		$job          = new stdClass();
+		$output_array = array( rand_str( 9 ) );
 		$this->worker
 			->expects( $this->once() )
 			->method( 'adjust_translation_fields_filter' )
@@ -97,29 +94,6 @@ class Test_WPML_TM_Page_Builders_Hooks extends \OTGS\PHPUnit\Tools\TestCase {
 		$subject         = $this->get_subject( $this->worker );
 		$filtered_result = $subject->adjust_translation_fields_filter( $input_array, $job );
 		$this->assertEquals( $output_array, $filtered_result );
-	}
-
-	/**
-	 * Data provider for adjust_translation_fields_filter().
-	 *
-	 * @return array
-	 */
-	public function adjust_translation_fields_filter_data_provider() {
-		return array(
-			array( array( rand_str( 12 ) ), array( rand_str( 9 ) ) ),
-			array(
-				array(
-					rand_str( 12 ),
-					'title'          => 'Heading',
-					'field_wrap_tag' => 'h2',
-				),
-				array(
-					rand_str( 9 ),
-					'title'          => 'Heading (h2)',
-					'field_wrap_tag' => 'h2',
-				),
-			),
-		);
 	}
 
 	/**

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders-hooks.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders-hooks.php
@@ -76,13 +76,18 @@ class Test_WPML_TM_Page_Builders_Hooks extends \OTGS\PHPUnit\Tools\TestCase {
 	}
 
 	/**
+	 * Test adjust_translation_fields_filter().
+	 *
 	 * @test
-	 * @group page-builders
+	 * @dataProvider adjust_translation_fields_filter_data_provider
+	 *
+	 * @group        page-builders
+	 *
+	 * @param array $input_array  Test input.
+	 * @param array $output_array Test output.
 	 */
-	public function adjust_translation_fields_filter() {
-		$input_array  = array( rand_str( 12 ) );
-		$job          = new stdClass();
-		$output_array = array( rand_str( 9 ) );
+	public function adjust_translation_fields_filter( $input_array, $output_array ) {
+		$job = new stdClass();
 		$this->worker
 			->expects( $this->once() )
 			->method( 'adjust_translation_fields_filter' )
@@ -92,6 +97,29 @@ class Test_WPML_TM_Page_Builders_Hooks extends \OTGS\PHPUnit\Tools\TestCase {
 		$subject         = $this->get_subject( $this->worker );
 		$filtered_result = $subject->adjust_translation_fields_filter( $input_array, $job );
 		$this->assertEquals( $output_array, $filtered_result );
+	}
+
+	/**
+	 * Data provider for adjust_translation_fields_filter().
+	 *
+	 * @return array
+	 */
+	public function adjust_translation_fields_filter_data_provider() {
+		return array(
+			array( array( rand_str( 12 ) ), array( rand_str( 9 ) ) ),
+			array(
+				array(
+					rand_str( 12 ),
+					'title'          => 'Heading',
+					'field_wrap_tag' => 'h2',
+				),
+				array(
+					rand_str( 9 ),
+					'title'          => 'Heading (h2)',
+					'field_wrap_tag' => 'h2',
+				),
+			),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -105,11 +105,12 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$expected_translation_package = $translation_package;
 		$expected_translation_package['contents']['body']['translate'] = 0;
 		foreach ( $strings as $string ) {
-			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string->id );
+			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
 			$expected_translation_package['contents'][ $key ] = array(
 				'translate' => 1,
 				'data'      => base64_encode( $string->value ),
 				'format'    => 'base64',
+				'wrap_tag'  => '',
 			);
 		}
 
@@ -166,11 +167,12 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$expected_translation_package['contents']['body']['translate'] = 0;
 		foreach ( $strings as $string ) {
 			$string_value = $string_translations[ $string->name ][ $job_lang_from ]['value'];
-			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string->id );
+			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
 			$expected_translation_package['contents'][ $key ] = array(
 				'translate' => 1,
 				'data'      => base64_encode( $string_value ),
 				'format'    => 'base64',
+				'wrap_tag'  => '',
 			);
 		}
 
@@ -336,10 +338,12 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 	 */
 	public function pro_translation_completed_action_data_provider() {
 		$data['string_package_id']  = rand( 1, 50 );
+
 		$data['string1_id']         = rand( 1, 50 );
 		$data['string2_id']         = rand( 51, 100 );
-		$data['string1_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $data['string1_id'] );
-		$data['string2_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $data['string2_id'] );
+
+		$data['string1_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $this->get_string( $data[ 'string1_id' ]  ) );
+		$data['string2_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $this->get_string( $data[ 'string2_id' ] ) );
 
 		$local_fields = array(
 			'title'                     => array(
@@ -431,9 +435,9 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 	 */
 	function it_adjusts_translation_fields_filter() {
 		$slugs = array(
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 1, 11 ),
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 2, 12 ),
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 3, 13 ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 1, $this->get_string( 11 ) ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 2, $this->get_string( 12 ) ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 3, $this->get_string( 13 ) ),
 		);
 
 		$fields = array_map( function ( $slug ) {
@@ -546,5 +550,19 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$post->ID        = rand( 1, 100 );
 		$post->post_type = rand_str();
 		return $post;
+	}
+
+	/**
+	 * @param string $id
+	 * @param string $name
+	 *
+	 * @return stdClass
+	 */
+	private function get_string( $id, $name = 'string_name' ) {
+		$string       = new stdClass();
+		$string->id   = $id;
+		$string->name = $name;
+
+		return $string;
 	}
 }

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -438,6 +438,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 	/**
 	 * @test
 	 * @group page-builders
+	 * @group wpmltm-3081
 	 */
 	function it_adjusts_translation_fields_filter() {
 		$slugs = array(
@@ -454,6 +455,11 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$expected_result[0]['field_style'] = 1;
 		$expected_result[1]['field_style'] = 2;
 		$expected_result[2]['field_style'] = 0;
+
+		$fields[0]['field_wrap_tag'] = 'h2';
+
+		$expected_result[0]['field_wrap_tag'] = 'h2';
+		$expected_result[0]['title'] = ' (h2)';
 
 		$that = $this;
 		$callback = function ( $slug ) use ( $slugs, $that ) {

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -105,7 +105,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$expected_translation_package = $translation_package;
 		$expected_translation_package['contents']['body']['translate'] = 0;
 		foreach ( $strings as $string ) {
-			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
+			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string->id );
 			$expected_translation_package['contents'][ $key ] = array(
 				'translate' => 1,
 				'data'      => base64_encode( $string->value ),
@@ -167,7 +167,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$expected_translation_package['contents']['body']['translate'] = 0;
 		foreach ( $strings as $string ) {
 			$string_value = $string_translations[ $string->name ][ $job_lang_from ]['value'];
-			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string );
+			$key = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $package_id, $string->id );
 			$expected_translation_package['contents'][ $key ] = array(
 				'translate' => 1,
 				'data'      => base64_encode( $string_value ),
@@ -342,8 +342,14 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$data['string1_id']         = rand( 1, 50 );
 		$data['string2_id']         = rand( 51, 100 );
 
-		$data['string1_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $this->get_string( $data[ 'string1_id' ]  ) );
-		$data['string2_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( $data['string_package_id'], $this->get_string( $data[ 'string2_id' ] ) );
+		$data['string1_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug(
+			$data['string_package_id'],
+			$data['string1_id']
+		);
+		$data['string2_field_name'] = WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug(
+			$data['string_package_id'],
+			$data['string2_id']
+		);
 
 		$local_fields = array(
 			'title'                     => array(
@@ -435,9 +441,9 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 	 */
 	function it_adjusts_translation_fields_filter() {
 		$slugs = array(
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 1, $this->get_string( 11 ) ),
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 2, $this->get_string( 12 ) ),
-			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 3, $this->get_string( 13 ) ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 1, 11 ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 2, 12 ),
+			WPML_TM_Page_Builders_Field_Wrapper::generate_field_slug( 3, 13 ),
 		);
 
 		$fields = array_map( function ( $slug ) {
@@ -550,19 +556,5 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$post->ID        = rand( 1, 100 );
 		$post->post_type = rand_str();
 		return $post;
-	}
-
-	/**
-	 * @param string $id
-	 * @param string $name
-	 *
-	 * @return stdClass
-	 */
-	private function get_string( $id, $name = 'string_name' ) {
-		$string       = new stdClass();
-		$string->id   = $id;
-		$string->name = $name;
-
-		return $string;
 	}
 }


### PR DESCRIPTION
Changes in wpml-page-builders-elementor to support task of the ticket.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmltm-3081