### PR TITLE
Improve support for posts which are not handled by the page builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,20 +28,16 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-
         "10up/wp_mock": "~0.2.0",
         "lucatume/function-mocker": "1.3.4",
         "symfony/dom-crawler": "^3.1",
         "symfony/css-selector": "^3.1",
         "phpunit/phpunit": "^5",
         "otgs/phpunit-tools": "dev-master",
-
         "squizlabs/php_codesniffer": "~3",
         "phpcompatibility/php-compatibility": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
-
         "wp-coding-standards/wpcs": "^0",
-
         "m4tthumphrey/php-gitlab-api": "^9.0.0",
         "php-http/guzzle6-adapter": "^1.1",
         "wpml/collect": "dev-wpml-collect-rename"

--- a/src/st/compatibility/class-wpml-page-builders-register-strings.php
+++ b/src/st/compatibility/class-wpml-page-builders-register-strings.php
@@ -50,20 +50,21 @@ abstract class WPML_Page_Builders_Register_Strings {
 
 		$this->string_location = 1;
 
-		$data = get_post_meta( $post->ID, $this->data_settings->get_meta_field(), false );
+		if ( $this->data_settings->is_handling_post( $post->ID ) ) {
+			$data = get_post_meta( $post->ID, $this->data_settings->get_meta_field(), false );
 
-		if ( $data ) {
-			$converted = $this->data_settings->convert_data_to_array( $data );
-			if ( is_array( $converted ) ) {
-				$this->register_strings_for_modules(
-					$converted,
-					$package
-				);
+			if ( $data ) {
+				$converted = $this->data_settings->convert_data_to_array( $data );
+				if ( is_array( $converted ) ) {
+					$this->register_strings_for_modules(
+						$converted,
+						$package
+					);
+				}
 			}
 		}
 
 		do_action( 'wpml_delete_unused_package_strings', $package );
-
 	}
 
 	/**

--- a/src/st/compatibility/interface-iwpml-page-builders-data-settings.php
+++ b/src/st/compatibility/interface-iwpml-page-builders-data-settings.php
@@ -45,4 +45,11 @@ interface IWPML_Page_Builders_Data_Settings {
 	public function get_pb_name();
 
 	public function add_hooks();
+
+	/**
+	 * @param int $postId
+	 *
+	 * @return bool
+	 */
+	public function is_handling_post( $postId );
 }

--- a/src/tm/class-wpml-pb-handle-custom-fields.php
+++ b/src/tm/class-wpml-pb-handle-custom-fields.php
@@ -23,7 +23,7 @@ class WPML_PB_Handle_Custom_Fields {
 	 * @return bool
 	 */
 	public function is_page_builder_page_filter( $is_page_builder_page, WP_Post $post ) {
-		if ( get_post_meta( $post->ID, $this->data_settings->get_meta_field() ) ) {
+		if ( $this->data_settings->is_handling_post( $post->ID ) ) {
 			$is_page_builder_page = true;
 		}
 

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -25,6 +25,14 @@ class WPML_TM_Page_Builders {
 	 */
 	public function translation_job_data_filter( array $translation_package, $post ) {
 		if ( self::PACKAGE_TYPE_EXTERNAL !== $translation_package['type'] && isset( $post->ID ) ) {
+
+			$translation_package['contents']['body']['translate'] = (int) apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
+
+			if ( $translation_package['contents']['body']['translate'] ) {
+				// If eventually, the post body must be translated, we won't include the package strings.
+				return $translation_package;
+			}
+
 			$post_element        = new WPML_Post_Element( $post->ID, $this->sitepress );
 			$source_post_id      = $post->ID;
 			$source_post_element = $post_element->get_source_element();
@@ -37,8 +45,6 @@ class WPML_TM_Page_Builders {
 			$job_source_is_not_post_source = $post->ID !== $source_post_id;
 
 			$string_packages = apply_filters( 'wpml_st_get_post_string_packages', false, $source_post_id );
-
-			$translation_package['contents']['body']['translate'] = apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
 
 			if ( $string_packages ) {
 

--- a/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
+++ b/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
@@ -114,6 +114,7 @@ class Test_WPML_Page_Builders_Update extends \OTGS\PHPUnit\Tools\TestCase {
 					'get_node_id_field',
 					'get_pb_name',
 					'add_hooks',
+					'is_handling_post',
 				)
 			)->disableOriginalConstructor()->getMock();
 	}

--- a/tests/phpunit/tests/st/compatibility/test-wpml-pb-register-strings.php
+++ b/tests/phpunit/tests/st/compatibility/test-wpml-pb-register-strings.php
@@ -8,8 +8,33 @@
  */
 class Test_WPML_PB_Register_Strings extends WPML_PB_TestCase2 {
 
+
+
 	/**
 	 * @test
+	 * @group wpmlcore-6929
+	 */
+	public function it_does_not_register_strings_if_page_builder_is_not_handling_post() {
+		list( , $post, $package ) = $this->get_post_and_package( 'Elementor' );
+
+		WP_Mock::expectAction( 'wpml_start_string_package_registration', $package );
+		WP_Mock::expectAction( 'wpml_delete_unused_package_strings', $package );
+
+		$data_settings = \Mockery::mock( 'IWPML_Page_Builders_Data_Settings' );
+		$data_settings->shouldReceive( 'is_handling_post' )->with( $post->ID )->andReturn( false );
+		$data_settings->shouldNotReceive( 'convert_data_to_array' );
+
+		$subject = new WPML_Concrete_Test_Register_Strings(
+			\Mockery::mock( 'IWPML_Page_Builders_Translatable_Nodes' ),
+			$data_settings,
+			\Mockery::mock( 'WPML_PB_String_Registration' )
+		);
+		$subject->register_strings( $post, $package );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6929
 	 */
 	public function it_does_not_throw_error_on_invalid_data() {
 		list( $name, $post, $package ) = $this->get_post_and_package( 'Elementor' );
@@ -24,6 +49,7 @@ class Test_WPML_PB_Register_Strings extends WPML_PB_TestCase2 {
 		WP_Mock::expectAction( 'wpml_delete_unused_package_strings', $package );
 
 		$data_settings = \Mockery::mock( 'IWPML_Page_Builders_Data_Settings' );
+		$data_settings->shouldReceive( 'is_handling_post' )->with( $post->ID )->andReturn( true );
 		$data_settings->shouldReceive( 'get_meta_field' )->andReturn( '_elementor_data' );
 		$data_settings->shouldReceive( 'convert_data_to_array' )->once()->with( $invalid_json )->andReturn( null );
 

--- a/tests/phpunit/tests/st/test-wpml-page-builders-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-page-builders-integration.php
@@ -25,16 +25,20 @@ class Test_WPML_Page_Builders_Integration extends \OTGS\PHPUnit\Tools\TestCase {
 		                           ->getMock();
 
 		$this->data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-			->setMethods( array(
-				'add_hooks',
-				'get_meta_field',
-				'get_node_id_field',
-				'get_fields_to_copy',
-				'get_fields_to_save',
-				'convert_data_to_array',
-				'prepare_data_for_saving',
-				'get_pb_name',
-				'add_data_custom_field_to_md5' ) )
+			->setMethods(
+				[
+					'add_hooks',
+					'get_meta_field',
+					'get_node_id_field',
+					'get_fields_to_copy',
+					'get_fields_to_save',
+					'convert_data_to_array',
+					'prepare_data_for_saving',
+					'get_pb_name',
+					'add_data_custom_field_to_md5',
+					'is_handling_post',
+				]
+			)
 			->disableOriginalConstructor()
 			->getMock();
 	}

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
@@ -23,19 +23,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_adds_hooks() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -55,19 +43,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_returns_true_when_post_has_the_custom_field() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -76,16 +52,10 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 		             ->getMock();
 
 		$post->ID    = 10;
-		$field       = 'my-custom-field';
-		$field_value = 'something';
 
-		$data_settings->method( 'get_meta_field' )
-		              ->willReturn( $field );
-
-		\WP_Mock::wpFunction( 'get_post_meta', array(
-			'args'   => array( $post->ID, $field ),
-			'return' => $field_value,
-		) );
+		$data_settings->method( 'is_handling_post' )
+			->with( $post->ID )
+			->willReturn( true );
 
 		$this->assertTrue( $subject->is_page_builder_page_filter( false, $post ) );
 	}
@@ -94,19 +64,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_returns_unfiltered_result_when_post_does_not_have_the_custom_field() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -115,15 +73,10 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 		             ->getMock();
 
 		$post->ID = 10;
-		$field    = 'my-custom-field';
 
-		$data_settings->method( 'get_meta_field' )
-		              ->willReturn( $field );
-
-		\WP_Mock::wpFunction( 'get_post_meta', array(
-			'args'   => array( $post->ID, $field ),
-			'return' => false,
-		) );
+		$data_settings->method( 'is_handling_post' )
+		              ->with( $post->ID )
+		              ->willReturn( false );
 
 		$this->assertFalse( $subject->is_page_builder_page_filter( false, $post ) );
 	}
@@ -132,19 +85,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_copies_custom_fields_when_original_custom_field_exists() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -173,19 +114,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_does_not_copy_custom_fields_when_original_custom_field_does_not_exists() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -274,5 +203,24 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 		$json_string = json_encode( $json );
 
 		$this->assertEquals( addslashes( $json_string ), WPML_PB_Handle_Custom_Fields::slash_json( $json_string ) );
+	}
+
+	private function getDataSettings() {
+		return $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+		                      ->setMethods(
+								[
+									'get_node_id_field',
+									'get_fields_to_copy',
+									'get_fields_to_save',
+									'get_meta_field',
+									'convert_data_to_array',
+									'prepare_data_for_saving',
+									'get_pb_name',
+									'add_hooks',
+									'is_handling_post',
+								]
+		                      )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
 	}
 }

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -93,6 +93,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$translation_package = $this->prepare_translation_package( 'post' );
 		$post                = $this->get_a_post_object();
 
+		$this->mock_should_body_be_translated_filter( false, $translation_package['contents']['body']['translate'], $post );
 		$this->set_hardcoded_wpml_post_element( null, rand_str( 2 ) );
 
 		$strings    = $this->prepare_package_strings();
@@ -128,6 +129,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 			$strings[ $key ]->type = 'LINK';
 		}
 
+		$this->mock_should_body_be_translated_filter( false, $translation_package['contents']['body']['translate'], $post );
 		$this->set_hardcoded_wpml_post_element( null, rand_str( 2 ) );
 
 		$package_id = rand( 1, 100 );
@@ -152,6 +154,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$translation_package = $this->prepare_translation_package( 'post' );
 		$post                = $this->get_a_post_object();
 
+		$this->mock_should_body_be_translated_filter( false, $translation_package['contents']['body']['translate'], $post );
 		$this->set_hardcoded_wpml_post_element( $source_post_id, $job_lang_from );
 
 		$strings    = $this->prepare_package_strings();
@@ -180,6 +183,21 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$filtered_translation_package = $subject->translation_job_data_filter( $translation_package, $post );
 
 		$this->assertEquals( $expected_translation_package, $filtered_translation_package );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6929)
+	 */
+	public function it_should_not_include_package_strings_if_body_should_be_translated() {
+		$translation_package = $this->prepare_translation_package( 'post' );
+		$post                = $this->get_a_post_object();
+
+		$this->mock_should_body_be_translated_filter( true, $translation_package['contents']['body']['translate'], $post );
+
+		$subject = $this->get_subject();
+
+		$this->assertSame( $translation_package, $subject->translation_job_data_filter( $translation_package, $post ) );
 	}
 
 	private function set_hardcoded_wpml_post_element( $post_source_id, $job_lang_from ) {
@@ -562,5 +580,16 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$post->ID        = rand( 1, 100 );
 		$post->post_type = rand_str();
 		return $post;
+	}
+
+	/**
+	 * @param bool             $shouldBeTranslated
+	 * @param int              $originalValue
+	 * @param stdClass|WP_Post $post
+	 */
+	private function mock_should_body_be_translated_filter( $shouldBeTranslated, $originalValue, $post ) {
+		\WP_Mock::onFilter( 'wpml_pb_should_body_be_translated' )
+			->with( $originalValue, $post )
+			->reply( $shouldBeTranslated );
 	}
 }


### PR DESCRIPTION
- Extend interface `IWPML_Page_Builders_Data_Settings` with public
method `is_handling_post`
- Improve `is_page_builder_page` filter
- Do not include the package strings to the translation job if the body should be translated (until now, we didn't have the case when the body should be translated and we have package strings).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6929