### PR TITLE
Allow translating content as page builder with mixed shortcodes and regular text

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,6 @@
             "tests/phpunit/util/"
         ]
     },
-    "repositories": {
-        "collect": {
-            "type": "vcs",
-            "url": "https://github.com/OnTheGoSystems/collect.git"
-        }
-    },
     "require-dev": {
         "roave/security-advisories": "dev-master",
         "10up/wp_mock": "~0.2.0",
@@ -40,6 +34,8 @@
         "wp-coding-standards/wpcs": "^0",
         "m4tthumphrey/php-gitlab-api": "^9.0.0",
         "php-http/guzzle6-adapter": "^1.1",
-        "wpml/collect": "dev-wpml-collect-rename"
+        "wpml/collect": "dev-wpml-collect-rename",
+        "wpml/fp": "dev-master",
+        "wpml/wp": "dev-master"
     }
 }

--- a/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
@@ -40,6 +40,7 @@ class WPML_PB_Register_Shortcodes {
 		$this->location_index = 1;
 
 		$content = apply_filters( 'wpml_pb_shortcode_content_for_translation', $content, $post_id );
+		$content = WPML_PB_Shortcode_Content_Wrapper::maybeWrap( $content, $this->shortcode_strategy->get_shortcodes() );
 
 		$shortcode_parser               = $this->shortcode_strategy->get_shortcode_parser();
 		$shortcodes                     = $shortcode_parser->get_shortcodes( $content );

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcodes.php
@@ -70,8 +70,6 @@ class WPML_PB_Shortcodes {
 			return false;
 		}
 
-		$content_with_stripped_shortcode = preg_replace( '/\[([\S]*)[^\]]*\][\s\S]*\[\/(\1)\]|\[[^\]]*\]/', '', $content );
-		$content_with_stripped_shortcode = trim( $content_with_stripped_shortcode );
-		return ! empty( $content_with_stripped_shortcode ) && trim( $content ) !== $content_with_stripped_shortcode;
+		return WPML_PB_Shortcode_Content_Wrapper::isStrippedContentDifferent( $content );
 	}
 }

--- a/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
@@ -43,6 +43,7 @@ class WPML_PB_Update_Shortcodes_In_Content {
 	}
 
 	public function update_content( $original_content, $string_translations, $lang ) {
+		$original_content          = WPML_PB_Shortcode_Content_Wrapper::maybeWrap( $original_content, $this->strategy->get_shortcodes() );
 		$this->new_content         = $original_content;
 		$this->string_translations = $string_translations;
 		$this->lang                = $lang;
@@ -55,7 +56,7 @@ class WPML_PB_Update_Shortcodes_In_Content {
 			$this->update_shortcode_attributes( $shortcode );
 		}
 
-		return $this->new_content;
+		return WPML_PB_Shortcode_Content_Wrapper::unwrap( $this->new_content );
 	}
 
 	private function update_shortcodes( $shortcode_data ) {
@@ -90,7 +91,7 @@ class WPML_PB_Update_Shortcodes_In_Content {
 		if ( $translation ) {
 
 			if ( $this->is_string_too_long_for_regex( $original ) ) {
-				$block             = $this->remove_wrappers( $block );
+				$block             = WPML_PB_Shortcode_Content_Wrapper::unwrap( $block );
 				$new_block         = str_replace( $original, $translation, $block );
 				$this->new_content = str_replace( $block, $new_block, $this->new_content );
 			} else {
@@ -104,8 +105,8 @@ class WPML_PB_Update_Shortcodes_In_Content {
 				}
 
 				$new_block   = preg_replace( $pattern, $replacement, $block );
-				$block       = $this->remove_wrappers( $block );
-				$new_block   = $this->remove_wrappers( $new_block );
+				$block       = WPML_PB_Shortcode_Content_Wrapper::unwrap( $block );
+				$new_block   = WPML_PB_Shortcode_Content_Wrapper::unwrap( $new_block );
 				$replacement = $this->escape_backward_reference_on_replacement_string( $new_block );
 
 				if ( $used_wrapper ) {
@@ -129,20 +130,6 @@ class WPML_PB_Update_Shortcodes_In_Content {
 	 */
 	private function escape_backward_reference_on_replacement_string( $string ) {
 		return preg_replace( '/\$([\d]{1,2})/', '\\\$' . '${1}', $string );
-	}
-
-	/**
-	 * @param string $block
-	 *
-	 * @return string
-	 */
-	private function remove_wrappers( $block ) {
-		$wrappers_to_remove = array(
-			'[' . WPML_PB_Shortcode_Content_Wrapper::WRAPPER_SHORTCODE_NAME . ']',
-			'[/' . WPML_PB_Shortcode_Content_Wrapper::WRAPPER_SHORTCODE_NAME . ']',
-		);
-
-		return str_replace( $wrappers_to_remove, '', $block );
 	}
 
 	private function replace_content_without_delimiters( $block, $replacement ) {

--- a/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
@@ -43,6 +43,7 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 		$this->shortcode_strategy->shouldReceive( 'get_package_key' )->andReturnNull();
 		$this->shortcode_strategy->shouldReceive( 'get_package_strings' )->andReturn( array() );
 		$this->shortcode_strategy->shouldReceive( 'get_shortcode_attributes' )->andReturn( array( 'title', 'link' ) );
+		$this->shortcode_strategy->shouldReceive( 'get_shortcodes' )->andReturn( [ 'vc_btn' ] );
 
 		\WP_Mock::wpFunction( 'shortcode_parse_atts',
 			array(


### PR DESCRIPTION
This happens when we have a content like below:

`[my_shortcode title="This is a title"] Hello there`

If we have at least one declared shortcode in `wpml-config.xml` (i.e.
"my_shortcode" in this situation), we will wrap the whole content to
translate it as a page builder. As a result in the translation job,
we'll have 2 strings: "This is a title" and "Hello there".

However, if `my_shortcode` is not a declared shortcode, we will not wrap the content and no page builder string will extracted. As a consequence, we will still display the fill post body in the translation job.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6971