### PR TITLE
Handle edge case where there is only one Gutenberg block with a shortcode

### DIFF
--- a/src/st/ShortCodesInGutenbergBlocks.php
+++ b/src/st/ShortCodesInGutenbergBlocks.php
@@ -2,6 +2,8 @@
 
 namespace WPML\PB;
 
+use WPML\FP\Fns;
+
 /**
  * Class ShortCodesInGutenbergBlocks
  * @package WPML\PB
@@ -41,11 +43,8 @@ class ShortCodesInGutenbergBlocks {
 		if ( count( $packagesToUpdate ) > 1 ) {
 			// If we have more than one package then we don't need to 'Force' it.
 			// The normal Gutenberg package will update all translations correctly.
-			foreach ( $packagesToUpdate as $id => $package_data ) {
-				if ( $package_data['package']->kind === self::FORCED_GUTENBERG ) {
-					unset( $packagesToUpdate[ $id ] );
-				}
-			}
+			$isForced         = function ( $package ) { return $package['package']->kind !== self::FORCED_GUTENBERG; };
+			$packagesToUpdate = array_filter( $packagesToUpdate, $isForced );
 		}
 
 		return $packagesToUpdate;

--- a/src/st/ShortCodesInGutenbergBlocks.php
+++ b/src/st/ShortCodesInGutenbergBlocks.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WPML\PB;
+
+/**
+ * Class ShortCodesInGutenbergBlocks
+ * @package WPML\PB
+ *
+ * This class is to handle an edge case when there is only one Gutenberg block
+ * that contains one or more shortcodes.
+ * In this case we need to force the Gutenberg processing as there will be
+ * no Gutenberg strings and only shortcode strings.
+ *
+ */
+class ShortCodesInGutenbergBlocks {
+
+	const FORCED_GUTENBERG = 'Forced-Gutenberg';
+
+	public static function recordPackage(
+		\WPML_PB_String_Translation_By_Strategy $strategy,
+		$strategyKind,
+		\WPML_Package $package,
+		$language
+	) {
+		if ( $strategyKind === 'Gutenberg' && $package->kind === 'Page Builder ShortCode Strings' ) {
+			$package->kind = self::FORCED_GUTENBERG;
+			$strategy->add_package_to_update_list( $package, $language );
+		}
+
+	}
+
+	public static function fixupPackage( $package_data ) {
+		if ( $package_data['package']->kind === self::FORCED_GUTENBERG ) {
+			$package_data['package']->kind = 'Gutenberg';
+		}
+
+		return $package_data;
+	}
+
+	public static function normalizePackages( array $packagesToUpdate ) {
+		if ( count( $packagesToUpdate ) > 1 ) {
+			// If we have more than one package then we don't need to 'Force' it.
+			// The normal Gutenberg package will update all translations correctly.
+			foreach ( $packagesToUpdate as $id => $package_data ) {
+				if ( $package_data['package']->kind === self::FORCED_GUTENBERG ) {
+					unset( $packagesToUpdate[ $id ] );
+				}
+			}
+		}
+
+		return $packagesToUpdate;
+	}
+}

--- a/src/st/class-wpml-pb-string-translation-by-strategy.php
+++ b/src/st/class-wpml-pb-string-translation-by-strategy.php
@@ -1,5 +1,7 @@
 <?php
 
+use WPML\PB\ShortCodesInGutenbergBlocks;
+
 class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation {
 
 	/** @var WPML_PB_Factory $factory */
@@ -22,14 +24,24 @@ class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation 
 		list( $package_id, $string_id, $language ) = $this->get_package_for_translated_string( $translated_string_id );
 		if ( $package_id ) {
 			$package = $this->factory->get_wpml_package( $package_id );
-			if ( $package->post_id && $this->strategy->get_package_kind() === $package->kind ) {
-				$this->add_package_to_update_list( $package, $language );
+			if ( $package->post_id ) {
+				$strategyKind = $this->strategy->get_package_kind();
+				if ( $strategyKind === $package->kind ) {
+					$this->add_package_to_update_list( $package, $language );
+				}
+				ShortCodesInGutenbergBlocks::recordPackage(
+					$this,
+					$strategyKind,
+					$package,
+					$language
+				);
 			}
 		}
 	}
 
 	public function save_translations_to_post() {
 		foreach ( $this->packages_to_update as $package_data ) {
+			$package_data = ShortCodesInGutenbergBlocks::fixupPackage( $package_data );
 			if ( $package_data['package']->kind == $this->strategy->get_package_kind() ) {
 				$update_post = $this->strategy->get_update_post( $package_data );
 				$update_post->update();
@@ -88,5 +100,7 @@ class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation 
 				$this->packages_to_update[ $package->ID ]['languages'][] = $language;
 			}
 		}
+
+		$this->packages_to_update = ShortCodesInGutenbergBlocks::normalizePackages( $this->packages_to_update );
 	}
 }

