### PR TITLE
Introduce the public filter hook "wpml_pb_post_use_translation_editor"

### DIFF
--- a/src/PublicApi/Hooks.php
+++ b/src/PublicApi/Hooks.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WPML\PB\PublicApi;
+
+use WPML_PB_Last_Translation_Edit_Mode;
+
+class Hooks {
+
+	/** @var WPML_PB_Last_Translation_Edit_Mode $lastEditMode */
+	private $lastEditMode;
+
+	public function __construct( WPML_PB_Last_Translation_Edit_Mode $lastEditMode ) {
+		$this->lastEditMode = $lastEditMode;
+	}
+
+	public function addHooks() {
+		add_filter( 'wpml_pb_post_use_translation_editor', [ $this, 'postUseTranslationEditor' ], 10, 2 );
+	}
+
+	/**
+	 * @param bool $incomingValue
+	 * @param int  $postId
+	 *
+	 * @return bool
+	 */
+	public function postUseTranslationEditor( $incomingValue, $postId ) {
+		return $this->lastEditMode->is_translation_editor( $postId );
+	}
+}
+
+class Factory {
+
+	public static function create() {
+		return new Hooks( new WPML_PB_Last_Translation_Edit_Mode() );
+	}
+}

--- a/src/PublicApi/Hooks.php
+++ b/src/PublicApi/Hooks.php
@@ -18,12 +18,12 @@ class Hooks {
 	}
 
 	/**
-	 * @param bool $incomingValue
+	 * @param bool $ignored
 	 * @param int  $postId
 	 *
 	 * @return bool
 	 */
-	public function postUseTranslationEditor( $incomingValue, $postId ) {
+	public function postUseTranslationEditor( $ignored, $postId ) {
 		return $this->lastEditMode->is_translation_editor( $postId );
 	}
 }

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -158,6 +158,7 @@ class WPML_PB_Integration {
 	 * Add all actions filters.
 	 */
 	public function add_hooks() {
+		\WPML\PB\PublicApi\Factory::create()->addHooks();
 		add_action( 'pre_post_update', array( $this, 'migrate_location' ) );
 		add_action( 'save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
 		add_action( 'wpml_pb_resave_post_translation', array( $this, 'resave_post_translation_in_shutdown' ), 10, 1 );

--- a/tests/phpunit/tests/PublicApi/TestHooks.php
+++ b/tests/phpunit/tests/PublicApi/TestHooks.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace WPML\PB\PublicApi;
+
+use OTGS\PHPUnit\Tools\TestCase;
+
+/**
+ * @group public-api
+ */
+class TestHooks extends TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = $this->getSubject();
+
+		\WP_Mock::expectFilterAdded( 'wpml_pb_post_use_translation_editor', [ $subject, 'postUseTranslationEditor' ], 10, 2 );
+
+		$subject->addHooks();
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpBool
+	 *
+	 * @param bool $bool
+	 */
+	public function itShouldReturnPostUseTranslationEditor( $bool ) {
+		$postId = 123;
+
+		$lastEditMode = $this->getLastEditMode();
+		$lastEditMode->method( 'is_translation_editor' )
+			->with( $postId )
+			->willReturn( $bool );
+
+		$subject = $this->getSubject( $lastEditMode );
+
+		$this->assertSame( $bool, $subject->postUseTranslationEditor( 'unused', $postId ) );
+	}
+
+	public function dpBool() {
+		return [
+			[ true ],
+			[ false ],
+		];
+	}
+
+	private function getSubject( $lastEditMode = null ) {
+		$lastEditMode = $lastEditMode ?: $this->getLastEditMode();
+
+		return new Hooks( $lastEditMode );
+	}
+
+	private function getLastEditMode() {
+		return $this->getMockBuilder( \WPML_PB_Last_Translation_Edit_Mode::class )
+			->setMethods( [ 'is_translation_editor' ] )
+			->disableOriginalConstructor()->getMock();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldCreateAndReturnInstanceOfHooks() {
+		$subject = new Factory();
+
+		$this->assertInstanceOf( Hooks::class, $subject::create() );
+	}
+}

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -1,5 +1,7 @@
 <?php
 
+use tad\FunctionMocker\FunctionMocker;
+
 /**
  * Class Test_WPML_PB_Integration
  *
@@ -43,6 +45,14 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$sitepress_mock = $this->get_sitepress_mock();
 		$factory_mock   = $this->get_factory( null, $sitepress_mock );
 		$pb_integration = new WPML_PB_Integration( $sitepress_mock, $factory_mock );
+
+		$publicApiHooks = $this->getMockBuilder( \WPML\PB\PublicApi\Hooks::class )
+			->setMethods( [ 'addHooks' ] )
+			->disableOriginalConstructor()->getMock();
+		$publicApiHooks->expects( $this->once() )->method( 'addHooks' );
+
+		FunctionMocker::replace( \WPML\PB\PublicApi\Factory::class . '::create', $publicApiHooks );
+
 		\WP_Mock::expectActionAdded( 'pre_post_update', array(
 			$pb_integration,
 			'migrate_location'


### PR DESCRIPTION
It will return true if a post ID was edited with a translation editor,
or false otherwise.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6964