### PR TITLE
Auto update translations when the original is updated no string changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "m4tthumphrey/php-gitlab-api": "^9.0.0",
         "php-http/guzzle6-adapter": "^1.1",
         "wpml/collect": "dev-wpml-collect-rename",
-        "wpml/fp": "dev-master",
-        "wpml/wp": "dev-master"
+        "wpml/fp": "dev-develop",
+        "wpml/wp": "dev-develop"
     }
 }

--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace WPML\PB\AutoUpdate;
+
+use WPML\FP\Fns;
+use WPML\FP\Logic;
+use WPML\FP\Lst;
+use WPML\FP\Maybe;
+use WPML\FP\Obj;
+use WPML\FP\Relation;
+use function WPML\FP\invoke;
+use function WPML\FP\pipe;
+
+class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC_Action {
+
+	const HASH_SEP = '-';
+
+	/** @var \WPML_PB_Integration $pbIntegration */
+	private $pbIntegration;
+
+	/** @var \WPML_Translation_Element_Factory $elementFactory */
+	private $elementFactory;
+
+	public function __construct(
+		\WPML_PB_Integration $pbIntegration,
+		\WPML_Translation_Element_Factory $elementFactory
+	) {
+		$this->pbIntegration     = $pbIntegration;
+		$this->elementFactory    = $elementFactory;
+	}
+
+	public function add_hooks() {
+		add_filter( 'wpml_tm_post_md5_content', [ $this, 'getMd5ContentFromPackageStrings' ], 10, 2 );
+		add_action( 'wpml_after_save_post', [ $this, 'resaveTranslationsAfterSavePost' ], 10, 4 );
+	}
+
+	/**
+	 * @param string   $content
+	 * @param \WP_Post $post
+	 *
+	 * @return string
+	 */
+	public function getMd5ContentFromPackageStrings( $content, $post ) {
+		// $joinPackageStringHashes :: \WPML_Package → string
+		$joinPackageStringHashes = pipe(
+			Obj::propOr( [], 'string_data' ),
+			Obj::keys(),
+			Lst::sort( Relation::gt() ),
+			Lst::join( self::HASH_SEP )
+		);
+
+		return Maybe::of( $post->ID )
+			->map( [ self::class, 'getPackages' ] )
+			->map( Fns::map( $joinPackageStringHashes ) )
+			->filter()
+			->map( Lst::join( self::HASH_SEP ) )
+			->getOrElse( $content );
+	}
+
+	/**
+	 * @param int $postId
+	 *
+	 * @return \WPML_Package[]
+	 */
+	public static function getPackages( $postId ) {
+		return apply_filters( 'wpml_st_get_post_string_packages', [], $postId );
+	}
+
+	/**
+	 * @param int         $postId
+	 * @param int         $trid
+	 * @param string      $lang
+	 * @param string|null $sourceLang
+	 */
+	public function resaveTranslationsAfterSavePost( $postId, $trid, $lang, $sourceLang ) {
+		if ( $sourceLang || ! self::getPackages( $postId ) ) {
+			return;
+		}
+
+		// $ifOriginal :: \WPML_Post_Element → bool
+		$ifOriginal = pipe( invoke( 'get_source_language_code' ), Logic::not() );
+
+		// $ifCompleted :: \WPML_Post_Element → bool
+		$ifCompleted = pipe( [ TranslationStatus::class, 'get' ], Relation::equals( ICL_TM_COMPLETE ) );
+
+		// $resaveElement :: \WPML_Post_Element → null
+		$resaveElement = [ $this->pbIntegration, 'resave_post_translation_in_shutdown' ];
+
+		wpml_collect( $this->elementFactory->create_post( $postId )->get_translations() )
+			->reject( $ifOriginal )
+			->filter( $ifCompleted )
+			->each( $resaveElement );
+	}
+}