--- a/tests/phpunit/tests/st/Test_ShortCodesInGutenbergBlocks.php
+++ b/tests/phpunit/tests/st/Test_ShortCodesInGutenbergBlocks.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace WPML\PB;
+
+class Test_ShortCodesInGutenbergBlocks extends \WPML_PB_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_records_package() {
+		$package       = \Mockery::mock( '\WPML_Package' );
+		$package->kind = 'Page Builder ShortCode Strings';
+		$language      = 'de';
+
+		$strategy = \Mockery::mock( '\WPML_PB_String_Translation_By_Strategy' );
+		$strategy->shouldReceive( 'add_package_to_update_list' )
+		         ->once()
+		         ->andReturnUsing( function ( $package, $lang ) use ( $language ) {
+			         $this->assertEquals( ShortCodesInGutenbergBlocks::FORCED_GUTENBERG, $package->kind );
+			         $this->assertEquals( $language, $lang );
+		         } );
+
+		ShortCodesInGutenbergBlocks::recordPackage( $strategy, 'Gutenberg', $package, $language );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_records_package_for_wrong_type() {
+		$package       = \Mockery::mock( '\WPML_Package' );
+		$package->kind = 'Page Builder ShortCode Strings';
+		$language      = 'de';
+
+		$strategy = \Mockery::mock( '\WPML_PB_String_Translation_By_Strategy' );
+		$strategy->shouldReceive( 'add_package_to_update_list' )
+		         ->never();
+
+		ShortCodesInGutenbergBlocks::recordPackage( $strategy, 'other', $package, $language );
+
+		$package->kind = 'other';
+		ShortCodesInGutenbergBlocks::recordPackage( $strategy, 'Gutenberg', $package, $language );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_fixes_package_kind() {
+		$packageData = [ 'package' => (object) [ 'kind' => ShortCodesInGutenbergBlocks::FORCED_GUTENBERG ] ];
+		$fixed = ShortCodesInGutenbergBlocks::fixupPackage( $packageData );
+		$this->assertEquals( 'Gutenberg', $fixed['package']->kind );
+
+		$packageData = [ 'package' => (object) [ 'kind' => 'other' ] ];
+		$fixed = ShortCodesInGutenbergBlocks::fixupPackage( $packageData );
+		$this->assertEquals( 'other', $fixed['package']->kind );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_normalizes_packages() {
+		$id1 = 'id1';
+		$id2 = 'id2';
+		$packageData1 = [ 'package' => (object) [ 'kind' => ShortCodesInGutenbergBlocks::FORCED_GUTENBERG ] ];
+		$packageData2 = [ 'package' => (object) [ 'kind' => 'Gutenberg' ] ];
+
+		$packages = [ $id1 => $packageData1, $id2 => $packageData2 ];
+		$normalized = ShortCodesInGutenbergBlocks::normalizePackages( $packages );
+
+		$this->assertEquals(  [ $id2 => $packageData2 ], $normalized );
+
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_normalizes_packages_if_less_than_two_packages() {
+		$packageData = [ 'package' => (object) [ 'kind' => ShortCodesInGutenbergBlocks::FORCED_GUTENBERG ] ];
+
+		$packages = [ $packageData ];
+		$normalized = ShortCodesInGutenbergBlocks::normalizePackages( $packages );
+
+		$this->assertEquals( $packages, $normalized );
+
+	}
+
+
+}

--- a/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
@@ -1,5 +1,9 @@
 <?php
 
+use tad\FunctionMocker;
+use WPML\FP\Fns;
+use WPML\FP\Lst;
+
 /**
  * @group page-builders
  */
@@ -16,20 +20,36 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		list( $factory_mock, $strategy_mock, $package ) = $this->get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2, $post_id );
 
 		$factory_mock->expects( $this->exactly( 2 ) )
-		        ->method( 'get_wpml_package' )
-		        ->with( $this->equalTo( $string_package_id ) )
-		        ->willReturn( $package );
+		             ->method( 'get_wpml_package' )
+		             ->with( $this->equalTo( $string_package_id ) )
+		             ->willReturn( $package );
 
 		$strategy_mock->expects( $this->exactly( $post_id ? 3 : 0 ) )
-		         ->method( 'get_package_kind' )
-		         ->willReturn( $package->kind );
+		              ->method( 'get_package_kind' )
+		              ->willReturn( $package->kind );
 
 		$wpdb_mock = $this->get_wpdb_mock( $string_package_id, $language_1, $language_2 );
 
 		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb_mock, $factory_mock, $strategy_mock );
+
+		$fixupPackage  = FunctionMocker\replace( 'WPML\PB\ShortCodesInGutenbergBlocks::fixupPackage', Fns::identity() );
+		$recordPackage = FunctionMocker\replace(
+			'WPML\PB\ShortCodesInGutenbergBlocks::recordPackage',
+			function ( $instance, $strategyKind, $thePackage, $language ) use ( $package, $language_1, $language_2 ) {
+				$this->assertInstanceOf( 'WPML_PB_String_Translation_By_Strategy', $instance );
+				$this->assertEquals( $package->kind, $strategyKind );
+				$this->assertTrue( Lst::includes( $language, [ $language_1, $language_2 ] ) );
+				$this->assertEquals( $package, $thePackage );
+			} );
+
+
 		$pb_string_translation->new_translation( $translated_string_id );
 		$pb_string_translation->new_translation( $translated_string_id );
 		$pb_string_translation->save_translations_to_post();
+
+		$expectedPackageData = [ 'package' => $package, 'languages' => [ $language_1, $language_2 ] ];
+		$fixupPackage->wasCalledWithTimes( [ $expectedPackageData ], $post_id ? 1 : 0 );
+		$recordPackage->wasCalledTimes( $post_id ? 2 : 0 );
 	}
 
 	/**
@@ -45,10 +65,14 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		list( $factory_mock, $strategy_mock, $package ) = $this->get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2 );
 		$wpdb_mock = $this->get_wpdb_mock( $string_package_id, $language_1, $language_2 );
 
+		$normalizePackages = FunctionMocker\replace( 'WPML\PB\ShortCodesInGutenbergBlocks::normalizePackages', Fns::identity() );
+
 		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb_mock, $factory_mock, $strategy_mock );
 		$pb_string_translation->add_package_to_update_list( $package, $language_1 );
 		$pb_string_translation->add_package_to_update_list( $package, $language_2 );
 		$pb_string_translation->save_translations_to_post();
+
+		$normalizePackages->wasCalledTimes( 2 );
 	}
 
 	public function new_translations_data_provider() {
@@ -61,28 +85,28 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	private function get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2, $post_id = null ) {
 		$package_kind = rand_str( 32 );
 
-		$factory       = $this->getMockBuilder( 'WPML_PB_Factory' )
-		                      ->setMethods( array( 'get_wpml_package' ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
-		$package       = $this->getMockBuilder( 'WPML_Package' )
-		                      ->setMethods()
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
-		$package->kind = $package_kind;
+		$factory          = $this->getMockBuilder( 'WPML_PB_Factory' )
+		                         ->setMethods( array( 'get_wpml_package' ) )
+		                         ->disableOriginalConstructor()
+		                         ->getMock();
+		$package          = $this->getMockBuilder( 'WPML_Package' )
+		                         ->setMethods()
+		                         ->disableOriginalConstructor()
+		                         ->getMock();
+		$package->kind    = $package_kind;
 		$package->post_id = $post_id;
-		$update = $this->getMockBuilder( 'WPML_PB_Update_Post' )
-		               ->setMethods( [ 'update', 'update_content' ] )
-		               ->disableOriginalConstructor()
-		               ->getMock();
+		$update           = $this->getMockBuilder( 'WPML_PB_Update_Post' )
+		                         ->setMethods( [ 'update', 'update_content' ] )
+		                         ->disableOriginalConstructor()
+		                         ->getMock();
 		$update->expects( $post_id ? $this->once() : $this->never() )
 		       ->method( 'update' );
 
 
-		$strategy = $this->getMockBuilder( 'WPML_PB_Shortcode_Strategy' )
-		                 ->setMethods( array( 'get_package_kind', 'get_update_post' ) )
-		                 ->disableOriginalConstructor()
-		                 ->getMock();
+		$strategy     = $this->getMockBuilder( 'WPML_PB_Shortcode_Strategy' )
+		                     ->setMethods( array( 'get_package_kind', 'get_update_post' ) )
+		                     ->disableOriginalConstructor()
+		                     ->getMock();
 		$package_data = array( 'package' => $package, 'languages' => array( $language_1, $language_2 ) );
 		$strategy->method( 'get_update_post' )
 		         ->with( $this->equalTo( $package_data ) )
@@ -116,11 +140,11 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	 * @dataProvider remove_string_db
 	 */
 	public function remove_string( $delete_count, $job_translated ) {
-		$context = rand_str();
-		$name = rand_str();
-		$job_id = mt_rand();
+		$context              = rand_str();
+		$name                 = rand_str();
+		$job_id               = mt_rand();
 		$translated_string_id = mt_rand();
-		$string_package_id = mt_rand();
+		$string_package_id    = mt_rand();
 
 		\WP_Mock::wpFunction( 'icl_unregister_string', array(
 			'times' => 1, // a string must be always unregistered contrary to a record in `icl_translate`
@@ -128,14 +152,13 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		) );
 
 
-
 		$factory_mock = $this->getMockBuilder( 'WPML_PB_Factory' )
-		                    ->disableOriginalConstructor()
-		                    ->getMock();
-
-		$strategy_mock = $this->getMockBuilder( 'IWPML_PB_Strategy' )
 		                     ->disableOriginalConstructor()
 		                     ->getMock();
+
+		$strategy_mock = $this->getMockBuilder( 'IWPML_PB_Strategy' )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
 
 		$wpdb = $this->stubs->wpdb();
 
@@ -143,7 +166,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		$wpdb->expects( $this->exactly( 2 ) )->method( 'get_var' )->willReturnOnConsecutiveCalls( $job_id, $job_translated );
 		$wpdb->expects( $this->exactly( $delete_count ) )->method( 'delete' )->with( $wpdb->prefix . 'icl_translate', array( 'field_type' => $field_type ), array( '%s' ) );
 		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb, $factory_mock, $strategy_mock );
