### PR TITLE
Get the latest Job Id from the `icl_translate` field type

### DIFF
--- a/src/st/class-wpml-pb-string-translation.php
+++ b/src/st/class-wpml-pb-string-translation.php
@@ -57,7 +57,7 @@ class WPML_PB_String_Translation {
 	 * @return bool
 	 */
 	private function get_job_id( $field_type ) {
-		return $this->wpdb->get_var( $this->wpdb->prepare( "SELECT job_id FROM {$this->wpdb->prefix}icl_translate WHERE field_type = %s", $field_type ) );
+		return $this->wpdb->get_var( $this->wpdb->prepare( "SELECT MAX(job_id) FROM {$this->wpdb->prefix}icl_translate WHERE field_type = %s", $field_type ) );
 	}
 
 	/**


### PR DESCRIPTION
While I was debugging wpmlcore-6913, I found a possible issue here even if I don't think it the real cause of the problem on the user' site.

We were getting the first job ID and this could cause a problem later when we check if the job is "in progress" or not (based on the `translated` value in `icl_translate_job`). Indeed, we could have cancelled the first job and started a new one

=> `icl_translate`

|tid|job_id|content_id|timestamp|field_type|
|:---|---|---|---|---:|
|29883|996|0|2018-07-14 08:11:45|package-string-258-67608|
|29920|997|0|2018-07-14 08:34:19|package-string-258-67608|

=> `icl_translate_job`

|job_id|rid|translator_id|translated|
|:---|---|---|---:|
|996|61|7|0|
|997|61|7|1|

Now with the fix, we'll always fetch the latest job ID.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6913