### PR TITLE
Add `wpml_pb_register_all_strings_for_translation` hook to be able to…

### DIFF
--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -167,6 +167,8 @@ class WPML_PB_Integration {
 		add_action( 'wpml_pro_translation_completed', array( $this, 'cleanup_strings_after_translation_completed' ), 10, 3 );
 
 		add_filter( 'wpml_tm_translation_job_data', array( $this, 'rescan' ), 9, 2 );
+
+		add_action( 'wpml_pb_register_all_strings_for_translation', [ $this, 'register_all_strings_for_translation' ] );
 	}
 
 	/**

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -154,6 +154,11 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array( $pb_integration, 'process_pb_content_with_hidden_strings_only' ), 9, 2 );
 		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array( $pb_integration, 'save_translations_to_post' ), 10 );
 
+		\WP_Mock::expectActionAdded(
+			'wpml_pb_register_all_strings_for_translation',
+			[ $pb_integration, 'register_all_strings_for_translation' ]
+		);
+
 		$pb_integration->add_hooks();
 	}
 


### PR DESCRIPTION
… register strings from a post on demand.

Typically, when a post is saved from edit page, its id is added to the queue and later, `register_all_strings_for_translation`  function is triggered on `shutdown` action. 

I have to run it also when a translation job is created before we reach editor (ATE or CTE )

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmltm-3824

Related MR: https://git.onthegosystems.com/wpml/sitepress-multilingual-cms/-/merge_requests/2719

@OnTheGoSystems/wpml 