--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -43,8 +43,8 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 	public function getMd5ContentFromPackageStrings( $content, $post ) {
 		// $joinPackageStringHashes :: \WPML_Package → string
 		$joinPackageStringHashes = pipe(
-			Obj::propOr( [], 'string_data' ),
-			Obj::keys(),
+			invoke( 'get_package_strings' )->with( true ),
+			Lst::pluck( 'name' ),
 			Lst::sort( Relation::gt() ),
 			Lst::join( self::HASH_SEP )
 		);

--- a/src/AutoUpdate/TranslationStatus.php
+++ b/src/AutoUpdate/TranslationStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WPML\PB\AutoUpdate;
+
+use WPML\FP\Maybe;
+use WPML_Post_Element;
+use function WPML\Container\make;
+use function WPML\FP\invoke;
+
+class TranslationStatus {
+
+	/**
+	 * @param WPML_Post_Element $element
+	 *
+	 * @return int|null
+	 */
+	public static function get( WPML_Post_Element $element ) {
+		return Maybe::fromNullable( make( '\WPML_TM_Translation_Status' ) )
+			->map( invoke( 'filter_translation_status' )->with( null, $element->get_trid(), $element->get_language_code() ) )
+			->getOrElse( null );
+	}
+}

--- a/src/Container/Config.php
+++ b/src/Container/Config.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace WPML\PB\Container;
+
+class Config {
+
+	public static function getSharedClasses() {
+		return [
+			'\WPML_PB_Factory',
+			'\WPML_PB_Integration',
+		];
+	}
+}

--- a/src/st/class-wpml-pb-factory.php
+++ b/src/st/class-wpml-pb-factory.php
@@ -4,11 +4,13 @@ use function WPML\Container\make;
 
 class WPML_PB_Factory {
 
+	/** @var wpdb */
 	private $wpdb;
+	/** @var SitePress */
 	private $sitepress;
 	private $string_translations = array();
 
-	public function __construct( $wpdb, $sitepress ) {
+	public function __construct( wpdb $wpdb, SitePress $sitepress ) {
 		$this->wpdb      = $wpdb;
 		$this->sitepress = $sitepress;
 	}

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -103,9 +103,7 @@ class WPML_PB_Integration {
 
 	/** @param int $post_id */
 	private function update_last_editor_mode( $post_id ) {
-		$post_element = $this->factory->get_post_element( $post_id );
-
-		if ( ! $post_element->get_source_language_code() ) {
+		if ( ! $this->is_translation( $post_id ) ) {
 			return;
 		}
 
@@ -118,8 +116,20 @@ class WPML_PB_Integration {
 		}
 	}
 
+	/** @return bool */
 	private function is_editing_translation_with_native_editor() {
-		return isset( $_POST['action'] ) && 'editpost' === $_POST['action'];
+		return isset( $_POST['action'], $_POST['ID'] )
+			&& 'editpost' === $_POST['action']
+			&& $this->is_translation( $_POST['ID'] );
+	}
+
+	/**
+	 * @param int $postId
+	 *
+	 * @return bool
+	 */
+	private function is_translation( $postId ) {
+		return (bool) $this->factory->get_post_element( $postId )->get_source_language_code();
 	}
 
 	/**

--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -1,6 +1,8 @@
 <?php
 
+use WPML\PB\Container\Config;
 use function WPML\Container\make;
+use function WPML\Container\share;
 
 class WPML_PB_Loader {
 
@@ -10,6 +12,8 @@ class WPML_PB_Loader {
 		WPML_ST_Settings $st_settings,
 		$pb_integration = null // Only needed for testing
 	) {
+		share( Config::getSharedClasses() );
+
 		do_action( 'wpml_load_page_builders_integration' );
 
 		$page_builder_strategies = array();
@@ -46,14 +50,14 @@ class WPML_PB_Loader {
 			}
 		}
 
-		self::load_hooks();
+		self::load_hooks( (bool) $page_builder_strategies );
 
 		if ( $page_builder_strategies ) {
 			if ( $pb_integration ) {
 				$factory = $pb_integration->get_factory();
 			} else {
-				$factory        = new WPML_PB_Factory( $wpdb, $sitepress );
-				$pb_integration = new WPML_PB_Integration( $sitepress, $factory );
+				$factory        = make( 'WPML_PB_Factory' );
+				$pb_integration = make( 'WPML_PB_Integration' );
 			}
 			$pb_integration->add_hooks();
 			foreach ( $page_builder_strategies as $strategy ) {
@@ -64,11 +68,23 @@ class WPML_PB_Loader {
 
 	}
 
-	private static function load_hooks() {
+	/**
+	 * @param bool $has_page_builder_strategy
+	 */
+	private static function load_hooks( $has_page_builder_strategy ) {
 		$hooks = [
-			WPML_PB_Handle_Post_Body::class,
 			WPML\PB\Compatibility\Toolset\Layouts\HooksFactory::class,
 		];
+
+		if ( $has_page_builder_strategy ) {
+			$hooks = array_merge(
+				$hooks,
+				[
+					WPML_PB_Handle_Post_Body::class,
+					WPML\PB\AutoUpdate\Hooks::class,
+				]
+			);
+		}
 
 		make( WPML_Action_Filter_Loader::class )->load( $hooks );
 	}

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -45,21 +45,17 @@ class TestHooks extends  TestCase {
 		$post    = (object) [ 'ID' => 123 ];
 		$content = 'some content';
 
-		$package1 = (object) [
-			'string_data' => [
-				'string1B' => 'The string 1B',
-				'string1A' => 'The string 1A',
-			],
-		];
+		$package1 = $this->getPackage( [
+			'string1B' => 'The string 1B',
+			'string1A' => 'The string 1A',
+		] );
 
-		$package2 = (object) [
-			'string_data' => [
-				'string2A' => 'The string 2A',
-				'string2B' => 'The string 2B',
-			],
-		];
+		$package2 = $this->getPackage( [
+			'string2A' => 'The string 2A',
+			'string2B' => 'The string 2B',
+		] );
 
-		$packageWithMissingStringData = (object) [];
+		$packageWithMissingStringData = $this->getPackage( [] );
 
 		// keys are sorted inside each package
 		$expectedPostContentMd5 = 'string1A' . Hooks::HASH_SEP . 'string1B' . Hooks::HASH_SEP . 'string2A' . Hooks::HASH_SEP . 'string2B-';
@@ -190,5 +186,25 @@ class TestHooks extends  TestCase {
 			->willReturn( array_merge( [ $element ], $translations ) );
 
 		return $element;
+	}
+
+	private function getPackage( array $strings ) {
+		$stringsData = [];
+
+		foreach ( $strings as $name => $value ) {
+			$stringsData[] = [
+				'name'  => $name,
+				'value' => $value,
+			];
+		}
+
+		$package = $this->getMockBuilder( '\WPML_Package' )
+			->setMethods( [ 'get_package_strings' ] )
+			->disableOriginalConstructor()->getMock();
+
+		$package->method( 'get_package_strings' )
+			->willReturn( $stringsData );
+
+		return $package;
 	}
 }

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace WPML\PB\AutoUpdate;
+
+use OTGS\PHPUnit\Tools\TestCase;
+use tad\FunctionMocker\FunctionMocker;
+
+/**
+ * @group auto-update
+ */
+class TestHooks extends  TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itAddsHooks() {
+		$subject = $this->getSubject();
+
+		\WP_Mock::expectFilterAdded( 'wpml_tm_post_md5_content', [ $subject, 'getMd5ContentFromPackageStrings' ], 10, 2 );
+		\WP_Mock::expectActionAdded( 'wpml_after_save_post', [ $subject, 'resaveTranslationsAfterSavePost' ], 10, 4 );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itDoesNotAlterMd5PostContentIfNoPackage() {
+		$post    = (object) [ 'ID' => 123 ];
+		$content = 'some content';
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( [], $post->ID )
+			->reply( [] );
+
+		$subject = $this->getSubject();
+
+		$this->assertEquals( $content, $subject->getMd5ContentFromPackageStrings( $content, $post ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itGetsMd5PostContentFromPackagesStrings() {
+		$post    = (object) [ 'ID' => 123 ];
+		$content = 'some content';
+
+		$package1 = (object) [
+			'string_data' => [
+				'string1B' => 'The string 1B',
+				'string1A' => 'The string 1A',
+			],
+		];
+
+		$package2 = (object) [
+			'string_data' => [
+				'string2A' => 'The string 2A',
+				'string2B' => 'The string 2B',
+			],
+		];
+
+		$packageWithMissingStringData = (object) [];
+
+		// keys are sorted inside each package
+		$expectedPostContentMd5 = 'string1A' . Hooks::HASH_SEP . 'string1B' . Hooks::HASH_SEP . 'string2A' . Hooks::HASH_SEP . 'string2B-';
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( [], $post->ID )
+			->reply( [ $package1, $package2, $packageWithMissingStringData ] );
+
+		$subject = $this->getSubject();
+
+		$this->assertEquals( $expectedPostContentMd5, $subject->getMd5ContentFromPackageStrings( $content, $post ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itDoesNotResaveTranslationsIfNotOriginal() {
+		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->expects( $this->never() )->method( 'resave_post_translation_in_shutdown' );
+
+		$factory = $this->getElementFactory();
+		$factory->expects( $this->never() )->method( 'create_post' );
+
+		$subject = $this->getSubject( $pbIntegration, $factory );
+
+		$subject->resaveTranslationsAfterSavePost( 123, 456, 'fr', 'en' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itDoesNotResaveTranslationsIfNoPackage() {
+		$postId = 123;
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( [], $postId )
+			->reply( [] );
+
+		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->expects( $this->never() )->method( 'resave_post_translation_in_shutdown' );
+
+		$factory = $this->getElementFactory();
+		$factory->expects( $this->never() )->method( 'create_post' );
+
+		$subject = $this->getSubject( $pbIntegration, $factory );
+
+		$subject->resaveTranslationsAfterSavePost( $postId, 456, 'fr', null );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itResavesTranslationsAfterSavePost() {
+		$postId = 123;
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( [], $postId )
+			->reply( [ 'some package' ] );
+
+		$translation1            = $this->getElement( 'en' );
+		$translation2            = $this->getElement( 'en' );
+		$translationNotCompleted = $this->getElement( 'en' );
+
+		$original = $this->getElement( null, [ $translation1, $translation2, $translationNotCompleted ] );
+
+		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->expects( $this->exactly( 2 ) )
+			->method( 'resave_post_translation_in_shutdown' )
+			->withConsecutive(
+				[ $translation1 ],
+				[ $translation2 ]
+			);
+
+		$factory = $this->getElementFactory();
+		$factory->method( 'create_post' )->with( $postId )->willReturn( $original );
+
+		FunctionMocker::replace(
+			TranslationStatus::class . '::get',
+			function( $element ) use ( $translationNotCompleted ){
+				return $element === $translationNotCompleted ? 'not completed' : ICL_TM_COMPLETE;
+			}
+		);
+
+		$subject = $this->getSubject( $pbIntegration, $factory );
+
+		$subject->resaveTranslationsAfterSavePost( $postId, 456, 'fr', null );
+	}
+
+	private function getSubject( $pbIntegration = null, $elementFactory = null ) {
+		$pbIntegration  = $pbIntegration ?: $this->getPbIntegration();
+		$elementFactory = $elementFactory ?: $this->getElementFactory();
+
+		return new Hooks( $pbIntegration, $elementFactory );
+	}
+
+	private function getPbIntegration() {
+		return $this->getMockBuilder( '\WPML_PB_Integration' )
+			->setMethods( [ 'resave_post_translation_in_shutdown' ] )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	private function getElementFactory( $postId = null, $element = null ) {
+		$factory = $this->getMockBuilder( '\WPML_Translation_Element_Factory' )
+			->setMethods( [ 'create_post' ] )
+			->disableOriginalConstructor()
+			->getMock();
+
+		if ( $postId && $element ) {
+			$factory->method( 'create_post' )
+				->with( $postId )
+				->willReturn( $element );
+		}
+
+		return $factory;
+	}
+
+	private function getElement( $sourceLang, $translations = [] ) {
+		$element = $this->getMockBuilder( '\WPML_Post_Element' )
+			->setMethods( [ 'get_source_language_code', 'get_translations' ] )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$element->method( 'get_source_language_code' )
+			->willReturn( $sourceLang );
+
+		$element->method( 'get_translations' )
+			->willReturn( array_merge( [ $element ], $translations ) );
+
+		return $element;
+	}
+}

--- a/tests/phpunit/tests/AutoUpdate/TestTranslationStatus.php
+++ b/tests/phpunit/tests/AutoUpdate/TestTranslationStatus.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WPML\PB\AutoUpdate;
+
+use Exception;
+use OTGS\PHPUnit\Tools\TestCase;
+
+/**
+ * @group auto-update
+ */
+class TestTranslationStatus extends TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itGetsAndReturnNullIfClassIsMissing() {
+		\WP_Mock::userFunction( 'WPML\Container\make' )->andReturn( null );
+
+		$this->assertNull( TranslationStatus::get( $this->getElement( 123, 'fr' ) ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itGets() {
+		$trid   = 123;
+		$lang   = 'fr';
+		$status = 999;
+
+		$statusObject = $this->getMockBuilder( '\WPML_TM_Translation_Status' )
+			->setMethods( [ 'filter_translation_status' ] )
+			->getMock();
+
+		$statusObject->method( 'filter_translation_status' )
+			->with( null, $trid, $lang )
+			->willReturn( $status );
+
+		\WP_Mock::userFunction( 'WPML\Container\make' )
+			->with( '\WPML_TM_Translation_Status' )
+			->andReturn( $statusObject );
+
+		$this->assertEquals( $status, TranslationStatus::get( $this->getElement( $trid, $lang ) ) );
+	}
+
+	private function getElement( $trid, $lang ) {
+		$element = $this->getMockBuilder( '\WPML_Post_Element' )
+			->setMethods( [ 'get_trid', 'get_language_code' ] )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$element->method( 'get_trid' )
+			->willReturn( $trid );
+
+		$element->method( 'get_language_code' )
+			->willReturn( $lang );
+
+		return $element;
+	}
+}

--- a/tests/phpunit/tests/st/test-wpml-pb-api-hooks-strategy.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-api-hooks-strategy.php
@@ -14,7 +14,7 @@ class Test_WPML_PB_API_Hooks_Strategy extends WPML_PB_TestCase {
 
 	function test_get_updaters() {
 		$subject = new WPML_PB_API_Hooks_Strategy( '' );
-		$factory = new WPML_PB_Factory( null, null );
+		$factory = $this->getPbFactory();
 		$subject->set_factory( $factory );
 		$this->assertInstanceOf( 'WPML_PB_Update_Post', $subject->get_update_post( array() ) );
 		$this->assertInstanceOf( 'WPML_PB_Update_API_Hooks_In_Content', $subject->get_content_updater( array() ) );
@@ -23,7 +23,7 @@ class Test_WPML_PB_API_Hooks_Strategy extends WPML_PB_TestCase {
 	function test_update_in_content() {
 		$name = rand_str();
 		$strategy = new WPML_PB_API_Hooks_Strategy( $name );
-		$factory = new WPML_PB_Factory( null, null );
+		$factory = $this->getPbFactory();
 		$strategy->set_factory( $factory );
 		$subject = new WPML_PB_Update_API_Hooks_In_Content( $strategy );
 
@@ -59,5 +59,7 @@ class Test_WPML_PB_API_Hooks_Strategy extends WPML_PB_TestCase {
 
 	}
 
-
+	private function getPbFactory() {
+		return new WPML_PB_Factory( $this->createMock( 'wpdb' ), $this->createMock( 'SitePress' ) );
+	}
 }

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -770,11 +770,13 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	 * @group wpmlcore-6120
 	 */
 	public function it_should_set_last_editor_mode_to_native_editor() {
+		$post_id = 123;
+
 		$_POST = array(
 			'action' => 'editpost',
+			'ID'     => $post_id,
 		);
 
-		$post_id      = 123;
 		$post         = $this->get_post( $post_id );
 		$post_element = $this->get_post_element( $post_id, $post );
 		$post_element->method( 'get_source_language_code' )->willReturn( 'en' );

--- a/tests/phpunit/util/wpml-pb-test-case.php
+++ b/tests/phpunit/util/wpml-pb-test-case.php
@@ -20,9 +20,10 @@ abstract class WPML_PB_TestCase extends WPML_PageBuilders_TestCase {
 	}
 
 	protected function get_factory( $wpdb, $sitepress ) {
-		$factory = new WPML_PB_Factory( $wpdb, $sitepress );
+		$wpdb      = $wpdb ?: $this->createMock( 'wpdb' );
+		$sitepress = $sitepress ?: $this->createMock( 'SitePress' );
 
-		return $factory;
+		return new WPML_PB_Factory( $wpdb, $sitepress );
 	}
 
 	protected function get_shortcode_strategy( WPML_PB_Factory $factory, $encoding = '', $encoding_condition = '' ) {


### PR DESCRIPTION
Goes with https://git.onthegosystems.com/wpml/wpml-translation-management/-/merge_requests/1615.

- The content hash used for the translation status will be made of a
concatenation of the package string hashes.
- When updating the original with no string changes, we will resave the
completed translations (applying the string translations on the updated
content).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7263