### PR TITLE
Revert partially change for wpmlcore-6929

### DIFF
--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -26,13 +26,6 @@ class WPML_TM_Page_Builders {
 	public function translation_job_data_filter( array $translation_package, $post ) {
 		if ( self::PACKAGE_TYPE_EXTERNAL !== $translation_package['type'] && isset( $post->ID ) ) {
 
-			$translation_package['contents']['body']['translate'] = (int) apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
-
-			if ( $translation_package['contents']['body']['translate'] ) {
-				// If eventually, the post body must be translated, we won't include the package strings.
-				return $translation_package;
-			}
-
 			$post_element        = new WPML_Post_Element( $post->ID, $this->sitepress );
 			$source_post_id      = $post->ID;
 			$source_post_element = $post_element->get_source_element();
@@ -45,6 +38,8 @@ class WPML_TM_Page_Builders {
 			$job_source_is_not_post_source = $post->ID !== $source_post_id;
 
 			$string_packages = apply_filters( 'wpml_st_get_post_string_packages', false, $source_post_id );
+
+			$translation_package['contents']['body']['translate'] = apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
 
 			if ( $string_packages ) {
 

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -187,9 +187,12 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test
-	 * @group wpmlcore-6929)
+	 * @group wpmlcore-6929
 	 */
 	public function it_should_not_include_package_strings_if_body_should_be_translated() {
+		$this->markTestSkipped( 'This was temporarily reverted, will be fixed in short.' );
+		return;
+
 		$translation_package = $this->prepare_translation_package( 'post' );
 		$post                = $this->get_a_post_object();
 


### PR DESCRIPTION
Reverted the change in the file
`src/tm/class-wpml-tm-page-builders.php` (see https://github.com/OnTheGoSystems/wpml-page-builders/pull/75/files#diff-13bd6585af08bcbb707abb15466470caR28).

It will keep the current behaviour which is to disable body translation
if the current post is handled with a page builder, but it has no
attached string package.

However, it will still (wrongly) show the page builder strings (not the
body) if the post is not handled anymore by the page builder. This needs
to be re-worked as it started to fail several CC tests and we don't want
to block the Core master branch.

I am running a CC pipeline [#135632](https://git.onthegosystems.com/wpml/codeception/pipelines/135632) to make sure this does not break other things.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7193