-		$string_data = array(
+		$string_data           = array(
 			'context'    => $context,
 			'name'       => $name,
 			'package_id' => $string_package_id,
@@ -155,14 +178,14 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	/**
 	 * @test
 	 * @group wpmlst-1215
-	 * @link https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlst-1215
+	 * @link  https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlst-1215
 	 */
 	public function it_should_remove_string_if_job_id_is_null() {
-		$context = rand_str();
-		$name = rand_str();
-		$job_id = null;
+		$context              = rand_str();
+		$name                 = rand_str();
+		$job_id               = null;
 		$translated_string_id = mt_rand();
-		$string_package_id = mt_rand();
+		$string_package_id    = mt_rand();
 
 		\WP_Mock::wpFunction( 'icl_unregister_string', array(
 			'times' => 1,
@@ -183,7 +206,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		$wpdb->expects( $this->exactly( 1 ) )->method( 'get_var' )->willReturn( $job_id );
 		$wpdb->expects( $this->exactly( 1 ) )->method( 'delete' )->with( $wpdb->prefix . 'icl_translate', array( 'field_type' => $field_type ), array( '%s' ) );
 		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb, $factory_mock, $strategy_mock );
-		$string_data = array(
+		$string_data           = array(
 			'context'    => $context,
 			'name'       => $name,
 			'package_id' => $string_package_id,


### PR DESCRIPTION
This is the best I could do. My initial try was to use hooks so the Gutenberg module could override the shortcode logic but this did not work. So I added a simple class here to detect and handle the case for shortcodes.