### PR TITLE
Always reset the link translation to the original

### DIFF
--- a/src/st/TranslateLinks.php
+++ b/src/st/TranslateLinks.php
@@ -12,16 +12,14 @@ class TranslateLinks {
 	 */
 	public static function getTranslatorForString( \WPML_ST_String_Factory $stringFactory, $activeLanguages ) {
 		return function ( $string_id ) use ( $stringFactory, $activeLanguages ) {
-			$string   = $stringFactory->find_by_id( $string_id );
-			$statuses = \wpml_collect( $string->get_translation_statuses() )->pluck( 'language' );
+			$string = $stringFactory->find_by_id( $string_id );
 
 			$sameStringLanguage = function ( $language ) use ( $string ) {
 				return $language === $string->get_language();
 			};
 
-			$setTranslation = function ( $language ) use ( $statuses, $string ) {
-				$value = $statuses->contains( $language ) ? null : $string->get_value();
-				$string->set_translation( $language, $value );
+			$setTranslation = function ( $language ) use ( $string ) {
+				$string->set_translation( $language, $string->get_value() );
 			};
 
 			\wpml_collect( $activeLanguages )->pluck( 'code' )


### PR DESCRIPTION
The PB string is translated by name. If we change link value for a node,
we will still use the same string that is already translated.

@brucepearson, I need your feedback as you are the author of this code. When we set the translation to `null` (because it already exists), the translation is not updated inside `\WPML_ST_String::set_translation`. My question is: Did you do this to avoid an unnecessary DB query, or do you think we should avoid to overwrite the translation if it exists?

I am wondering if we can have one of this link translated manually before it's applied to the content...

FTR, this `TranslateLinks::getTranslatorForString` mehod is used in `WPML_PB_String_Registration::register_string`:

```php
if ( 'LINK' === $type ) {
  call_user_func( $this->set_link_translations, $string_id );
}
```

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7102