### PR TITLE
Don't call WPML_PB_Integration::save_translations_to_post from "shutdown" if it has already been called

### DIFF
--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -245,6 +245,7 @@ class WPML_PB_Integration {
 			$this->with_strategies( function( IWPML_PB_Strategy $strategy ) {
 				$this->factory->get_string_translations( $strategy )->save_translations_to_post();
 			} );
+			$this->new_translations_recieved = false;
 		}
 	}
 


### PR DESCRIPTION
The problem is complex and took me a lot of time to understand what happens.

The culprit is in `WPML_PB_Integration::save_translations_to_post` which ultimately calls `wp_update_post`. When we save translations in TE, first we execute the mention method via this stack:

<img width="1253" alt="firstCall" src="https://user-images.githubusercontent.com/5097181/79415991-32827100-7fe1-11ea-9653-78d8951e6d8c.PNG">

This call is correct and does not cause any harm. Unfortunately, we do not change `$this->new_translations_recieved` value, it remains TRUE even if we already performed saving.

Due to that, this code is called again on "shutdown" action:

<img width="1443" alt="secondCall" src="https://user-images.githubusercontent.com/5097181/79416088-72495880-7fe1-11ea-9207-904e552d99ea.PNG">

This time some essential WPML Hooks are already turn off! When we call `wp_update_post`, it tries to retrieve post data:

```
$post = get_post( $postarr['ID'], ARRAY_A );
```

but the value in `$post['post_category']` refers now to "original" category instead of "translated" and in the consequence, we override it in `wp_term_relationships` table!


---------

I am not familiar with this code so can't be sure if my fix does not cause any side effects. 
 