### PR TITLE
Do not apply `wp_slash` on non-encoded data

### DIFF
--- a/src/tm/class-wpml-pb-handle-custom-fields.php
+++ b/src/tm/class-wpml-pb-handle-custom-fields.php
@@ -60,6 +60,10 @@ class WPML_PB_Handle_Custom_Fields {
 	 * @return mixed string
 	 */
 	public static function slash_json( $data ) {
+		if ( ! is_string( $data ) ) {
+			return $data;
+		}
+
  		json_decode( $data );
 		if ( json_last_error() === JSON_ERROR_NONE ) {
 			return wp_slash( $data );

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
@@ -253,6 +253,19 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 		$not_json = 'do not escape these - \\ " \'';
 		$this->assertEquals( $not_json, WPML_PB_Handle_Custom_Fields::slash_json( $not_json ) );
 	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-7141
+	 */
+	public function it_does_NOT_slash_if_original_data_is_NOT_a_string() {
+		$not_string = [ 'some data' ];
+
+		\WP_Mock::userFunction( 'wp_slash', [ 'times' => 0 ] );
+
+		$this->assertEquals( $not_string, WPML_PB_Handle_Custom_Fields::slash_json( $not_string ) );
+	}
+
 	/**
 	 * @test
 	 */


### PR DESCRIPTION
We started to apply `wp_slash` to fix an issue when copying some fields
on Elementor and this had a side effect on Beaver Builder (it actually
caused the same symptom than the one we fixed in Elementor).

=> Here's the related commit https://github.com/OnTheGoSystems/wpml-page-builders/commit/eb2be54fee03e982bc2727fe5a39aa7618e66186.

I think we fixed a very specific case in Elementor and possibly
something that was fixed on their side later because I could not
reproduce it after removing `return wp_slash( $data );`.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7141