### PR TITLE
Prevent loading Page Builders integration if TM is not active

### DIFF
--- a/src/st/class-wpml-page-builders-app.php
+++ b/src/st/class-wpml-page-builders-app.php
@@ -25,7 +25,7 @@ class WPML_Page_Builders_App {
 	}
 
 	public function load_integration() {
-		if ( ! class_exists( 'WPML_ST_Package_Factory' ) ) {
+		if ( ! class_exists( 'WPML_ST_Package_Factory' ) || ! defined( 'WPML_TM_VERSION' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
I know it might not be needed anymore soon, but I suggest to fix this anyway.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6640