### PR TITLE
WIP: Hotfix/wpmlcore 7032

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,21 @@
+name: OTGS CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set github token for composer
+        run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run test suite
+        run: ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -28,20 +28,16 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-
         "10up/wp_mock": "~0.2.0",
         "lucatume/function-mocker": "1.3.4",
         "symfony/dom-crawler": "^3.1",
         "symfony/css-selector": "^3.1",
         "phpunit/phpunit": "^5",
         "otgs/phpunit-tools": "dev-master",
-
         "squizlabs/php_codesniffer": "~3",
         "phpcompatibility/php-compatibility": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
-
         "wp-coding-standards/wpcs": "^0",
-
         "m4tthumphrey/php-gitlab-api": "^9.0.0",
         "php-http/guzzle6-adapter": "^1.1",
         "wpml/collect": "dev-wpml-collect-rename"

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,6 @@
             "tests/phpunit/util/"
         ]
     },
-    "repositories": {
-        "collect": {
-            "type": "vcs",
-            "url": "https://github.com/OnTheGoSystems/collect.git"
-        }
-    },
     "require-dev": {
         "roave/security-advisories": "dev-master",
         "10up/wp_mock": "~0.2.0",
@@ -40,6 +34,8 @@
         "wp-coding-standards/wpcs": "^0",
         "m4tthumphrey/php-gitlab-api": "^9.0.0",
         "php-http/guzzle6-adapter": "^1.1",
-        "wpml/collect": "dev-wpml-collect-rename"
+        "wpml/collect": "dev-wpml-collect-rename",
+        "wpml/fp": "dev-master",
+        "wpml/wp": "dev-master"
     }
 }

--- a/src/Compatibility/Toolset/Layouts/Hooks.php
+++ b/src/Compatibility/Toolset/Layouts/Hooks.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WPML\PB\Compatibility\Toolset\Layouts;
+
+class Hooks implements \IWPML_Action {
+
+	public function add_hooks() {
+		add_filter( 'wpml_pb_is_page_builder_page', [ __CLASS__, 'isLayoutPage' ], 10, 2 );
+	}
+
+	/**
+	 * @see Toolset_User_Editors_Editor_Layouts::LAYOUTS_BUILDER_OPTION_NAME
+	 * @see Toolset_User_Editors_Editor_Layouts::LAYOUTS_BUILDER_OPTION_VALUE
+	 *
+	 * @param bool     $isPbPage
+	 * @param \WP_Post $post
+	 */
+	public static function isLayoutPage( $isPbPage, \WP_Post $post ) {
+		if ( 'yes' === get_post_meta( $post->ID, '_private_layouts_template_in_use', true ) ) {
+			return true;
+		}
+
+		return $isPbPage;
+	}
+}

--- a/src/Compatibility/Toolset/Layouts/Hooks.php
+++ b/src/Compatibility/Toolset/Layouts/Hooks.php
@@ -2,7 +2,9 @@
 
 namespace WPML\PB\Compatibility\Toolset\Layouts;
 
-class Hooks implements \IWPML_Action {
+use IWPML_Action;
+
+class Hooks implements IWPML_Action {
 
 	public function add_hooks() {
 		add_filter( 'wpml_pb_is_page_builder_page', [ __CLASS__, 'isLayoutPage' ], 10, 2 );

--- a/src/Compatibility/Toolset/Layouts/HooksFactory.php
+++ b/src/Compatibility/Toolset/Layouts/HooksFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace WPML\PB\Compatibility\Toolset\Layouts;
+
+class HooksFactory implements \IWPML_Backend_Action_Loader, \IWPML_Frontend_Action_Loader {
+
+	public function create() 	{
+		if ( defined( 'WPDDL_VERSION' ) ) {
+			return new Hooks();
+		}
+
+		return null;
+	}
+}

--- a/src/Compatibility/Toolset/Layouts/HooksFactory.php
+++ b/src/Compatibility/Toolset/Layouts/HooksFactory.php
@@ -2,9 +2,12 @@
 
 namespace WPML\PB\Compatibility\Toolset\Layouts;
 
-class HooksFactory implements \IWPML_Backend_Action_Loader, \IWPML_Frontend_Action_Loader {
+use IWPML_Backend_Action_Loader;
+use IWPML_Frontend_Action_Loader;
 
-	public function create() 	{
+class HooksFactory implements IWPML_Backend_Action_Loader, IWPML_Frontend_Action_Loader {
+
+	public function create() {
 		if ( defined( 'WPDDL_VERSION' ) ) {
 			return new Hooks();
 		}

--- a/src/st/ShortCodesInGutenbergBlocks.php
+++ b/src/st/ShortCodesInGutenbergBlocks.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WPML\PB;
+
+use WPML\FP\Fns;
+
+/**
+ * Class ShortCodesInGutenbergBlocks
+ * @package WPML\PB
+ *
+ * This class is to handle an edge case when there is only one Gutenberg block
+ * that contains one or more shortcodes.
+ * In this case we need to force the Gutenberg processing as there will be
+ * no Gutenberg strings and only shortcode strings.
+ *
+ */
+class ShortCodesInGutenbergBlocks {
+
+	const FORCED_GUTENBERG = 'Forced-Gutenberg';
+
+	public static function recordPackage(
+		\WPML_PB_String_Translation_By_Strategy $strategy,
+		$strategyKind,
+		\WPML_Package $package,
+		$language
+	) {
+		if ( $strategyKind === 'Gutenberg' && $package->kind === 'Page Builder ShortCode Strings' ) {
+			$package->kind = self::FORCED_GUTENBERG;
+			$strategy->add_package_to_update_list( $package, $language );
+		}
+
+	}
+
+	public static function fixupPackage( $package_data ) {
+		if ( $package_data['package']->kind === self::FORCED_GUTENBERG ) {
+			$package_data['package']->kind = 'Gutenberg';
+		}
+
+		return $package_data;
+	}
+
+	public static function normalizePackages( array $packagesToUpdate ) {
+		if ( count( $packagesToUpdate ) > 1 ) {
+			// If we have more than one package then we don't need to 'Force' it.
+			// The normal Gutenberg package will update all translations correctly.
+			$isForced         = function ( $package ) { return $package['package']->kind !== self::FORCED_GUTENBERG; };
+			$packagesToUpdate = array_filter( $packagesToUpdate, $isForced );
+		}
+
+		return $packagesToUpdate;
+	}
+}

--- a/src/st/TranslateLinks.php
+++ b/src/st/TranslateLinks.php
@@ -12,16 +12,14 @@ class TranslateLinks {
 	 */
 	public static function getTranslatorForString( \WPML_ST_String_Factory $stringFactory, $activeLanguages ) {
 		return function ( $string_id ) use ( $stringFactory, $activeLanguages ) {
-			$string   = $stringFactory->find_by_id( $string_id );
-			$statuses = \wpml_collect( $string->get_translation_statuses() )->pluck( 'language' );
+			$string = $stringFactory->find_by_id( $string_id );
 
 			$sameStringLanguage = function ( $language ) use ( $string ) {
 				return $language === $string->get_language();
 			};
 
-			$setTranslation = function ( $language ) use ( $statuses, $string ) {
-				$value = $statuses->contains( $language ) ? null : $string->get_value();
-				$string->set_translation( $language, $value );
+			$setTranslation = function ( $language ) use ( $string ) {
+				$string->set_translation( $language, $string->get_value() );
 			};
 
 			\wpml_collect( $activeLanguages )->pluck( 'code' )

--- a/src/st/class-wpml-pb-factory.php
+++ b/src/st/class-wpml-pb-factory.php
@@ -8,7 +8,7 @@ class WPML_PB_Factory {
 	private $sitepress;
 	private $string_translations = array();
 
-	public function __construct( $wpdb, $sitepress ) {
+	public function __construct( wpdb $wpdb, SitePress $sitepress ) {
 		$this->wpdb      = $wpdb;
 		$this->sitepress = $sitepress;
 	}

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -245,6 +245,7 @@ class WPML_PB_Integration {
 			$this->with_strategies( function( IWPML_PB_Strategy $strategy ) {
 				$this->factory->get_string_translations( $strategy )->save_translations_to_post();
 			} );
+			$this->new_translations_recieved = false;
 		}
 	}
 

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -81,13 +81,12 @@ class WPML_PB_Integration {
 			);
 		}
 
-		foreach ( $this->strategies as $strategy ) {
-
+		$this->with_strategies( function( IWPML_PB_Strategy $strategy ) use ( $updated_packages, $post_element ) {
 			foreach ( $updated_packages as $package ) {
 				$this->factory->get_string_translations( $strategy )
 					->add_package_to_update_list( $package, $post_element->get_language_code() );
 			}
-		}
+		} );
 
 		$this->new_translations_recieved = true;
 		$this->queue_save_post_actions( $post_element->get_id(), $post_element->get_wp_object() );
@@ -129,9 +128,9 @@ class WPML_PB_Integration {
 	public function register_all_strings_for_translation( $post ) {
 		if ( $this->is_post_status_ok( $post ) && $this->is_original_post( $post ) ) {
 			$this->is_registering_string = true;
-			foreach ( $this->strategies as $strategy ) {
+			$this->with_strategies( function( IWPML_PB_Strategy $strategy ) use ( $post ) {
 				$strategy->register_strings( $post );
-			}
+			} );
 			$this->is_registering_string = false;
 		}
 	}
@@ -163,7 +162,8 @@ class WPML_PB_Integration {
 		add_action( 'wpml_pb_resave_post_translation', array( $this, 'resave_post_translation_in_shutdown' ), 10, 1 );
 		add_action( 'icl_st_add_string_translation', array( $this, 'new_translation' ), 10, 1 );
 		add_action( 'shutdown', array( $this, 'do_shutdown_action' ) );
-		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'save_translations_to_post' ) );
+		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'process_pb_content_with_hidden_strings_only' ), 9, 2 );
+		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'save_translations_to_post' ), 10 );
 		add_action( 'wpml_pro_translation_completed', array( $this, 'cleanup_strings_after_translation_completed' ), 10, 3 );
 
 		add_filter( 'wpml_tm_translation_job_data', array( $this, 'rescan' ), 9, 2 );
@@ -195,18 +195,56 @@ class WPML_PB_Integration {
 
 	public function new_translation( $translated_string_id ) {
 		if ( ! $this->is_registering_string ) {
-			foreach ( $this->strategies as $strategy ) {
+			$this->with_strategies( function( $strategy ) use ( $translated_string_id ) {
 				$this->factory->get_string_translations( $strategy )->new_translation( $translated_string_id );
-			}
+			} );
 			$this->new_translations_recieved = true;
+		}
+	}
+
+	/**
+	 * @param callable $callable
+	 * 
+	 * @return mixed
+	 */
+	private function with_strategies( callable $callable ) {
+		wpml_collect( $this->strategies )->each( $callable );
+	}
+
+	/**
+	 * When a Page Builder content has only a "LINK" string, it's won't be part
+	 * of the translation job as it's automatically converted.
+	 * We need to add the package to the update list (by strategies).
+	 *
+	 * @param int $new_post_id
+	 * @param int $original_doc_id
+	 */
+	public function process_pb_content_with_hidden_strings_only( $new_post_id, $original_doc_id ) {
+		if (
+			! did_action( 'wpml_add_string_translation' )
+			&& apply_filters( 'wpml_pb_is_page_builder_page', false, get_post( $new_post_id ) )
+		) {
+			$targetLang = $this->sitepress->get_language_for_element( $new_post_id, 'post_' . get_post_type( $new_post_id ) );
+
+			$addPackageToUpdateList = function( WPML_Package $package ) use ( $targetLang ) {
+				$this->with_strategies( function( IWPML_PB_Strategy $strategy ) use ( $package, $targetLang ) {
+					$this->factory
+						->get_string_translations( $strategy )
+						->add_package_to_update_list( $package, $targetLang );
+				} );
+			};
+
+			$this->new_translations_recieved = wpml_collect( apply_filters( 'wpml_st_get_post_string_packages', [], $original_doc_id ) )
+				->each( $addPackageToUpdateList )
+				->isNotEmpty();
 		}
 	}
 
 	public function save_translations_to_post() {
 		if ( $this->new_translations_recieved ) {
-			foreach ( $this->strategies as $strategy ) {
+			$this->with_strategies( function( IWPML_PB_Strategy $strategy ) {
 				$this->factory->get_string_translations( $strategy )->save_translations_to_post();
-			}
+			} );
 		}
 	}
 
@@ -233,9 +271,9 @@ class WPML_PB_Integration {
 			$wpdb = $this->sitepress->get_wpdb();
 			$post = $wpdb->get_row( $wpdb->prepare( "SELECT ID, post_type, post_status, post_content FROM {$wpdb->posts} WHERE ID = %d", $post_id ) );
 			if ( $this->is_post_status_ok( $post ) && $this->is_original_post( $post ) ) {
-				foreach ( $this->strategies as $strategy ) {
+				$this->with_strategies( function( IWPML_PB_Strategy $strategy ) use ( $post_id, $post ) {
 					$strategy->migrate_location( $post_id, $post->post_content );
-				}
+				} );
 			}
 
 			$this->mark_migrate_location_done( $post_id );

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -171,6 +171,7 @@ class WPML_PB_Integration {
 
 		add_action( 'wpml_pb_register_all_strings_for_translation', [ $this, 'register_all_strings_for_translation' ] );
 		add_filter( 'wpml_pb_register_strings_in_content', [ $this, 'register_strings_in_content' ], 10, 3 );
+		add_filter( 'wpml_pb_update_translations_in_content', [ $this, 'update_translations_in_content'], 10, 2 );
 	}
 
 	/**
@@ -252,6 +253,20 @@ class WPML_PB_Integration {
 	}
 
 	/**
+	 * @param string $content
+	 * @param string $lang
+	 *
+	 * @return string
+	 */
+	public function update_translations_in_content( $content, $lang ) {
+		$this->with_strategies( function ( IWPML_PB_Strategy $strategy ) use ( &$content, $lang ) {
+			$content = $this->factory->get_string_translations( $strategy )->update_translations_in_content( $content, $lang );
+		} );
+
+		return $content;
+	}
+
+	/**
 	 * @see https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlst-958
 	 * @param array                $translation_package
 	 * @param WP_Post|WPML_Package $post
@@ -281,9 +296,16 @@ class WPML_PB_Integration {
 		}
 	}
 
+	/**
+	 * @param bool $registered
+	 * @param string|int $post_id
+	 * @param string $content
+	 *
+	 * @return bool
+	 */
 	public function register_strings_in_content( $registered, $post_id, $content ) {
 		foreach ( $this->strategies as $strategy ) {
-			$registered |= $strategy->register_strings_in_content( $post_id, $content, false );
+			$registered = $strategy->register_strings_in_content( $post_id, $content, false ) || $registered;
 		}
 		return $registered;
 	}

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -167,6 +167,8 @@ class WPML_PB_Integration {
 		add_action( 'wpml_pro_translation_completed', array( $this, 'cleanup_strings_after_translation_completed' ), 10, 3 );
 
 		add_filter( 'wpml_tm_translation_job_data', array( $this, 'rescan' ), 9, 2 );
+
+		add_action( 'wpml_pb_register_all_strings_for_translation', [ $this, 'register_all_strings_for_translation' ] );
 	}
 
 	/**

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -20,6 +20,9 @@ class WPML_PB_Integration {
 
 	private $strategies = array();
 
+	/** @var StringCleanUp[]  */
+	private $stringCleanUp = [];
+
 	/**
 	 * @var WPML_PB_Integration_Rescan
 	 */
@@ -172,10 +175,11 @@ class WPML_PB_Integration {
 		add_filter( 'wpml_tm_translation_job_data', array( $this, 'rescan' ), 9, 2 );
 
 		add_action( 'wpml_pb_register_all_strings_for_translation', [ $this, 'register_all_strings_for_translation' ] );
-		add_filter( 'wpml_pb_register_strings_in_content', [ $this, 'register_strings_in_content' ], 10, 4 );
+		add_filter( 'wpml_pb_register_strings_in_content', [ $this, 'register_strings_in_content' ], 10, 3 );
 		add_filter( 'wpml_pb_update_translations_in_content', [ $this, 'update_translations_in_content'], 10, 2 );
 
-		add_filter( 'wpml_pb_get_string_clean_up', [ $this, 'get_string_clean_up' ], 10, 2 );
+		add_action( 'wpml_start_GB_register_strings', [ $this, 'initialize_string_clean_up' ], 10, 1 );
+		add_action( 'wpml_end_GB_register_strings', [ $this, 'clean_up_strings' ], 10, 1 );
 	}
 
 	/**
@@ -308,9 +312,9 @@ class WPML_PB_Integration {
 	 *
 	 * @return bool
 	 */
-	public function register_strings_in_content( $registered, $post_id, $content, WPML\PB\Shortcode\StringCleanUp $stringCleanUp = null) {
+	public function register_strings_in_content( $registered, $post_id, $content ) {
 		foreach ( $this->strategies as $strategy ) {
-			$registered = $strategy->register_strings_in_content( $post_id, $content, $stringCleanUp ) || $registered;
+			$registered = $strategy->register_strings_in_content( $post_id, $content, $this->stringCleanUp[ $post_id ] ) || $registered;
 		}
 		return $registered;
 	}
@@ -319,12 +323,14 @@ class WPML_PB_Integration {
 		return $this->factory;
 	}
 
-	public function get_string_clean_up( $_, $postId ) {
+	public function initialize_string_clean_up( WP_Post $post ) {
 		$shortcodeStrategy = make( WPML_PB_Shortcode_Strategy::class );
 		$shortcodeStrategy->set_factory( $this->factory );
-		$stringCleanUp = new StringCleanUp( $postId, $shortcodeStrategy );
+		$this->stringCleanUp[ $post->ID ] = new StringCleanUp( $post->ID, $shortcodeStrategy );
+	}
 
-		return $stringCleanUp;
+	public function clean_up_strings( WP_Post $post ) {
+		$this->stringCleanUp[ $post->ID ]->cleanUp();
 	}
 
 	/**

--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -54,6 +54,8 @@ class WPML_PB_Loader {
 			$post_body_handler->add_hooks();
 		}
 
+		self::load_hooks();
+
 		if ( $page_builder_strategies ) {
 			if ( $pb_integration ) {
 				$factory = $pb_integration->get_factory();
@@ -68,5 +70,14 @@ class WPML_PB_Loader {
 			}
 		}
 
+	}
+
+	private static function load_hooks() {
+		$hooks = [
+			WPML\PB\Compatibility\Toolset\Layouts\HooksFactory::class,
+		];
+
+		$hooks_loader = new WPML_Action_Filter_Loader();
+		$hooks_loader->load( $hooks );
 	}
 }

--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WPML\Container\make;
+
 class WPML_PB_Loader {
 
 	public function __construct(
@@ -44,16 +46,6 @@ class WPML_PB_Loader {
 			}
 		}
 
-		if ( class_exists( 'WPML_Config_Built_With_Page_Builders' ) ) {
-			$post_body_handler = new WPML_PB_Handle_Post_Body(
-				new WPML_Page_Builders_Page_Built(
-					new WPML_Config_Built_With_Page_Builders()
-				)
-			);
-
-			$post_body_handler->add_hooks();
-		}
-
 		self::load_hooks();
 
 		if ( $page_builder_strategies ) {
@@ -74,10 +66,10 @@ class WPML_PB_Loader {
 
 	private static function load_hooks() {
 		$hooks = [
+			WPML_PB_Handle_Post_Body::class,
 			WPML\PB\Compatibility\Toolset\Layouts\HooksFactory::class,
 		];
 
-		$hooks_loader = new WPML_Action_Filter_Loader();
-		$hooks_loader->load( $hooks );
+		make( WPML_Action_Filter_Loader::class )->load( $hooks );
 	}
 }

--- a/src/st/class-wpml-pb-string-translation-by-strategy.php
+++ b/src/st/class-wpml-pb-string-translation-by-strategy.php
@@ -38,6 +38,22 @@ class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation 
 	}
 
 	/**
+	 * @param string $content
+	 * @param string $lang
+	 *
+	 * @return string
+	 */
+	public function update_translations_in_content( $content, $lang ) {
+		foreach ( $this->packages_to_update as $package_data ) {
+			if ( $package_data['package']->kind == $this->strategy->get_package_kind() ) {
+				$update_post = $this->strategy->get_update_post( $package_data );
+				$content = $update_post->update_content( $content, $lang );
+			}
+		}
+		return $content;
+	}
+
+	/**
 	 * @param int $translated_string_id
 	 *
 	 * @return array

--- a/src/st/class-wpml-pb-string-translation-by-strategy.php
+++ b/src/st/class-wpml-pb-string-translation-by-strategy.php
@@ -1,5 +1,7 @@
 <?php
 
+use WPML\PB\ShortCodesInGutenbergBlocks;
+
 class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation {
 
 	/** @var WPML_PB_Factory $factory */
@@ -22,14 +24,24 @@ class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation 
 		list( $package_id, $string_id, $language ) = $this->get_package_for_translated_string( $translated_string_id );
 		if ( $package_id ) {
 			$package = $this->factory->get_wpml_package( $package_id );
-			if ( $package->post_id && $this->strategy->get_package_kind() === $package->kind ) {
-				$this->add_package_to_update_list( $package, $language );
+			if ( $package->post_id ) {
+				$strategyKind = $this->strategy->get_package_kind();
+				if ( $strategyKind === $package->kind ) {
+					$this->add_package_to_update_list( $package, $language );
+				}
+				ShortCodesInGutenbergBlocks::recordPackage(
+					$this,
+					$strategyKind,
+					$package,
+					$language
+				);
 			}
 		}
 	}
 
 	public function save_translations_to_post() {
 		foreach ( $this->packages_to_update as $package_data ) {
+			$package_data = ShortCodesInGutenbergBlocks::fixupPackage( $package_data );
 			if ( $package_data['package']->kind == $this->strategy->get_package_kind() ) {
 				$update_post = $this->strategy->get_update_post( $package_data );
 				$update_post->update();
@@ -88,5 +100,7 @@ class WPML_PB_String_Translation_By_Strategy extends WPML_PB_String_Translation 
 				$this->packages_to_update[ $package->ID ]['languages'][] = $language;
 			}
 		}
+
+		$this->packages_to_update = ShortCodesInGutenbergBlocks::normalizePackages( $this->packages_to_update );
 	}
 }

--- a/src/st/class-wpml-pb-update-post.php
+++ b/src/st/class-wpml-pb-update-post.php
@@ -1,5 +1,8 @@
 <?php
 
+use \WPML\FP\Wrapper;
+use function \WPML\FP\invoke;
+
 class WPML_PB_Update_Post {
 
 	private $package_data;
@@ -35,6 +38,23 @@ class WPML_PB_Update_Post {
 				$this->update_post( $post_translations[ $lang ]->element_id, $post, $string_translations, $lang );
 			}
 		}
+	}
+
+	/**
+	 * @param string $content
+	 * @param string $lang
+	 *
+	 * @return string
+	 */
+	public function update_content( $content, $lang ) {
+		return Wrapper::of( $this->strategy )
+		              ->map( invoke( 'get_content_updater' ) )
+		              ->map( invoke( 'update_content' )->with(
+			              $content,
+			              $this->package_data['package']->get_translated_strings( [] ),
+			              $lang
+		              ) )
+		              ->get();
 	}
 
 	private function update_post( $translated_post_id, $original_post, $string_translations, $lang ) {

--- a/src/st/compatibility/class-wpml-page-builders-register-strings.php
+++ b/src/st/compatibility/class-wpml-page-builders-register-strings.php
@@ -50,20 +50,21 @@ abstract class WPML_Page_Builders_Register_Strings {
 
 		$this->string_location = 1;
 
-		$data = get_post_meta( $post->ID, $this->data_settings->get_meta_field(), false );
+		if ( $this->data_settings->is_handling_post( $post->ID ) ) {
+			$data = get_post_meta( $post->ID, $this->data_settings->get_meta_field(), false );
 
-		if ( $data ) {
-			$converted = $this->data_settings->convert_data_to_array( $data );
-			if ( is_array( $converted ) ) {
-				$this->register_strings_for_modules(
-					$converted,
-					$package
-				);
+			if ( $data ) {
+				$converted = $this->data_settings->convert_data_to_array( $data );
+				if ( is_array( $converted ) ) {
+					$this->register_strings_for_modules(
+						$converted,
+						$package
+					);
+				}
 			}
 		}
 
 		do_action( 'wpml_delete_unused_package_strings', $package );
-
 	}
 
 	/**

--- a/src/st/compatibility/interface-iwpml-page-builders-data-settings.php
+++ b/src/st/compatibility/interface-iwpml-page-builders-data-settings.php
@@ -45,4 +45,11 @@ interface IWPML_Page_Builders_Data_Settings {
 	public function get_pb_name();
 
 	public function add_hooks();
+
+	/**
+	 * @param int $postId
+	 *
+	 * @return bool
+	 */
+	public function is_handling_post( $postId );
 }

--- a/src/st/strategy/api-hooks/class-wpml-pb-api-hooks-strategy.php
+++ b/src/st/strategy/api-hooks/class-wpml-pb-api-hooks-strategy.php
@@ -19,13 +19,13 @@ class WPML_PB_API_Hooks_Strategy implements IWPML_PB_Strategy {
 	}
 
 	/**
-	 * @param bool $registered
 	 * @param string|int $post_id
 	 * @param string $content
+	 * @param WPML\PB\Shortcode\StringCleanUp $stringCleanUp
 	 *
 	 * @return bool
 	 */
-	public function register_strings_in_content( $post_id, $content, $do_cleanup ) {}
+	public function register_strings_in_content( $post_id, $content, WPML\PB\Shortcode\StringCleanUp $stringCleanUp ) {}
 
 	public function set_factory( $factory ) {
 		$this->factory = $factory;

--- a/src/st/strategy/api-hooks/class-wpml-pb-api-hooks-strategy.php
+++ b/src/st/strategy/api-hooks/class-wpml-pb-api-hooks-strategy.php
@@ -18,6 +18,8 @@ class WPML_PB_API_Hooks_Strategy implements IWPML_PB_Strategy {
 		do_action( 'wpml_page_builder_register_strings', $post, $this->get_package_key( $post->ID ) );
 	}
 
+	public function register_strings_in_content( $post_id, $content, $do_cleanup ) {}
+
 	public function set_factory( $factory ) {
 		$this->factory = $factory;
 	}

--- a/src/st/strategy/api-hooks/class-wpml-pb-api-hooks-strategy.php
+++ b/src/st/strategy/api-hooks/class-wpml-pb-api-hooks-strategy.php
@@ -18,6 +18,13 @@ class WPML_PB_API_Hooks_Strategy implements IWPML_PB_Strategy {
 		do_action( 'wpml_page_builder_register_strings', $post, $this->get_package_key( $post->ID ) );
 	}
 
+	/**
+	 * @param bool $registered
+	 * @param string|int $post_id
+	 * @param string $content
+	 *
+	 * @return bool
+	 */
 	public function register_strings_in_content( $post_id, $content, $do_cleanup ) {}
 
 	public function set_factory( $factory ) {

--- a/src/st/strategy/api-hooks/class-wpml-pb-update-api-hooks-in-content.php
+++ b/src/st/strategy/api-hooks/class-wpml-pb-update-api-hooks-in-content.php
@@ -21,4 +21,15 @@ class WPML_PB_Update_API_Hooks_In_Content {
 
 	}
 
+	/**
+	 * @param string $original_content
+	 * @param array  $string_translations
+	 * @param string $lang
+	 *
+	 * @return string
+	 */
+	public function update_content( $original_content, $string_translations, $lang ) {
+		return $original_content;
+	}
+
 }

--- a/src/st/strategy/interface-iwpml-pb-strategy.php
+++ b/src/st/strategy/interface-iwpml-pb-strategy.php
@@ -11,11 +11,11 @@ interface IWPML_PB_Strategy {
 	/**
 	 * @param int $post_id
 	 * @param string $content
-	 * @param bool $do_cleanup
+	 * @param WPML\PB\Shortcode\StringCleanUp $stringCleanUp
 	 *
 	 * @return bool - true if strings were added.
 	 */
-	public function register_strings_in_content( $post_id, $content, $do_cleanup );
+	public function register_strings_in_content( $post_id, $content, WPML\PB\Shortcode\StringCleanUp $stringCleanUp );
 
 	/**
 	 * @param WPML_PB_Factory $factory

--- a/src/st/strategy/interface-iwpml-pb-strategy.php
+++ b/src/st/strategy/interface-iwpml-pb-strategy.php
@@ -9,6 +9,15 @@ interface IWPML_PB_Strategy {
 	public function register_strings( $post );
 
 	/**
+	 * @param int $post_id
+	 * @param string $content
+	 * @param bool $do_cleanup
+	 *
+	 * @return bool - true if strings were added.
+	 */
+	public function register_strings_in_content( $post_id, $content, $do_cleanup );
+
+	/**
 	 * @param WPML_PB_Factory $factory
 	 *
 	 */

--- a/src/st/strategy/shortcode/StringCleanUp.php
+++ b/src/st/strategy/shortcode/StringCleanUp.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WPML\PB\Shortcode;
+
+use WPML\FP\Fns;
+
+class StringCleanUp {
+
+	/* @var array */
+	private $existingStrings;
+
+	/* @var \WPML_PB_Shortcode_Strategy */
+	private $shortcodeStrategy;
+
+	/**
+	 * StringCleanUp constructor.
+	 *
+	 * @param int                         $postId
+	 * @param \WPML_PB_Shortcode_Strategy $shortcodeStrategy
+	 */
+	public function __construct( $postId, \WPML_PB_Shortcode_Strategy $shortcodeStrategy ) {
+		$this->shortcodeStrategy = $shortcodeStrategy;
+		$this->existingStrings   = $shortcodeStrategy->get_package_strings( $shortcodeStrategy->get_package_key( $postId ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get() {
+		return $this->existingStrings;
+	}
+
+	/**
+	 * @param string $value
+	 */
+	public function remove( $value ) {
+		unset( $this->existingStrings[ md5( $value ) ] );
+	}
+
+	public function cleanUp() {
+		Fns::each( [ $this->shortcodeStrategy, 'remove_string' ], $this->existingStrings );
+	}
+
+}

--- a/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
@@ -1,5 +1,7 @@
 <?php
 
+use WPML\PB\Shortcode\StringCleanUp;
+
 /**
  * Class WPML_PB_Register_Shortcodes
  */
@@ -13,7 +15,9 @@ class WPML_PB_Register_Shortcodes {
 	/** @var WPML_PB_Reuse_Translations_By_Strategy|null $reuse_translations */
 	private $reuse_translations;
 
-	private $existing_package_strings;
+	/** @var StringCleanUp */
+	private $existingStrings;
+
 	/** @var  int $location_index */
 	private $location_index;
 
@@ -36,13 +40,17 @@ class WPML_PB_Register_Shortcodes {
 	}
 
 	/**
-	 * @param string|int $post_id
-	 * @param string $content
-	 * @param bool $is_whole_page
+	 * @param string|int    $post_id
+	 * @param string        $content
+	 * @param StringCleanUp $externalStringCleanUp
 	 *
 	 * @return bool
 	 */
-	public function register_shortcode_strings( $post_id, $content, $is_whole_page ) {
+	public function register_shortcode_strings(
+		$post_id,
+		$content,
+		StringCleanUp $externalStringCleanUp = null
+	) {
 
 		$any_registered = false;
 
@@ -51,12 +59,12 @@ class WPML_PB_Register_Shortcodes {
 		$content = apply_filters( 'wpml_pb_shortcode_content_for_translation', $content, $post_id );
 		$content = WPML_PB_Shortcode_Content_Wrapper::maybeWrap( $content, $this->shortcode_strategy->get_shortcodes() );
 
-		$shortcode_parser               = $this->shortcode_strategy->get_shortcode_parser();
-		$shortcodes                     = $shortcode_parser->get_shortcodes( $content );
-		$this->existing_package_strings = $this->shortcode_strategy->get_package_strings( $this->shortcode_strategy->get_package_key( $post_id ) );
+		$shortcode_parser      = $this->shortcode_strategy->get_shortcode_parser();
+		$shortcodes            = $shortcode_parser->get_shortcodes( $content );
+		$this->existingStrings = $externalStringCleanUp ?: new StringCleanUp( $post_id, $this->shortcode_strategy );
 
 		if ( $this->reuse_translations ) {
-			$this->reuse_translations->set_original_strings( $this->existing_package_strings );
+			$this->reuse_translations->set_original_strings( $this->existingStrings->get() );
 		}
 
 		foreach ( $shortcodes as $shortcode ) {
@@ -86,11 +94,11 @@ class WPML_PB_Register_Shortcodes {
 		}
 
 		if ( $this->reuse_translations ) {
-			$this->reuse_translations->find_and_reuse( $post_id, $this->existing_package_strings );
+			$this->reuse_translations->find_and_reuse( $post_id, $this->existingStrings->get() );
 		}
 
-		if( $is_whole_page ) {
-			$this->clean_up_package_leftovers();
+		if( ! $externalStringCleanUp ) {
+			$this->existingStrings->cleanUp();
 			$this->mark_post_as_migrate_location_done( $post_id );
 		}
 
@@ -164,7 +172,9 @@ class WPML_PB_Register_Shortcodes {
 				}
 			}
 		} else {
-			$this->remove_from_clean_up_list( $content );
+			if ( $this->existingStrings ) {
+				$this->existingStrings->remove( $content );
+			}
 			try {
 				$string_id    = $this->handle_strings->get_string_id_from_package( $post_id, $content );
 				$string_title = $this->get_updated_shortcode_string_title( $string_id, $shortcode, $attribute );
@@ -178,21 +188,6 @@ class WPML_PB_Register_Shortcodes {
 		}
 
 		return $string_id !== 0;
-	}
-
-	private function remove_from_clean_up_list( $value ) {
-		$hash_value = md5( $value );
-		if ( isset( $this->existing_package_strings[ $hash_value ] ) ) {
-			unset( $this->existing_package_strings[ $hash_value ] );
-		}
-	}
-
-	private function clean_up_package_leftovers() {
-		if ( ! empty( $this->existing_package_strings ) ) {
-			foreach ( $this->existing_package_strings as $string_data ) {
-				$this->shortcode_strategy->remove_string( $string_data );
-			}
-		}
 	}
 
 	/**

--- a/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
@@ -35,7 +35,14 @@ class WPML_PB_Register_Shortcodes {
 		$this->reuse_translations     = $reuse_translations;
 	}
 
-	public function register_shortcode_strings( $post_id, $content, $do_cleanup ) {
+	/**
+	 * @param string|int $post_id
+	 * @param string $content
+	 * @param bool $is_whole_page
+	 *
+	 * @return bool
+	 */
+	public function register_shortcode_strings( $post_id, $content, $is_whole_page ) {
 
 		$any_registered = false;
 
@@ -60,7 +67,7 @@ class WPML_PB_Register_Shortcodes {
 				$encoding_condition = $this->shortcode_strategy->get_shortcode_tag_encoding_condition( $shortcode['tag'] );
 				$type               = $this->shortcode_strategy->get_shortcode_tag_type( $shortcode['tag'] );
 				$shortcode_content  = $this->encoding->decode( $shortcode_content, $encoding, $encoding_condition );
-				$any_registered |= $this->register_string( $post_id, $shortcode_content, $shortcode, 'content', $type );
+				$any_registered     = $this->register_string( $post_id, $shortcode_content, $shortcode, 'content', $type ) || $any_registered;
 			}
 
 			$attributes              = (array) shortcode_parse_atts( $shortcode['attributes'] );
@@ -72,7 +79,7 @@ class WPML_PB_Register_Shortcodes {
 						$type       = $this->shortcode_strategy->get_shortcode_attribute_type( $shortcode['tag'], $attr );
 						$attr_value = $this->encoding->decode( $attr_value, $encoding );
 
-						$any_registered |= $this->register_string( $post_id, $attr_value, $shortcode, $attr, $type );
+						$any_registered = $this->register_string( $post_id, $attr_value, $shortcode, $attr, $type ) || $any_registered;
 					}
 				}
 			}
@@ -82,11 +89,10 @@ class WPML_PB_Register_Shortcodes {
 			$this->reuse_translations->find_and_reuse( $post_id, $this->existing_package_strings );
 		}
 
-		if( $do_cleanup ) {
+		if( $is_whole_page ) {
 			$this->clean_up_package_leftovers();
+			$this->mark_post_as_migrate_location_done( $post_id );
 		}
-
-		$this->mark_post_as_migrate_location_done( $post_id );
 
 		return $any_registered;
 	}

--- a/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-register-shortcodes.php
@@ -40,6 +40,7 @@ class WPML_PB_Register_Shortcodes {
 		$this->location_index = 1;
 
 		$content = apply_filters( 'wpml_pb_shortcode_content_for_translation', $content, $post_id );
+		$content = WPML_PB_Shortcode_Content_Wrapper::maybeWrap( $content, $this->shortcode_strategy->get_shortcodes() );
 
 		$shortcode_parser               = $this->shortcode_strategy->get_shortcode_parser();
 		$shortcodes                     = $shortcode_parser->get_shortcodes( $content );

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcode-content-wrapper.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcode-content-wrapper.php
@@ -3,12 +3,13 @@
 use WPML\FP\Logic;
 use WPML\FP\Maybe;
 use WPML\FP\Str;
+use WPML\LIB\WP\Gutenberg;
 use function WPML\FP\pipe;
+
 
 class WPML_PB_Shortcode_Content_Wrapper {
 
 	const WRAPPER_SHORTCODE_NAME  = 'wpml_string_wrapper';
-	const GUTENBERG_OPENING_START = '<!-- wp:';
 
 	/** @var string $content */
 	private $content;
@@ -264,11 +265,10 @@ class WPML_PB_Shortcode_Content_Wrapper {
 	 * @return string
 	 */
 	public static function maybeWrap( $content, array $shortcodes ) {
-		$notGutenbergContent  = pipe( Str::includes( self::GUTENBERG_OPENING_START ), Logic::not() );
 		$containsOneShortcode = pipe( Str::match( '/' . get_shortcode_regex( $shortcodes ) . '/s' ), Logic::isEmpty(), Logic::not() );
 
 		return Maybe::of( $content )
-			->filter( $notGutenbergContent )
+			->filter( Gutenberg::doesNotHaveBlock() )
 			->filter( $containsOneShortcode )
 			->filter( [ self::class, 'isStrippedContentDifferent' ] )
 			->map( [ self::class, 'wrap' ] )

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
@@ -98,21 +98,21 @@ class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 	 */
 	public function register_strings( $post ) {
 		if ( Gutenberg::doesNotHaveBlock( $post->post_content ) ) {
-			$this->register_strings_in_content( $post->ID, $post->post_content, true );
+			$this->register_strings_in_content( $post->ID, $post->post_content, null );
 		}
 	}
 
 	/**
 	 * @param string|int $post_id
 	 * @param string     $content
-	 * @param bool       $do_cleanup
+	 * @param WPML\PB\Shortcode\StringCleanUp $stringCleanUp
 	 *
 	 * @return bool
 	 */
-	public function register_strings_in_content( $post_id, $content, $do_cleanup ) {
+	public function register_strings_in_content( $post_id, $content, WPML\PB\Shortcode\StringCleanUp $stringCleanUp = null ) {
 		$register_shortcodes = $this->factory->get_register_shortcodes( $this );
 
-		return $register_shortcodes->register_shortcode_strings( $post_id, $content, $do_cleanup );
+		return $register_shortcodes->register_shortcode_strings( $post_id, $content, $stringCleanUp );
 	}
 
 	public function set_factory( $factory ) {
@@ -155,6 +155,6 @@ class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 	 */
 	public function migrate_location( $post_id, $post_content ) {
 		$migrate_locations = $this->factory->get_register_shortcodes( $this, true );
-		$migrate_locations->register_shortcode_strings( $post_id, $post_content, true );
+		$migrate_locations->register_shortcode_strings( $post_id, $post_content, null );
 	}
 }

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
@@ -1,5 +1,7 @@
 <?php
 
+use \WPML\LIB\WP\Gutenberg;
+
 class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 
 	private $shortcodes = array(
@@ -95,8 +97,14 @@ class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 	 *
 	 */
 	public function register_strings( $post ) {
+		if ( Gutenberg::doesNotHaveBlock( $post->post_content ) ) {
+			$this->register_strings_in_content( $post->ID, $post->post_content, true );
+		}
+	}
+
+	public function register_strings_in_content( $post_id, $content, $do_cleanup ) {
 		$register_shortcodes = $this->factory->get_register_shortcodes( $this );
-		$register_shortcodes->register_shortcode_strings( $post->ID, $post->post_content );
+		return $register_shortcodes->register_shortcode_strings( $post_id, $content, $do_cleanup );
 	}
 
 	public function set_factory( $factory ) {

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
@@ -102,8 +102,16 @@ class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 		}
 	}
 
+	/**
+	 * @param string|int $post_id
+	 * @param string     $content
+	 * @param bool       $do_cleanup
+	 *
+	 * @return bool
+	 */
 	public function register_strings_in_content( $post_id, $content, $do_cleanup ) {
 		$register_shortcodes = $this->factory->get_register_shortcodes( $this );
+
 		return $register_shortcodes->register_shortcode_strings( $post_id, $content, $do_cleanup );
 	}
 

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcode-strategy.php
@@ -155,6 +155,6 @@ class WPML_PB_Shortcode_Strategy implements IWPML_PB_Strategy {
 	 */
 	public function migrate_location( $post_id, $post_content ) {
 		$migrate_locations = $this->factory->get_register_shortcodes( $this, true );
-		$migrate_locations->register_shortcode_strings( $post_id, $post_content );
+		$migrate_locations->register_shortcode_strings( $post_id, $post_content, true );
 	}
 }

--- a/src/st/strategy/shortcode/class-wpml-pb-shortcodes.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-shortcodes.php
@@ -70,8 +70,6 @@ class WPML_PB_Shortcodes {
 			return false;
 		}
 
-		$content_with_stripped_shortcode = preg_replace( '/\[([\S]*)[^\]]*\][\s\S]*\[\/(\1)\]|\[[^\]]*\]/', '', $content );
-		$content_with_stripped_shortcode = trim( $content_with_stripped_shortcode );
-		return ! empty( $content_with_stripped_shortcode ) && trim( $content ) !== $content_with_stripped_shortcode;
+		return WPML_PB_Shortcode_Content_Wrapper::isStrippedContentDifferent( $content );
 	}
 }

--- a/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
@@ -43,6 +43,7 @@ class WPML_PB_Update_Shortcodes_In_Content {
 	}
 
 	public function update_content( $original_content, $string_translations, $lang ) {
+		$original_content          = WPML_PB_Shortcode_Content_Wrapper::maybeWrap( $original_content, $this->strategy->get_shortcodes() );
 		$this->new_content         = $original_content;
 		$this->string_translations = $string_translations;
 		$this->lang                = $lang;
@@ -55,7 +56,7 @@ class WPML_PB_Update_Shortcodes_In_Content {
 			$this->update_shortcode_attributes( $shortcode );
 		}
 
-		return $this->new_content;
+		return WPML_PB_Shortcode_Content_Wrapper::unwrap( $this->new_content );
 	}
 
 	private function update_shortcodes( $shortcode_data ) {
@@ -90,7 +91,7 @@ class WPML_PB_Update_Shortcodes_In_Content {
 		if ( $translation ) {
 
 			if ( $this->is_string_too_long_for_regex( $original ) ) {
-				$block             = $this->remove_wrappers( $block );
+				$block             = WPML_PB_Shortcode_Content_Wrapper::unwrap( $block );
 				$new_block         = str_replace( $original, $translation, $block );
 				$this->new_content = str_replace( $block, $new_block, $this->new_content );
 			} else {
@@ -104,8 +105,8 @@ class WPML_PB_Update_Shortcodes_In_Content {
 				}
 
 				$new_block   = preg_replace( $pattern, $replacement, $block );
-				$block       = $this->remove_wrappers( $block );
-				$new_block   = $this->remove_wrappers( $new_block );
+				$block       = WPML_PB_Shortcode_Content_Wrapper::unwrap( $block );
+				$new_block   = WPML_PB_Shortcode_Content_Wrapper::unwrap( $new_block );
 				$replacement = $this->escape_backward_reference_on_replacement_string( $new_block );
 
 				if ( $used_wrapper ) {
@@ -129,20 +130,6 @@ class WPML_PB_Update_Shortcodes_In_Content {
 	 */
 	private function escape_backward_reference_on_replacement_string( $string ) {
 		return preg_replace( '/\$([\d]{1,2})/', '\\\$' . '${1}', $string );
-	}
-
-	/**
-	 * @param string $block
-	 *
-	 * @return string
-	 */
-	private function remove_wrappers( $block ) {
-		$wrappers_to_remove = array(
-			'[' . WPML_PB_Shortcode_Content_Wrapper::WRAPPER_SHORTCODE_NAME . ']',
-			'[/' . WPML_PB_Shortcode_Content_Wrapper::WRAPPER_SHORTCODE_NAME . ']',
-		);
-
-		return str_replace( $wrappers_to_remove, '', $block );
 	}
 
 	private function replace_content_without_delimiters( $block, $replacement ) {

--- a/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
@@ -118,7 +118,11 @@ class WPML_PB_Update_Shortcodes_In_Content {
 				if ( $used_wrapper ) {
 					$this->new_content = $this->replace_content_without_delimiters( $block, $replacement );
 				} else {
-					$this->new_content = preg_replace( '/' . preg_quote( $block, '/' ) . '/', $replacement, $this->new_content, 1 );
+					if (!$this->is_string_too_long_for_regex( $block )) {
+						$this->new_content = preg_replace( '/' . preg_quote( $block, '/' ) . '/', $replacement, $this->new_content, 1 );
+					} else {
+						$this->new_content = str_replace( $block, $replacement, $this->new_content );
+					}
 				}
 			}
 		}

--- a/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
+++ b/src/st/strategy/shortcode/class-wpml-pb-update-shortcodes-in-content.php
@@ -1,5 +1,7 @@
 <?php
 
+use WPML\LIB\WP\Gutenberg;
+
 class WPML_PB_Update_Shortcodes_In_Content {
 
 	const LONG_STRING_THRESHOLD = 5000;
@@ -19,6 +21,10 @@ class WPML_PB_Update_Shortcodes_In_Content {
 	}
 
 	public function update( $translated_post_id, $original_post, $string_translations, $lang ) {
+		if ( Gutenberg::hasBlock( $original_post->post_content ) ) {
+			return;
+		}
+
 		$original_content = $original_post->post_content;
 		$original_content = apply_filters( 'wpml_pb_shortcode_content_for_translation', $original_content, $original_post->ID );
 

--- a/src/tm/class-wpml-pb-handle-custom-fields.php
+++ b/src/tm/class-wpml-pb-handle-custom-fields.php
@@ -60,6 +60,10 @@ class WPML_PB_Handle_Custom_Fields {
 	 * @return mixed string
 	 */
 	public static function slash_json( $data ) {
+		if ( ! is_string( $data ) ) {
+			return $data;
+		}
+
  		json_decode( $data );
 		if ( json_last_error() === JSON_ERROR_NONE ) {
 			return wp_slash( $data );

--- a/src/tm/class-wpml-pb-handle-custom-fields.php
+++ b/src/tm/class-wpml-pb-handle-custom-fields.php
@@ -23,7 +23,7 @@ class WPML_PB_Handle_Custom_Fields {
 	 * @return bool
 	 */
 	public function is_page_builder_page_filter( $is_page_builder_page, WP_Post $post ) {
-		if ( get_post_meta( $post->ID, $this->data_settings->get_meta_field() ) ) {
+		if ( $this->data_settings->is_handling_post( $post->ID ) ) {
 			$is_page_builder_page = true;
 		}
 

--- a/src/tm/class-wpml-pb-handle-post-body.php
+++ b/src/tm/class-wpml-pb-handle-post-body.php
@@ -1,6 +1,6 @@
 <?php
 
-class WPML_PB_Handle_Post_Body {
+class WPML_PB_Handle_Post_Body implements IWPML_Backend_Action, IWPML_Frontend_Action, IWPML_DIC_Action {
 
 	private $page_builders_built;
 

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -25,6 +25,14 @@ class WPML_TM_Page_Builders {
 	 */
 	public function translation_job_data_filter( array $translation_package, $post ) {
 		if ( self::PACKAGE_TYPE_EXTERNAL !== $translation_package['type'] && isset( $post->ID ) ) {
+
+			$translation_package['contents']['body']['translate'] = (int) apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
+
+			if ( $translation_package['contents']['body']['translate'] ) {
+				// If eventually, the post body must be translated, we won't include the package strings.
+				return $translation_package;
+			}
+
 			$post_element        = new WPML_Post_Element( $post->ID, $this->sitepress );
 			$source_post_id      = $post->ID;
 			$source_post_element = $post_element->get_source_element();
@@ -37,8 +45,6 @@ class WPML_TM_Page_Builders {
 			$job_source_is_not_post_source = $post->ID !== $source_post_id;
 
 			$string_packages = apply_filters( 'wpml_st_get_post_string_packages', false, $source_post_id );
-
-			$translation_package['contents']['body']['translate'] = apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
 
 			if ( $string_packages ) {
 

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -26,13 +26,6 @@ class WPML_TM_Page_Builders {
 	public function translation_job_data_filter( array $translation_package, $post ) {
 		if ( self::PACKAGE_TYPE_EXTERNAL !== $translation_package['type'] && isset( $post->ID ) ) {
 
-			$translation_package['contents']['body']['translate'] = (int) apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
-
-			if ( $translation_package['contents']['body']['translate'] ) {
-				// If eventually, the post body must be translated, we won't include the package strings.
-				return $translation_package;
-			}
-
 			$post_element        = new WPML_Post_Element( $post->ID, $this->sitepress );
 			$source_post_id      = $post->ID;
 			$source_post_element = $post_element->get_source_element();
@@ -45,6 +38,8 @@ class WPML_TM_Page_Builders {
 			$job_source_is_not_post_source = $post->ID !== $source_post_id;
 
 			$string_packages = apply_filters( 'wpml_st_get_post_string_packages', false, $source_post_id );
+
+			$translation_package['contents']['body']['translate'] = apply_filters( 'wpml_pb_should_body_be_translated', $translation_package['contents']['body']['translate'], $post );
 
 			if ( $string_packages ) {
 

--- a/src/tm/class-wpml-tm-page-builders.php
+++ b/src/tm/class-wpml-tm-page-builders.php
@@ -92,11 +92,15 @@ class WPML_TM_Page_Builders {
 	}
 
 	/**
-	 * @param int      $new_post_id
+	 * @param int      $new_element_id
 	 * @param array    $fields
 	 * @param stdClass $job
 	 */
-	public function pro_translation_completed_action( $new_post_id, array $fields, stdClass $job ) {
+	public function pro_translation_completed_action( $new_element_id, array $fields, stdClass $job ) {
+		if ( 'post' !== $job->element_type_prefix ) {
+			return;
+		}
+
 		foreach ( $fields as $field_id => $field ) {
 			$field_slug = isset( $field['field_type'] ) ? $field['field_type'] : $field_id;
 			$wrapper = $this->create_field_wrapper( $field_slug );
@@ -115,7 +119,7 @@ class WPML_TM_Page_Builders {
 			}
 		}
 
-		do_action( 'wpml_pb_finished_adding_string_translations', $new_post_id, $job->original_doc_id, $fields );
+		do_action( 'wpml_pb_finished_adding_string_translations', $new_element_id, $job->original_doc_id, $fields );
 	}
 
 	/**

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,4 +1,7 @@
 <?php
+
+use tad\FunctionMocker\FunctionMocker;
+
 define( 'WPML_ST_SITE_URL', 'https://domain.tld' );
 
 define( 'WPML_ST_TESTS_MAIN_FILE', __DIR__ . '/../../plugin.php' );
@@ -37,3 +40,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+FunctionMocker::init(
+	[
+		'blacklist' => [],
+		'whitelist' => [],
+		'redefinable-internals' => [
+			'defined',
+		],
+	]
+);

--- a/tests/phpunit/stubs/action-loader-stubs.php
+++ b/tests/phpunit/stubs/action-loader-stubs.php
@@ -1,0 +1,4 @@
+<?php
+
+interface IWPML_Backend_Action_Loader {}
+interface IWPML_Frontend_Action_Loader {}

--- a/tests/phpunit/stubs/action-loader-stubs.php
+++ b/tests/phpunit/stubs/action-loader-stubs.php
@@ -2,3 +2,6 @@
 
 interface IWPML_Backend_Action_Loader {}
 interface IWPML_Frontend_Action_Loader {}
+interface IWPML_Backend_Action {}
+interface IWPML_Frontend_Action {}
+interface IWPML_DIC_Action {}

--- a/tests/phpunit/tests/Compatibility/Toolset/Layouts/TestHooks.php
+++ b/tests/phpunit/tests/Compatibility/Toolset/Layouts/TestHooks.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace WPML\PB\Compatibility\Toolset\Layouts;
+
+/**
+ * @group compatibility
+ * @group toolset
+ * @group layouts
+ */
+class TestHooks extends \OTGS\PHPUnit\Tools\TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itImplementActionLoader() {
+		$subject = new Hooks();
+		$this->assertInstanceOf( '\IWPML_Action', $subject );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = new Hooks();
+		\WP_Mock::expectFilterAdded( 'wpml_pb_is_page_builder_page', [ Hooks::class, 'isLayoutPage' ], 10, 2 );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpItShouldNotFilterIsLayoutPageIfNotLayoutPage
+	 *
+	 * @param mixed $metaValue
+	 */
+	public function itShouldNotFilterIsLayoutPageIfNotLayoutPage( $metaValue ) {
+		$isPbPage = 'some-boolean';
+		$post     = $this->getPost( 123 );
+
+		\WP_Mock::userFunction( 'get_post_meta' )
+			->with( $post->ID, '_private_layouts_template_in_use', true )
+			->andReturn( $metaValue );
+
+		$this->assertEquals( $isPbPage, Hooks::isLayoutPage( $isPbPage, $post ) );
+	}
+
+	public function dpItShouldNotFilterIsLayoutPageIfNotLayoutPage() {
+		return [
+			[ '' ],
+			[ 'no' ],
+		];
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldNotFilterIsLayoutPage() {
+		$isPbPage = 'some-boolean';
+		$post     = $this->getPost( 123 );
+
+		\WP_Mock::userFunction( 'get_post_meta' )
+			->with( $post->ID, '_private_layouts_template_in_use', true )
+			->andReturn( 'yes' );
+
+		$this->assertTrue( Hooks::isLayoutPage( $isPbPage, $post ) );
+	}
+
+	/**
+	 * @param int $id
+	 *
+	 * @return \PHPUnit_Framework_MockObject_MockObject|\WP_Post
+	 */
+	private function getPost( $id ) {
+		$post = $this->createMock( 'WP_Post' );
+		$post->ID = $id;
+
+		return $post;
+	}
+}

--- a/tests/phpunit/tests/Compatibility/Toolset/Layouts/TestHooks.php
+++ b/tests/phpunit/tests/Compatibility/Toolset/Layouts/TestHooks.php
@@ -2,19 +2,21 @@
 
 namespace WPML\PB\Compatibility\Toolset\Layouts;
 
+use OTGS\PHPUnit\Tools\TestCase;
+
 /**
  * @group compatibility
  * @group toolset
  * @group layouts
  */
-class TestHooks extends \OTGS\PHPUnit\Tools\TestCase {
+class TestHooks extends TestCase {
 
 	/**
 	 * @test
 	 */
 	public function itImplementActionLoader() {
 		$subject = new Hooks();
-		$this->assertInstanceOf( '\IWPML_Action', $subject );
+		$this->assertInstanceOf( \IWPML_Action::class, $subject );
 	}
 
 	/**

--- a/tests/phpunit/tests/Compatibility/Toolset/Layouts/TestHooksFactory.php
+++ b/tests/phpunit/tests/Compatibility/Toolset/Layouts/TestHooksFactory.php
@@ -2,6 +2,7 @@
 
 namespace WPML\PB\Compatibility\Toolset\Layouts;
 
+use OTGS\PHPUnit\Tools\TestCase;
 use Peast\Syntax\Node\Function_;
 use tad\FunctionMocker\FunctionMocker;
 
@@ -10,15 +11,15 @@ use tad\FunctionMocker\FunctionMocker;
  * @group toolset
  * @group layouts
  */
-class TestHooksFactory extends \OTGS\PHPUnit\Tools\TestCase {
+class TestHooksFactory extends TestCase {
 
 	/**
 	 * @test
 	 */
 	public function itLoadsOnBackendAndFrontend() {
 		$subject = new HooksFactory();
-		$this->assertInstanceOf( '\IWPML_Backend_Action_Loader', $subject );
-		$this->assertInstanceOf( '\IWPML_Frontend_Action_Loader', $subject );
+		$this->assertInstanceOf( \IWPML_Backend_Action_Loader::class, $subject );
+		$this->assertInstanceOf( \IWPML_Frontend_Action_Loader::class, $subject );
 	}
 
 	/**

--- a/tests/phpunit/tests/Compatibility/Toolset/Layouts/TestHooksFactory.php
+++ b/tests/phpunit/tests/Compatibility/Toolset/Layouts/TestHooksFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WPML\PB\Compatibility\Toolset\Layouts;
+
+use Peast\Syntax\Node\Function_;
+use tad\FunctionMocker\FunctionMocker;
+
+/**
+ * @group compatibility
+ * @group toolset
+ * @group layouts
+ */
+class TestHooksFactory extends \OTGS\PHPUnit\Tools\TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itLoadsOnBackendAndFrontend() {
+		$subject = new HooksFactory();
+		$this->assertInstanceOf( '\IWPML_Backend_Action_Loader', $subject );
+		$this->assertInstanceOf( '\IWPML_Frontend_Action_Loader', $subject );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsNullIfLayoutsNotActive() {
+		$defined = FunctionMocker::replace( 'defined', false );
+
+		$subject = new HooksFactory();
+		$this->assertNull( $subject->create() );
+
+		$defined->wasCalledWithOnce( [ 'WPDDL_VERSION' ] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsHooksObjectIfLayoutsActive() {
+		$defined = FunctionMocker::replace( 'defined', true );
+
+		$subject = new HooksFactory();
+		$this->assertInstanceOf( Hooks::class, $subject->create() );
+
+		$defined->wasCalledWithOnce( [ 'WPDDL_VERSION' ] );
+	}
+}

--- a/tests/phpunit/tests/st/Test_ShortCodesInGutenbergBlocks.php
+++ b/tests/phpunit/tests/st/Test_ShortCodesInGutenbergBlocks.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace WPML\PB;
+
+class Test_ShortCodesInGutenbergBlocks extends \WPML_PB_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_records_package() {
+		$package       = \Mockery::mock( '\WPML_Package' );
+		$package->kind = 'Page Builder ShortCode Strings';
+		$language      = 'de';
+
+		$strategy = \Mockery::mock( '\WPML_PB_String_Translation_By_Strategy' );
+		$strategy->shouldReceive( 'add_package_to_update_list' )
+		         ->once()
+		         ->andReturnUsing( function ( $package, $lang ) use ( $language ) {
+			         $this->assertEquals( ShortCodesInGutenbergBlocks::FORCED_GUTENBERG, $package->kind );
+			         $this->assertEquals( $language, $lang );
+		         } );
+
+		ShortCodesInGutenbergBlocks::recordPackage( $strategy, 'Gutenberg', $package, $language );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_records_package_for_wrong_type() {
+		$package       = \Mockery::mock( '\WPML_Package' );
+		$package->kind = 'Page Builder ShortCode Strings';
+		$language      = 'de';
+
+		$strategy = \Mockery::mock( '\WPML_PB_String_Translation_By_Strategy' );
+		$strategy->shouldReceive( 'add_package_to_update_list' )
+		         ->never();
+
+		ShortCodesInGutenbergBlocks::recordPackage( $strategy, 'other', $package, $language );
+
+		$package->kind = 'other';
+		ShortCodesInGutenbergBlocks::recordPackage( $strategy, 'Gutenberg', $package, $language );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_fixes_package_kind() {
+		$packageData = [ 'package' => (object) [ 'kind' => ShortCodesInGutenbergBlocks::FORCED_GUTENBERG ] ];
+		$fixed = ShortCodesInGutenbergBlocks::fixupPackage( $packageData );
+		$this->assertEquals( 'Gutenberg', $fixed['package']->kind );
+
+		$packageData = [ 'package' => (object) [ 'kind' => 'other' ] ];
+		$fixed = ShortCodesInGutenbergBlocks::fixupPackage( $packageData );
+		$this->assertEquals( 'other', $fixed['package']->kind );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_normalizes_packages() {
+		$id1 = 'id1';
+		$id2 = 'id2';
+		$packageData1 = [ 'package' => (object) [ 'kind' => ShortCodesInGutenbergBlocks::FORCED_GUTENBERG ] ];
+		$packageData2 = [ 'package' => (object) [ 'kind' => 'Gutenberg' ] ];
+
+		$packages = [ $id1 => $packageData1, $id2 => $packageData2 ];
+		$normalized = ShortCodesInGutenbergBlocks::normalizePackages( $packages );
+
+		$this->assertEquals(  [ $id2 => $packageData2 ], $normalized );
+
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_normalizes_packages_if_less_than_two_packages() {
+		$packageData = [ 'package' => (object) [ 'kind' => ShortCodesInGutenbergBlocks::FORCED_GUTENBERG ] ];
+
+		$packages = [ $packageData ];
+		$normalized = ShortCodesInGutenbergBlocks::normalizePackages( $packages );
+
+		$this->assertEquals( $packages, $normalized );
+
+	}
+
+
+}

--- a/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
+++ b/tests/phpunit/tests/st/compatibility/test-wpml-page-builders-update.php
@@ -114,6 +114,7 @@ class Test_WPML_Page_Builders_Update extends \OTGS\PHPUnit\Tools\TestCase {
 					'get_node_id_field',
 					'get_pb_name',
 					'add_hooks',
+					'is_handling_post',
 				)
 			)->disableOriginalConstructor()->getMock();
 	}

--- a/tests/phpunit/tests/st/compatibility/test-wpml-pb-register-strings.php
+++ b/tests/phpunit/tests/st/compatibility/test-wpml-pb-register-strings.php
@@ -8,8 +8,33 @@
  */
 class Test_WPML_PB_Register_Strings extends WPML_PB_TestCase2 {
 
+
+
 	/**
 	 * @test
+	 * @group wpmlcore-6929
+	 */
+	public function it_does_not_register_strings_if_page_builder_is_not_handling_post() {
+		list( , $post, $package ) = $this->get_post_and_package( 'Elementor' );
+
+		WP_Mock::expectAction( 'wpml_start_string_package_registration', $package );
+		WP_Mock::expectAction( 'wpml_delete_unused_package_strings', $package );
+
+		$data_settings = \Mockery::mock( 'IWPML_Page_Builders_Data_Settings' );
+		$data_settings->shouldReceive( 'is_handling_post' )->with( $post->ID )->andReturn( false );
+		$data_settings->shouldNotReceive( 'convert_data_to_array' );
+
+		$subject = new WPML_Concrete_Test_Register_Strings(
+			\Mockery::mock( 'IWPML_Page_Builders_Translatable_Nodes' ),
+			$data_settings,
+			\Mockery::mock( 'WPML_PB_String_Registration' )
+		);
+		$subject->register_strings( $post, $package );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6929
 	 */
 	public function it_does_not_throw_error_on_invalid_data() {
 		list( $name, $post, $package ) = $this->get_post_and_package( 'Elementor' );
@@ -24,6 +49,7 @@ class Test_WPML_PB_Register_Strings extends WPML_PB_TestCase2 {
 		WP_Mock::expectAction( 'wpml_delete_unused_package_strings', $package );
 
 		$data_settings = \Mockery::mock( 'IWPML_Page_Builders_Data_Settings' );
+		$data_settings->shouldReceive( 'is_handling_post' )->with( $post->ID )->andReturn( true );
 		$data_settings->shouldReceive( 'get_meta_field' )->andReturn( '_elementor_data' );
 		$data_settings->shouldReceive( 'convert_data_to_array' )->once()->with( $invalid_json )->andReturn( null );
 

--- a/tests/phpunit/tests/st/strategy/shortcode/test-StringCleanUp.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-StringCleanUp.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace WPML\PB\Shortcode;
+
+class Test_StringCleanUp extends \WPML_PB_TestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->existingStrings = [ md5( 'string1' ) => 'string1', md5( 'string2' ) => 'string2' ];
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_can_get_existing_strings() {
+		$postId = 123;
+
+		$subject = $this->getSubject( $postId );
+
+		$this->assertEquals( $this->existingStrings, $subject->get() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_removes_string() {
+		$postId = 123;
+
+		$subject = $this->getSubject( $postId );
+		$subject->remove( 'string1' );
+
+		$remainingStrings = $subject->get();
+		$this->assertCount( 1, $remainingStrings );
+		$this->assertEquals( 'string2', $remainingStrings[ md5( 'string2' ) ] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_cleans_up() {
+		$postId = 123;
+
+		$strategy = $this->getStrategy();
+
+		foreach( $this->existingStrings as $string ) {
+			$strategy->shouldReceive( 'remove_string' )->once()->with( $string );
+		}
+
+		$subject = new StringCleanUp( $postId, $strategy );
+		$subject->cleanUp();
+	}
+
+	/**
+	 * @param $postId
+	 *
+	 * @return StringCleanUp
+	 */
+	private function getSubject( $postId ) {
+		return new StringCleanUp( $postId, $this->getStrategy() );
+	}
+
+	/**
+	 * @return \Mockery\MockInterface
+	 */
+	private function getStrategy() {
+		$strategy = \Mockery::mock( 'WPML_PB_Shortcode_Strategy' );
+		$strategy->shouldReceive( 'get_package_key' )->andReturn( 'packageKey' );
+		$strategy->shouldReceive( 'get_package_strings' )->andReturn( $this->existingStrings );
+
+		return $strategy;
+	}
+
+}

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-register-shortcodes.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-register-shortcodes.php
@@ -76,7 +76,8 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $shortcode );
+		$any_registered = $shortcode_handler->register_shortcode_strings( $post_id, $shortcode, true );
+		$this->assertTrue( $any_registered );
 	}
 
 	public function encode_data_provider() {
@@ -122,7 +123,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $empty_content );
+		$shortcode_handler->register_shortcode_strings( $post_id, $empty_content, true );
 
 	}
 
@@ -190,7 +191,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( mt_rand( 1, 100 ), rand_str() );
+		$shortcode_handler->register_shortcode_strings( mt_rand( 1, 100 ), rand_str(), true );
 	}
 
 	public function test_reuse_translations() {
@@ -215,7 +216,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' )->once()->with( $post_id, $strings );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy_mock, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, rand_str() );
+		$shortcode_handler->register_shortcode_strings( $post_id, rand_str(), true );
 
 	}
 
@@ -268,7 +269,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$string_handler_mock->expects( $this->never() )->method( 'register_string' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding() );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
 	}
 
 	/**
@@ -306,7 +307,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$string_handler_mock->expects( $this->never() )->method( 'register_string' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding() );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
 	}
 
 
@@ -345,7 +346,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$string_handler_mock->expects( $this->never() )->method( 'register_string' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding() );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
 	}
 
 	public function dp_media_tag_type() {
@@ -422,7 +423,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
 	}
 
 	/**
@@ -449,7 +450,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
 	}
 
 	/**
@@ -482,7 +483,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
 	}
 
 	/** @return WPML_PB_Shortcode_Strategy|PHPUnit_Framework_MockObject_MockObject */

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-register-shortcodes.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-register-shortcodes.php
@@ -76,7 +76,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$any_registered = $shortcode_handler->register_shortcode_strings( $post_id, $shortcode, true );
+		$any_registered = $shortcode_handler->register_shortcode_strings( $post_id, $shortcode, null );
 		$this->assertTrue( $any_registered );
 	}
 
@@ -123,7 +123,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $empty_content, true );
+		$shortcode_handler->register_shortcode_strings( $post_id, $empty_content, null );
 
 	}
 
@@ -181,7 +181,6 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$strategy->method( 'get_shortcode_parser' )->willReturn( $pb_shortcodes_mock );
 		$strategy->method( 'get_package_strings' )->willReturn( $string_data );
 
-		$strategy->method( 'get_package_strings' )->willReturn( array() );
 		$strategy->method( 'get_shortcode_attributes' )->willReturn( array( 'text' ) );
 		$strategy->method( 'get_shortcode_attribute_encoding' )->willReturn( WPML_PB_Shortcode_Encoding::ENCODE_TYPES_BASE64 );
 		$strategy->expects( $this->once() )->method( 'remove_string' )->with( $string_data['dummy_data'] );
@@ -191,7 +190,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( mt_rand( 1, 100 ), rand_str(), true );
+		$shortcode_handler->register_shortcode_strings( mt_rand( 1, 100 ), rand_str(), null );
 	}
 
 	public function test_reuse_translations() {
@@ -216,7 +215,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' )->once()->with( $post_id, $strings );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy_mock, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, rand_str(), true );
+		$shortcode_handler->register_shortcode_strings( $post_id, rand_str(), null );
 
 	}
 
@@ -258,6 +257,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 			)
 		);
 
+		$strategy->method( 'get_package_strings' )->willReturn( [] );
 		$strategy->method( 'get_shortcode_parser' )->willReturn( $pb_shortcodes_mock );
 		$strategy->method( 'get_shortcode_ignore_content' )->with( 'tag_with_ignore_content' )->willReturn( true );
 
@@ -269,7 +269,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$string_handler_mock->expects( $this->never() )->method( 'register_string' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding() );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, null );
 	}
 
 	/**
@@ -294,6 +294,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 			)
 		);
 
+		$strategy->method( 'get_package_strings' )->willReturn( [] );
 		$strategy->method( 'get_shortcode_parser' )->willReturn( $pb_shortcodes_mock );
 
 		\WP_Mock::wpFunction( 'shortcode_parse_atts', array( 'return' => array() ) );
@@ -307,7 +308,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$string_handler_mock->expects( $this->never() )->method( 'register_string' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding() );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, null );
 	}
 
 
@@ -334,6 +335,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 			)
 		);
 
+		$strategy->method( 'get_package_strings' )->willReturn( [] );
 		$strategy->method( 'get_shortcode_parser' )->willReturn( $pb_shortcodes_mock );
 		$strategy->method( 'get_shortcode_ignore_content' )->with( 'tag_with_media_content' )->willReturn( false );
 		$strategy->method( 'get_shortcode_tag_type' )->with( 'tag_with_media_content' )->willReturn( $type );
@@ -346,7 +348,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$string_handler_mock->expects( $this->never() )->method( 'register_string' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding() );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, null );
 	}
 
 	public function dp_media_tag_type() {
@@ -423,7 +425,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, null );
 	}
 
 	/**
@@ -450,7 +452,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, null );
 	}
 
 	/**
@@ -483,7 +485,7 @@ class Test_WPML_PB_Register_Shortcodes extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$shortcode_handler = new WPML_PB_Register_Shortcodes( $string_handler_mock, $strategy, new WPML_PB_Shortcode_Encoding(), $reuse_translations_mock );
-		$shortcode_handler->register_shortcode_strings( $post_id, $content, true );
+		$shortcode_handler->register_shortcode_strings( $post_id, $content, null );
 	}
 
 	/** @return WPML_PB_Shortcode_Strategy|PHPUnit_Framework_MockObject_MockObject */

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
@@ -110,6 +110,28 @@ class Test_WPML_PB_Shortcode_Strategy extends \OTGS\PHPUnit\Tools\TestCase {
 		);
 	}
 
+	/**
+	 * @test
+	 */
+	public function it_migrate_locations() {
+		$postId = 123;
+		$postContent = '<h1>Some content</h1>';
+
+		$page_builder_settings = $this->get_page_builder_settings();
+		$subject = $this->get_subject( $page_builder_settings );
+
+		$registerShortcodes = \Mockery::mock( '\WPML_PB_Register_Shortcodes' );
+		$registerShortcodes->shouldReceive( 'register_shortcode_strings' )
+			->once()
+			->with( $postId, $postContent, true );
+
+		$factory = \Mockery::mock( '\WPML_PB_Factory' );
+		$factory->shouldReceive( 'get_register_shortcodes' )->andReturn( $registerShortcodes );
+		$subject->set_factory( $factory );
+
+		$subject->migrate_location( $postId, $postContent );
+	}
+
 	private function get_subject( $page_builder_settings ) {
 		return new WPML_PB_Shortcode_Strategy( $page_builder_settings );
 	}

--- a/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
+++ b/tests/phpunit/tests/st/strategy/shortcode/test-wpml-pb-shortcode-strategy.php
@@ -123,7 +123,7 @@ class Test_WPML_PB_Shortcode_Strategy extends \OTGS\PHPUnit\Tools\TestCase {
 		$registerShortcodes = \Mockery::mock( '\WPML_PB_Register_Shortcodes' );
 		$registerShortcodes->shouldReceive( 'register_shortcode_strings' )
 			->once()
-			->with( $postId, $postContent, true );
+			->with( $postId, $postContent, null );
 
 		$factory = \Mockery::mock( '\WPML_PB_Factory' );
 		$factory->shouldReceive( 'get_register_shortcodes' )->andReturn( $registerShortcodes );

--- a/tests/phpunit/tests/st/test-wpml-page-builders-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-page-builders-integration.php
@@ -25,16 +25,20 @@ class Test_WPML_Page_Builders_Integration extends \OTGS\PHPUnit\Tools\TestCase {
 		                           ->getMock();
 
 		$this->data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-			->setMethods( array(
-				'add_hooks',
-				'get_meta_field',
-				'get_node_id_field',
-				'get_fields_to_copy',
-				'get_fields_to_save',
-				'convert_data_to_array',
-				'prepare_data_for_saving',
-				'get_pb_name',
-				'add_data_custom_field_to_md5' ) )
+			->setMethods(
+				[
+					'add_hooks',
+					'get_meta_field',
+					'get_node_id_field',
+					'get_fields_to_copy',
+					'get_fields_to_save',
+					'convert_data_to_array',
+					'prepare_data_for_saving',
+					'get_pb_name',
+					'add_data_custom_field_to_md5',
+					'is_handling_post',
+				]
+			)
 			->disableOriginalConstructor()
 			->getMock();
 	}

--- a/tests/phpunit/tests/st/test-wpml-pb-api-hooks-strategy.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-api-hooks-strategy.php
@@ -14,7 +14,7 @@ class Test_WPML_PB_API_Hooks_Strategy extends WPML_PB_TestCase {
 
 	function test_get_updaters() {
 		$subject = new WPML_PB_API_Hooks_Strategy( '' );
-		$factory = new WPML_PB_Factory( null, null );
+		$factory = new WPML_PB_Factory( \Mockery::mock( 'wpdb' ), \Mockery::mock( 'SitePress' ) );
 		$subject->set_factory( $factory );
 		$this->assertInstanceOf( 'WPML_PB_Update_Post', $subject->get_update_post( array() ) );
 		$this->assertInstanceOf( 'WPML_PB_Update_API_Hooks_In_Content', $subject->get_content_updater( array() ) );
@@ -23,7 +23,7 @@ class Test_WPML_PB_API_Hooks_Strategy extends WPML_PB_TestCase {
 	function test_update_in_content() {
 		$name = rand_str();
 		$strategy = new WPML_PB_API_Hooks_Strategy( $name );
-		$factory = new WPML_PB_Factory( null, null );
+		$factory = new WPML_PB_Factory( \Mockery::mock( 'wpdb' ), \Mockery::mock( 'SitePress' ) );
 		$strategy->set_factory( $factory );
 		$subject = new WPML_PB_Update_API_Hooks_In_Content( $strategy );
 

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -154,6 +154,11 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array( $pb_integration, 'process_pb_content_with_hidden_strings_only' ), 9, 2 );
 		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array( $pb_integration, 'save_translations_to_post' ), 10 );
 
+		\WP_Mock::expectActionAdded(
+			'wpml_pb_register_all_strings_for_translation',
+			[ $pb_integration, 'register_all_strings_for_translation' ]
+		);
+
 		$pb_integration->add_hooks();
 	}
 

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -145,7 +145,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 	public function test_add_hooks() {
 		$sitepress_mock = $this->get_sitepress_mock();
-		$factory_mock   = $this->get_factory( null, $sitepress_mock );
+		$factory_mock   = $this->get_factory( \Mockery::mock( 'wpdb' ), $sitepress_mock );
 		$pb_integration = new WPML_PB_Integration( $sitepress_mock, $factory_mock );
 		\WP_Mock::expectActionAdded( 'pre_post_update', array(
 			$pb_integration,
@@ -180,7 +180,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		\WP_Mock::expectFilterAdded( 'wpml_pb_register_strings_in_content', [
 			$pb_integration,
 			'register_strings_in_content'
-		], 10, 3 );
+		], 10, 4 );
 		\WP_Mock::expectFilterAdded( 'wpml_pb_update_translations_in_content', [
 			$pb_integration,
 			'update_translations_in_content'
@@ -189,6 +189,13 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		\WP_Mock::expectActionAdded(
 			'wpml_pb_register_all_strings_for_translation',
 			[ $pb_integration, 'register_all_strings_for_translation' ]
+		);
+
+		\WP_Mock::expectFilterAdded(
+			'wpml_pb_get_string_clean_up',
+			[ $pb_integration, 'get_string_clean_up' ],
+			10,
+			2
 		);
 
 		$pb_integration->add_hooks();
@@ -538,7 +545,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$rescan->expects( $this->never() )->method( 'rescan' );
 
 		$sitepress_mock = $this->get_sitepress_mock();
-		$factory_mock   = $this->get_factory( null, $sitepress_mock );
+		$factory_mock   = $this->get_factory( \Mockery::mock( 'wpdb' ), $sitepress_mock );
 		$subject        = new WPML_PB_Integration( $sitepress_mock, $factory_mock );
 
 		$subject->set_rescan( $rescan );
@@ -557,7 +564,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$rescan->expects( $this->once() )->method( 'rescan' )->with( $translation_package, $post )->willReturn( $translation_package );
 
 		$sitepress_mock = $this->get_sitepress_mock();
-		$factory_mock   = $this->get_factory( null, $sitepress_mock );
+		$factory_mock   = $this->get_factory( \Mockery::mock( 'wpdb' ), $sitepress_mock );
 		$subject        = new WPML_PB_Integration( $sitepress_mock, $factory_mock );
 
 		$subject->set_rescan( $rescan );
@@ -593,7 +600,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$sitepress_mock = \Mockery::mock( 'SitePress' );
 		$sitepress_mock->shouldReceive( 'get_wpdb' )->andReturn( $wpdb );
 
-		$factory_mock = $this->get_factory( null, $sitepress_mock );
+		$factory_mock = $this->get_factory( \Mockery::mock( 'wpdb' ), $sitepress_mock );
 
 		\WP_Mock::wpFunction( 'update_post_meta', array(
 			'times' => 0,
@@ -628,7 +635,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$sitepress_mock = \Mockery::mock( 'SitePress' );
 		$sitepress_mock->shouldReceive( 'get_wpdb' )->andReturn( $wpdb );
 
-		$factory_mock = $this->get_factory( null, $sitepress_mock );
+		$factory_mock = $this->get_factory( \Mockery::mock( 'wpdb' ), $sitepress_mock );
 
 		\WP_Mock::wpFunction( 'get_post_meta', array(
 			'times'  => 0,
@@ -673,7 +680,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$sitepress_mock = \Mockery::mock( 'SitePress' );
 		$sitepress_mock->shouldReceive( 'get_wpdb' )->andReturn( $wpdb );
 
-		$factory_mock = $this->get_factory( null, $sitepress_mock );
+		$factory_mock = $this->get_factory( \Mockery::mock( 'wpdb' ), $sitepress_mock );
 
 		\WP_Mock::wpFunction( 'get_post_meta', array(
 			'times'  => 1,
@@ -725,7 +732,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$sitepress_mock->shouldReceive( 'get_wpdb' )->andReturn( $wpdb );
 		$sitepress_mock->shouldReceive( 'get_original_element_id' )->andReturn( $post->ID );
 
-		$factory_mock = $this->get_factory( null, $sitepress_mock );
+		$factory_mock = $this->get_factory( \Mockery::mock( 'wpdb' ), $sitepress_mock );
 
 		\WP_Mock::wpFunction( 'get_post_meta', array(
 			'times'  => 1,

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -181,6 +181,10 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 			$pb_integration,
 			'register_strings_in_content'
 		], 10, 3 );
+		\WP_Mock::expectFilterAdded( 'wpml_pb_update_translations_in_content', [
+			$pb_integration,
+			'update_translations_in_content'
+		], 10, 2 );
 
 		\WP_Mock::expectActionAdded(
 			'wpml_pb_register_all_strings_for_translation',
@@ -862,6 +866,75 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		return array(
 			array( array() ),
 			array( array( 'action' => 'something' ) ),
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_false_if_no_strategy_registers_strings_in_content() {
+		$post_id = 123;
+		$content = 'some content';
+
+		$subject = new WPML_PB_Integration(
+			\Mockery::mock( 'SitePress' ),
+			\Mockery::mock( 'WPML_PB_Factory' )
+		);
+
+		$this->assertFalse( $subject->register_strings_in_content( false, $post_id, $content ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_true_if_strategy_registers_strings_in_content() {
+		$post_id = 123;
+		$content = 'some content';
+
+		$subject = new WPML_PB_Integration(
+			\Mockery::mock( 'SitePress' ),
+			\Mockery::mock( 'WPML_PB_Factory' )
+		);
+
+		$strategy = $this->getMockBuilder( 'WPML_PB_Shortcode_Strategy' )
+		                 ->setMethods( [ 'register_strings_in_content' ] )
+		                 ->disableOriginalConstructor()->getMock();
+		$strategy->method( 'register_strings_in_content' )
+		         ->with( $post_id, $content, false )
+		         ->willReturn( true );
+		$subject->add_strategy( $strategy );
+
+		$this->assertTrue( $subject->register_strings_in_content( false, $post_id, $content ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_updates_translations_in_content() {
+		$lang            = 'de';
+		$content         = 'some content';
+		$updated_content = 'some content[updated]';
+
+		$string_translations = \Mockery::mock( 'WPML_PB_String_Translation_By_Strategy' );
+		$string_translations->shouldReceive( 'update_translations_in_content' )
+		                    ->with( $content, $lang )
+		                    ->andReturn( $updated_content );
+
+		$strategy = $this->getMockBuilder( 'WPML_PB_Shortcode_Strategy' )
+		                 ->setMethods( [] )
+		                 ->disableOriginalConstructor()->getMock();
+
+		$factory = \Mockery::mock( 'WPML_PB_Factory' );
+		$factory->shouldReceive( 'get_string_translations' )
+		        ->with( $strategy )
+		        ->andReturn( $string_translations );
+		$subject = new WPML_PB_Integration( \Mockery::mock( 'SitePress' ), $factory );
+
+		$subject->add_strategy( $strategy );
+
+		$this->assertEquals(
+			$updated_content,
+			$subject->update_translations_in_content( $content, $lang )
 		);
 	}
 

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -33,7 +33,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	 */
 	public function it_should_NOT_process_pb_content_with_hidden_strings_only_if_string_translation_was_added() {
 		\WP_Mock::userFunction( 'did_action' )
-			->with( "wpml_add_string_translation" )->andReturn( true );
+		        ->with( "wpml_add_string_translation" )->andReturn( true );
 
 		$sitepress = $this->get_sitepress_mock();
 		$sitepress->expects( $this->never() )->method( 'get_language_for_element' );
@@ -55,11 +55,11 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$post      = $this->get_post( $newPostId );
 
 		\WP_Mock::userFunction( 'did_action' )
-			->with( "wpml_add_string_translation" )->andReturn( false );
+		        ->with( "wpml_add_string_translation" )->andReturn( false );
 		\WP_Mock::userFunction( 'get_post' )
-			->with( $newPostId )->andReturn( $post );
+		        ->with( $newPostId )->andReturn( $post );
 		\WP_Mock::onFilter( 'wpml_pb_is_page_builder_page' )
-			->with( false, $post )->reply( false );
+		        ->with( false, $post )->reply( false );
 
 		$sitepress = $this->get_sitepress_mock();
 		$sitepress->expects( $this->never() )->method( 'get_language_for_element' );
@@ -86,31 +86,49 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$strategiesNumber = 3;
 
 		\WP_Mock::userFunction( 'did_action' )
-			->with( "wpml_add_string_translation" )->andReturn( false );
+		        ->with( "wpml_add_string_translation" )->andReturn( false );
 		\WP_Mock::userFunction( 'get_post' )
-			->with( $newPostId )->andReturn( $post );
+		        ->with( $newPostId )->andReturn( $post );
 		\WP_Mock::onFilter( 'wpml_pb_is_page_builder_page' )
-			->with( false, $post )->reply( true );
+		        ->with( false, $post )->reply( true );
 		\WP_Mock::userFunction( 'get_post_type' )
-			->with( $newPostId )->andReturn( $post->post_type );
+		        ->with( $newPostId )->andReturn( $post->post_type );
 		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
-			->with( [], $originalPostId )->reply( [ $package ] );
+		        ->with( [], $originalPostId )->reply( [ $package ] );
 
 		$sitepress = $this->get_sitepress_mock();
 		$sitepress->method( 'get_language_for_element' )
-			->with( $newPostId, 'post_' . $post->post_type )
-			->willReturn( $targetLang );
+		          ->with( $newPostId, 'post_' . $post->post_type )
+		          ->willReturn( $targetLang );
 
 		$factory        = $this->get_factory_mock_for_add_package_to_update_list( $package, $targetLang, $strategiesNumber );
 		$strategy       = $this->get_shortcode_strategy( $factory );
 		$pb_integration = new WPML_PB_Integration( $sitepress, $factory );
 
-		for ( $i = 0; $i < $strategiesNumber; $i++ ) {
+		for ( $i = 0; $i < $strategiesNumber; $i ++ ) {
 			$pb_integration->add_strategy( $strategy );
 		}
 
 		$pb_integration->process_pb_content_with_hidden_strings_only( $newPostId, $originalPostId );
 		$pb_integration->save_translations_to_post();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_NOT_process_shortcodes_globally_for_gutenberg_pages() {
+		$newPostId = 456;
+		$post      = (object) [
+			'ID'           => $newPostId,
+			'post_content' => '<!-- wp:paragraph --><p>Some content on the page.</p><!-- /wp:paragraph -->'
+		];
+
+		$factory = \Mockery::mock( '\WPML_PB_Factory' );
+		$factory->shouldNotReceive( 'get_register_shortcodes' );
+
+		$subject = new WPML_PB_Shortcode_Strategy( \Mockery::mock( '\WPML_Page_Builder_Settings' ) );
+		$subject->set_factory( $factory );
+		$subject->register_strings( $post );
 	}
 
 	public function test_translations() {
@@ -149,10 +167,20 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		\WP_Mock::expectActionAdded( 'wpml_pro_translation_completed', array(
 			$pb_integration,
 			'cleanup_strings_after_translation_completed',
-		),	10, 3 );
+		), 10, 3 );
 		\WP_Mock::expectFilterAdded( 'wpml_tm_translation_job_data', array( $pb_integration, 'rescan' ), 9, 2 );
-		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array( $pb_integration, 'process_pb_content_with_hidden_strings_only' ), 9, 2 );
-		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array( $pb_integration, 'save_translations_to_post' ), 10 );
+		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array(
+			$pb_integration,
+			'process_pb_content_with_hidden_strings_only'
+		), 9, 2 );
+		\WP_Mock::expectActionAdded( 'wpml_pb_finished_adding_string_translations', array(
+			$pb_integration,
+			'save_translations_to_post'
+		), 10 );
+		\WP_Mock::expectFilterAdded( 'wpml_pb_register_strings_in_content', [
+			$pb_integration,
+			'register_strings_in_content'
+		], 10, 3 );
 
 		\WP_Mock::expectActionAdded(
 			'wpml_pb_register_all_strings_for_translation',
@@ -168,7 +196,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	public function it_should_not_cleanup_strings_if_not_a_post_translation_job() {
 		/** @var SitePress|PHPUnit_Framework_MockObject_MockObject $factory_mock */
 		$sitepress_mock = $this->getMockBuilder( 'SitePress' )->setMethods( array( 'get_original_element_id' ) )
-			->disableOriginalConstructor()->getMock();
+		                       ->disableOriginalConstructor()->getMock();
 		$sitepress_mock->expects( $this->never() )->method( 'get_original_element_id' );
 		/** @var WPML_PB_Factory|PHPUnit_Framework_MockObject_MockObject $factory_mock */
 		$factory_mock   = $this->getMockBuilder( 'WPML_PB_Factory' )->disableOriginalConstructor()->getMock();
@@ -176,10 +204,10 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		\WP_Mock::wpFunction( 'get_post', array(
 			'times' => 0
-		));
+		) );
 
 		$job = (object) array(
-		    'element_type_prefix' => 'package',
+			'element_type_prefix' => 'package',
 		);
 
 		$pb_integration->cleanup_strings_after_translation_completed( mt_rand( 1, 100 ), array(), $job );
@@ -201,11 +229,11 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		\WP_Mock::wpFunction( 'get_post', array(
 			'args'   => array( $original_post->ID ),
 			'return' => $original_post,
-		));
+		) );
 
 		$job = (object) array(
 			'original_doc_id'     => $original_post->ID,
-		    'element_type_prefix' => 'post',
+			'element_type_prefix' => 'post',
 		);
 
 		$pb_integration->cleanup_strings_after_translation_completed( mt_rand( 1, 100 ), array(), $job );
@@ -219,14 +247,14 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$original_post = $this->get_post();
 
 		$sitepress_mock = $this->get_sitepress_mock( $original_post->ID );
-		$factory_mock = $this->getMockBuilder( 'WPML_PB_Factory' )
-		                     ->setMethods( array( 'get_string_translations' ) )
-		                     ->disableOriginalConstructor()
-		                     ->getMock();
+		$factory_mock   = $this->getMockBuilder( 'WPML_PB_Factory' )
+		                       ->setMethods( array( 'get_string_translations' ) )
+		                       ->disableOriginalConstructor()
+		                       ->getMock();
 		$factory_mock->expects( $this->never() )->method( 'get_string_translations' );
 
 		$strategy = $this->getMockBuilder( 'WPML_PB_Shortcode_Strategy' )
-		                 ->setMethods( array( ) )
+		                 ->setMethods( array() )
 		                 ->disableOriginalConstructor()->getMock();
 
 		$pb_integration = new WPML_PB_Integration( $sitepress_mock, $factory_mock );
@@ -235,14 +263,14 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		$strategy->method( 'register_strings' )
 		         ->with( $original_post )
-		         ->willReturnCallback( function() use ( $pb_integration ) {
+		         ->willReturnCallback( function () use ( $pb_integration ) {
 			         $pb_integration->new_translation( mt_rand( 1, 1000 ) );
-		         });
+		         } );
 
 		\WP_Mock::wpFunction( 'get_post', array(
 			'args'   => array( $original_post->ID ),
 			'return' => $original_post,
-		));
+		) );
 
 		$job = (object) array(
 			'original_doc_id'     => $original_post->ID,
@@ -254,7 +282,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 	/**
 	 * @dataProvider dp_do_shutdown_action
-	 * @group wpmlpb-160
+	 * @group        wpmlpb-160
 	 *
 	 * @param bool $wpml_media_enabled
 	 */
@@ -265,16 +293,16 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$wp_api = $this->getMockBuilder( 'constant' )->setMethods( array( 'constant' ) )->getMock();
 		$wp_api->method( 'constant' )->with( 'WPML_MEDIA_VERSION' )->willReturn( $wpml_media_enabled );
 
-		$sitepress_mock  = $this->get_sitepress_mock();
+		$sitepress_mock = $this->get_sitepress_mock();
 		$sitepress_mock->method( 'get_wp_api' )->willReturn( $wp_api );
 		$sitepress_mock->method( 'get_original_element_id' )
-		               ->willReturnCallback( function( $id ) use ( $original_post ) {
-		               	    if ( $id !== $original_post->ID ) {
-		               	    	return $original_post->ID;
-		                    }
+		               ->willReturnCallback( function ( $id ) use ( $original_post ) {
+			               if ( $id !== $original_post->ID ) {
+				               return $original_post->ID;
+			               }
 
-		                    return $id;
-		               });
+			               return $id;
+		               } );
 		$factory_mock   = $this->get_factory_mock_for_shutdown();
 		$strategy       = $this->get_shortcode_strategy( $factory_mock );
 		$pb_integration = new WPML_PB_Integration( $sitepress_mock, $factory_mock );
@@ -297,7 +325,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 	/**
 	 * @dataProvider dp_do_shutdown_action
-	 * @group wpmlcore-5765
+	 * @group        wpmlcore-5765
 	 *
 	 * @param bool $wpml_media_enabled
 	 */
@@ -309,26 +337,26 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$translated_element = $this->get_post_element( $translated_post->ID, $translated_post, $target_lang, $original_element );
 
 		\WP_Mock::wpFunction( 'did_action', array(
-             'args'   => array( 'shutdown' ),
-             'return' => 0,
-         ));
+			'args'   => array( 'shutdown' ),
+			'return' => 0,
+		) );
 
 		$wp_api = $this->getMockBuilder( 'constant' )->setMethods( array( 'constant' ) )->getMock();
 		$wp_api->method( 'constant' )->with( 'WPML_MEDIA_VERSION' )->willReturn( $wpml_media_enabled );
 
-		$sitepress_mock  = $this->get_sitepress_mock();
+		$sitepress_mock = $this->get_sitepress_mock();
 		$sitepress_mock->method( 'get_wp_api' )->willReturn( $wp_api );
 		$sitepress_mock->method( 'get_original_element_id' )
-		               ->willReturnCallback( function( $id ) use ( $original_post ) {
+		               ->willReturnCallback( function ( $id ) use ( $original_post ) {
 			               if ( $id !== $original_post->ID ) {
 				               return $original_post->ID;
 			               }
 
 			               return $id;
-		               });
+		               } );
 
 		$updated_package = $this->getMockBuilder( 'WPML_Package' )
-								->disableOriginalConstructor()->getMock();
+		                        ->disableOriginalConstructor()->getMock();
 
 		$string_translation = $this->getMockBuilder( 'WPML_PB_String_Translation_By_Strategy' )
 		                           ->setMethods( array( 'save_translations_to_post', 'add_package_to_update_list' ) )
@@ -337,18 +365,18 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		$string_translation->expects( $this->once() )->method( 'save_translations_to_post' );
 		$string_translation->expects( $this->once() )->method( 'add_package_to_update_list' )
-							->with( $updated_package, $target_lang );
+		                   ->with( $updated_package, $target_lang );
 
 		$factory_mock = $this->getMockBuilder( 'WPML_PB_Factory' )
-		                ->setMethods( array(
-				                'get_update_translated_posts_from_original',
-				                'get_string_translations',
-				                'get_package_strings_resave',
-				                'get_last_translation_edit_mode',
-				                'get_post_element',
-                            )
-		                )->disableOriginalConstructor()
-		                ->getMock();
+		                     ->setMethods( array(
+				                     'get_update_translated_posts_from_original',
+				                     'get_string_translations',
+				                     'get_package_strings_resave',
+				                     'get_last_translation_edit_mode',
+				                     'get_post_element',
+			                     )
+		                     )->disableOriginalConstructor()
+		                     ->getMock();
 
 		$strategy = $this->get_shortcode_strategy( $factory_mock );
 
@@ -364,7 +392,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$factory_mock->method( 'get_post_element' )->willReturn( $post_element );
 
 		$package_strings_resave = $this->getMockBuilder( 'WPML_PB_Package_Strings_Resave' )
-									->setMethods( array( 'from_element' ) )->disableOriginalConstructor()->getMock();
+		                               ->setMethods( array( 'from_element' ) )->disableOriginalConstructor()->getMock();
 		$package_strings_resave->expects( $this->once() )->method( 'from_element' )->with( $translated_element )->willReturn( array( $updated_package ) );
 
 		$factory_mock->method( 'get_package_strings_resave' )->willReturn( $package_strings_resave );
@@ -389,7 +417,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 	/**
 	 * @dataProvider dp_do_shutdown_action
-	 * @group wpmlcore-5935
+	 * @group        wpmlcore-5935
 	 *
 	 * @param bool $wpml_media_enabled
 	 */
@@ -401,42 +429,42 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$translated_element = $this->get_post_element( $translated_post->ID, $translated_post, $target_lang, $original_element );
 
 		\WP_Mock::wpFunction( 'did_action', array(
-             'args'   => array( 'shutdown' ),
-             'return' => 0,
-         ));
+			'args'   => array( 'shutdown' ),
+			'return' => 0,
+		) );
 
 		$wp_api = $this->getMockBuilder( 'constant' )->setMethods( array( 'constant' ) )->getMock();
 		$wp_api->method( 'constant' )->with( 'WPML_MEDIA_VERSION' )->willReturn( $wpml_media_enabled );
 
-		$sitepress_mock  = $this->get_sitepress_mock();
+		$sitepress_mock = $this->get_sitepress_mock();
 		$sitepress_mock->method( 'get_wp_api' )->willReturn( $wp_api );
 		$sitepress_mock->method( 'get_original_element_id' )
-		               ->willReturnCallback( function( $id ) use ( $original_post ) {
+		               ->willReturnCallback( function ( $id ) use ( $original_post ) {
 			               if ( $id !== $original_post->ID ) {
 				               return $original_post->ID;
 			               }
 
 			               return $id;
-		               });
+		               } );
 
 		$updated_package = $this->getMockBuilder( 'WPML_Package' )
-								->disableOriginalConstructor()->getMock();
+		                        ->disableOriginalConstructor()->getMock();
 
 		$string_translation = $this->getMockBuilder( 'WPML_PB_String_Translation_By_Strategy' )
 		                           ->disableOriginalConstructor()
 		                           ->getMock();
 
 		$factory_mock = $this->getMockBuilder( 'WPML_PB_Factory' )
-		                ->setMethods( array(
-				                'get_update_translated_posts_from_original',
-				                'get_string_translations',
-				                'get_package_strings_resave',
-				                'get_handle_post_body',
-				                'get_last_translation_edit_mode',
-				                'get_post_element',
-                            )
-		                )->disableOriginalConstructor()
-		                ->getMock();
+		                     ->setMethods( array(
+				                     'get_update_translated_posts_from_original',
+				                     'get_string_translations',
+				                     'get_package_strings_resave',
+				                     'get_handle_post_body',
+				                     'get_last_translation_edit_mode',
+				                     'get_post_element',
+			                     )
+		                     )->disableOriginalConstructor()
+		                     ->getMock();
 
 		$strategy = $this->get_shortcode_strategy( $factory_mock );
 
@@ -452,17 +480,17 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$factory_mock->method( 'get_post_element' )->willReturn( $post_element );
 
 		$package_strings_resave = $this->getMockBuilder( 'WPML_PB_Package_Strings_Resave' )
-									->setMethods( array( 'from_element' ) )->disableOriginalConstructor()->getMock();
+		                               ->setMethods( array( 'from_element' ) )->disableOriginalConstructor()->getMock();
 		$package_strings_resave->expects( $this->once() )->method( 'from_element' )
-			->with( $translated_element )->willReturn( array() );
+		                       ->with( $translated_element )->willReturn( array() );
 
 		$factory_mock->method( 'get_package_strings_resave' )->willReturn( $package_strings_resave );
 
 		$handle_post_body = $this->getMockBuilder( 'WPML_PB_Handle_Post_Body' )
-			->setMethods( array( 'copy' ) )->disableOriginalConstructor()->getMock();
+		                         ->setMethods( array( 'copy' ) )->disableOriginalConstructor()->getMock();
 
 		$handle_post_body->expects( $this->once() )
-			->method( 'copy' )->with( $translated_post->ID, $original_post->ID, array() );
+		                 ->method( 'copy' )->with( $translated_post->ID, $original_post->ID, array() );
 
 		$factory_mock->method( 'get_handle_post_body' )->willReturn( $handle_post_body );
 
@@ -487,7 +515,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	public function dp_do_shutdown_action() {
 		return array(
 			'WPML Media deactivated' => array( false ),
-			'WPML Media activated' => array( true ),
+			'WPML Media activated'   => array( true ),
 		);
 	}
 
@@ -589,9 +617,9 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$string_packages_table = $wpdb->prefix . 'icl_string_packages';
 
 		$wpdb->expects( $this->once() )
-			->method( 'get_var' )
-			->with( "SHOW TABLES LIKE '" . $string_packages_table . "'" )
-			->willReturn( false );
+		     ->method( 'get_var' )
+		     ->with( "SHOW TABLES LIKE '" . $string_packages_table . "'" )
+		     ->willReturn( false );
 
 		$sitepress_mock = \Mockery::mock( 'SitePress' );
 		$sitepress_mock->shouldReceive( 'get_wpdb' )->andReturn( $wpdb );
@@ -727,8 +755,8 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		$sitepress = $this->get_sitepress_mock();
 		$factory   = $this->getMockBuilder( 'WPML_PB_Factory' )
-			->setMethods( array( 'get_last_translation_edit_mode', 'get_package_strings_resave' ) )
-			->disableOriginalConstructor()->getMock();
+		                  ->setMethods( array( 'get_last_translation_edit_mode', 'get_package_strings_resave' ) )
+		                  ->disableOriginalConstructor()->getMock();
 
 		$last_edit_mode = $this->get_last_edit_mode();
 		$last_edit_mode->method( 'is_native_editor' )->with( $post_id )->willReturn( true );
@@ -738,7 +766,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		$factory->expects( $this->never() )->method( 'get_package_strings_resave' );
 
 		$subject = new WPML_PB_Integration( $sitepress, $factory );
-		
+
 		$subject->resave_post_translation_in_shutdown( $post_element );
 	}
 
@@ -753,8 +781,8 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		$sitepress = $this->get_sitepress_mock();
 		$factory   = $this->getMockBuilder( 'WPML_PB_Factory' )
-			->setMethods( array( 'get_post_element', 'get_last_translation_edit_mode' ) )
-			->disableOriginalConstructor()->getMock();
+		                  ->setMethods( array( 'get_post_element', 'get_last_translation_edit_mode' ) )
+		                  ->disableOriginalConstructor()->getMock();
 
 		$factory->method( 'get_post_element' )->with( $post_id )->willReturn( $post_element );
 
@@ -781,8 +809,8 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		$sitepress = $this->get_sitepress_mock();
 		$factory   = $this->getMockBuilder( 'WPML_PB_Factory' )
-			->setMethods( array( 'get_post_element', 'get_last_translation_edit_mode' ) )
-			->disableOriginalConstructor()->getMock();
+		                  ->setMethods( array( 'get_post_element', 'get_last_translation_edit_mode' ) )
+		                  ->disableOriginalConstructor()->getMock();
 
 		$factory->method( 'get_post_element' )->with( $post_id )->willReturn( $post_element );
 
@@ -800,7 +828,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	/**
 	 * @test
 	 * @dataProvider dp_post_payload_not_from_native_editor
-	 * @group wpmlcore-6120
+	 * @group        wpmlcore-6120
 	 *
 	 * @param array $_post_payloaad
 	 */
@@ -814,8 +842,8 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		$sitepress = $this->get_sitepress_mock();
 		$factory   = $this->getMockBuilder( 'WPML_PB_Factory' )
-			->setMethods( array( 'get_post_element', 'get_last_translation_edit_mode' ) )
-			->disableOriginalConstructor()->getMock();
+		                  ->setMethods( array( 'get_post_element', 'get_last_translation_edit_mode' ) )
+		                  ->disableOriginalConstructor()->getMock();
 
 		$factory->method( 'get_post_element' )->with( $post_id )->willReturn( $post_element );
 
@@ -850,8 +878,8 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		$factory = $this->getMockBuilder( 'WPML_PB_Factory' )
 		                ->setMethods(
-		                	array(
-		                		'get_register_shortcodes',
+			                array(
+				                'get_register_shortcodes',
 				                'get_update_translated_posts_from_original',
 				                'get_last_translation_edit_mode',
 				                'get_post_element',
@@ -899,10 +927,10 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 		                                ->setMethods( [ 'add_package_to_update_list', 'save_translations_to_post' ] )
 		                                ->disableOriginalConstructor()
 		                                ->getMock();
-		$string_translation_mock->expects(  $package ? $this->exactly( $strategiesNumber ) : $this->never() )
+		$string_translation_mock->expects( $package ? $this->exactly( $strategiesNumber ) : $this->never() )
 		                        ->method( 'add_package_to_update_list' )
 		                        ->with( $package, $targetLang );
-		$string_translation_mock->expects(  $package ? $this->exactly( $strategiesNumber ) : $this->never() )
+		$string_translation_mock->expects( $package ? $this->exactly( $strategiesNumber ) : $this->never() )
 		                        ->method( 'save_translations_to_post' );
 
 		$factory = $this->getMockBuilder( 'WPML_PB_Factory' )
@@ -936,7 +964,11 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 	private function get_sitepress_mock( $post_id = null ) {
 		$sitepress_mock = $this->getMockBuilder( 'SitePress' )
-		                       ->setMethods( array( 'get_original_element_id', 'get_wp_api', 'get_language_for_element' ) )
+		                       ->setMethods( array(
+			                       'get_original_element_id',
+			                       'get_wp_api',
+			                       'get_language_for_element'
+		                       ) )
 		                       ->disableOriginalConstructor()
 		                       ->getMock();
 		if ( $post_id ) {
@@ -961,28 +993,29 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	private function get_post_element( $post_id, WP_Post $post, $lang = null, WPML_Post_Element $source_element = null ) {
 		$element = $this->getMockBuilder( 'WPML_Post_Element' )
 		                ->setMethods( array(
-		                        'get_id',
-		                        'get_wp_object',
-		                        'get_language_code',
-		                        'get_source_language_code',
-		                        'get_source_element',
-		                	)
+				                'get_id',
+				                'get_wp_object',
+				                'get_language_code',
+				                'get_source_language_code',
+				                'get_source_element',
+			                )
 		                )->disableOriginalConstructor()->getMock();
 		$element->method( 'get_id' )->willReturn( $post_id );
 		$element->method( 'get_wp_object' )->willReturn( $post );
 		$element->method( 'get_language_code' )->willReturn( $lang );
 		$element->method( 'get_source_element' )->willReturn( $source_element );
+
 		return $element;
 	}
 
 	private function get_last_edit_mode() {
 		return $this->getMockBuilder( 'WPML_PB_Last_Translation_Edit_Mode' )
-		     ->setMethods(
-		     	array(
-		     		'is_native_editor',
-		     		'set_native_editor',
-		     		'set_translation_editor',
-		        )
-		     )->getMock();
+		            ->setMethods(
+			            array(
+				            'is_native_editor',
+				            'set_native_editor',
+				            'set_translation_editor',
+			            )
+		            )->getMock();
 	}
 }

--- a/tests/phpunit/tests/st/test-wpml-pb-loader.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-loader.php
@@ -1,6 +1,29 @@
 <?php
 
 class Test_WPML_PB_Loader extends WPML_PB_TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$this->mockActionFilterLoader();
+	}
+
+	private function mockActionFilterLoader() {
+		$hooks = [
+			WPML_PB_Handle_Post_Body::class,
+			WPML\PB\Compatibility\Toolset\Layouts\HooksFactory::class,
+		];
+
+		$actionFilterLoader = \Mockery::mock( 'WPML_Action_Filter_Loader' );
+		$actionFilterLoader->shouldReceive( 'load' )->with( $hooks );
+
+		\WP_Mock::userFunction( 'WPML\Container\make' )
+			->with( 'WPML_Action_Filter_Loader' )
+			->andReturn( $actionFilterLoader );
+	}
+
+	/**
+	 * @group pierre
+	 */
 	public function test_no_strategies() {
 		$st_settings      = $this->get_wpml_st_settings();
 		$integration_mock = $this->get_pb_integration_mock();

--- a/tests/phpunit/tests/st/test-wpml-pb-string-registration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-registration.php
@@ -24,7 +24,6 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$string_title          = rand_str();
 		$expected_string_name  = $string_name ? $string_name : md5( $shortcode_content );
 
-		$sitepress_mock = $this->get_sitepress_mock();
 		\WP_Mock::expectAction( 'wpml_register_string',
 		                        $shortcode_content,
 		                        $expected_string_name,
@@ -32,8 +31,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		                        $string_title,
 		                        'VISUAL' );
 
-		$wpdb     = null;
-		$factory  = $this->get_factory( $wpdb, $sitepress_mock );
+		$factory  = $this->get_factory( \Mockery::mock( 'wpdb' ), $this->get_sitepress_mock() );
 		$strategy = $this->get_shortcode_strategy( $factory );
 
 		$string_factory = $this->get_string_factory_mock();
@@ -93,7 +91,6 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$expected_package_data = $this->get_expected_package( $post_id );
 		$shortcode_content     = 'http://somelink.com';
 
-		$sitepress_mock = $this->get_sitepress_mock();
 		\WP_Mock::expectAction( 'wpml_register_string',
 		                        $shortcode_content,
 		                        md5( $shortcode_content ),
@@ -105,8 +102,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 
 		\WP_Mock::onFilter( 'wpml_string_id_from_package' )->with( null )->reply( 1 );
 
-		$wpdb     = null;
-		$factory  = $this->get_factory( $wpdb, $sitepress_mock );
+		$factory  = $this->get_factory( \Mockery::mock( 'wpdb' ), $this->get_sitepress_mock() );
 		$strategy = $this->get_shortcode_strategy( $factory );
 
 		$package_factory = $this->get_package_factory_mock();
@@ -160,9 +156,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$translate_link_targets->shouldReceive( 'is_internal_url' )->with( $offsite_link_url )->andReturn( false );
 		$translate_link_targets->shouldReceive( 'is_internal_url' )->with( $local_link_url )->andReturn( true );
 
-		$sitepress_mock = $this->get_sitepress_mock();
-		$wpdb           = null;
-		$factory        = $this->get_factory( $wpdb, $sitepress_mock );
+		$factory        = $this->get_factory( \Mockery::mock( 'wpdb' ), $this->get_sitepress_mock() );
 		$strategy       = $this->get_shortcode_strategy( $factory );
 
 		$package_factory = $this->get_package_factory_mock();
@@ -216,9 +210,7 @@ class Test_WPML_PB_String_Registration extends WPML_PB_TestCase {
 		$location = mt_rand();
 		$wrap_tag     = 'h2';
 
-		$sitepress_mock = $this->get_sitepress_mock();
-		$wpdb           = null;
-		$factory        = $this->get_factory( $wpdb, $sitepress_mock );
+		$factory        = $this->get_factory( \Mockery::mock( 'wpdb' ), $this->get_sitepress_mock() );
 		$strategy       = $this->get_shortcode_strategy( $factory );
 
 		$string = \Mockery::mock( 'WPML_ST_String' );

--- a/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-string-translation.php
@@ -1,5 +1,9 @@
 <?php
 
+use tad\FunctionMocker;
+use WPML\FP\Fns;
+use WPML\FP\Lst;
+
 /**
  * @group page-builders
  */
@@ -16,20 +20,36 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		list( $factory_mock, $strategy_mock, $package ) = $this->get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2, $post_id );
 
 		$factory_mock->expects( $this->exactly( 2 ) )
-		        ->method( 'get_wpml_package' )
-		        ->with( $this->equalTo( $string_package_id ) )
-		        ->willReturn( $package );
+		             ->method( 'get_wpml_package' )
+		             ->with( $this->equalTo( $string_package_id ) )
+		             ->willReturn( $package );
 
 		$strategy_mock->expects( $this->exactly( $post_id ? 3 : 0 ) )
-		         ->method( 'get_package_kind' )
-		         ->willReturn( $package->kind );
+		              ->method( 'get_package_kind' )
+		              ->willReturn( $package->kind );
 
 		$wpdb_mock = $this->get_wpdb_mock( $string_package_id, $language_1, $language_2 );
 
 		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb_mock, $factory_mock, $strategy_mock );
+
+		$fixupPackage  = FunctionMocker\replace( 'WPML\PB\ShortCodesInGutenbergBlocks::fixupPackage', Fns::identity() );
+		$recordPackage = FunctionMocker\replace(
+			'WPML\PB\ShortCodesInGutenbergBlocks::recordPackage',
+			function ( $instance, $strategyKind, $thePackage, $language ) use ( $package, $language_1, $language_2 ) {
+				$this->assertInstanceOf( 'WPML_PB_String_Translation_By_Strategy', $instance );
+				$this->assertEquals( $package->kind, $strategyKind );
+				$this->assertTrue( Lst::includes( $language, [ $language_1, $language_2 ] ) );
+				$this->assertEquals( $package, $thePackage );
+			} );
+
+
 		$pb_string_translation->new_translation( $translated_string_id );
 		$pb_string_translation->new_translation( $translated_string_id );
 		$pb_string_translation->save_translations_to_post();
+
+		$expectedPackageData = [ 'package' => $package, 'languages' => [ $language_1, $language_2 ] ];
+		$fixupPackage->wasCalledWithTimes( [ $expectedPackageData ], $post_id ? 1 : 0 );
+		$recordPackage->wasCalledTimes( $post_id ? 2 : 0 );
 	}
 
 	/**
@@ -45,10 +65,14 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		list( $factory_mock, $strategy_mock, $package ) = $this->get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2 );
 		$wpdb_mock = $this->get_wpdb_mock( $string_package_id, $language_1, $language_2 );
 
+		$normalizePackages = FunctionMocker\replace( 'WPML\PB\ShortCodesInGutenbergBlocks::normalizePackages', Fns::identity() );
+
 		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb_mock, $factory_mock, $strategy_mock );
 		$pb_string_translation->add_package_to_update_list( $package, $language_1 );
 		$pb_string_translation->add_package_to_update_list( $package, $language_2 );
 		$pb_string_translation->save_translations_to_post();
+
+		$normalizePackages->wasCalledTimes( 2 );
 	}
 
 	public function new_translations_data_provider() {
@@ -61,28 +85,28 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	private function get_factory_and_strategy_mock( $string_package_id, $language_1, $language_2, $post_id = null ) {
 		$package_kind = rand_str( 32 );
 
-		$factory       = $this->getMockBuilder( 'WPML_PB_Factory' )
-		                      ->setMethods( array( 'get_wpml_package' ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
-		$package       = $this->getMockBuilder( 'WPML_Package' )
-		                      ->setMethods()
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
-		$package->kind = $package_kind;
+		$factory          = $this->getMockBuilder( 'WPML_PB_Factory' )
+		                         ->setMethods( array( 'get_wpml_package' ) )
+		                         ->disableOriginalConstructor()
+		                         ->getMock();
+		$package          = $this->getMockBuilder( 'WPML_Package' )
+		                         ->setMethods()
+		                         ->disableOriginalConstructor()
+		                         ->getMock();
+		$package->kind    = $package_kind;
 		$package->post_id = $post_id;
-		$update = $this->getMockBuilder( 'WPML_PB_Update_Post' )
-		               ->setMethods( [ 'update', 'update_content' ] )
-		               ->disableOriginalConstructor()
-		               ->getMock();
+		$update           = $this->getMockBuilder( 'WPML_PB_Update_Post' )
+		                         ->setMethods( [ 'update', 'update_content' ] )
+		                         ->disableOriginalConstructor()
+		                         ->getMock();
 		$update->expects( $post_id ? $this->once() : $this->never() )
 		       ->method( 'update' );
 
 
-		$strategy = $this->getMockBuilder( 'WPML_PB_Shortcode_Strategy' )
-		                 ->setMethods( array( 'get_package_kind', 'get_update_post' ) )
-		                 ->disableOriginalConstructor()
-		                 ->getMock();
+		$strategy     = $this->getMockBuilder( 'WPML_PB_Shortcode_Strategy' )
+		                     ->setMethods( array( 'get_package_kind', 'get_update_post' ) )
+		                     ->disableOriginalConstructor()
+		                     ->getMock();
 		$package_data = array( 'package' => $package, 'languages' => array( $language_1, $language_2 ) );
 		$strategy->method( 'get_update_post' )
 		         ->with( $this->equalTo( $package_data ) )
@@ -116,11 +140,11 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	 * @dataProvider remove_string_db
 	 */
 	public function remove_string( $delete_count, $job_translated ) {
-		$context = rand_str();
-		$name = rand_str();
-		$job_id = mt_rand();
+		$context              = rand_str();
+		$name                 = rand_str();
+		$job_id               = mt_rand();
 		$translated_string_id = mt_rand();
-		$string_package_id = mt_rand();
+		$string_package_id    = mt_rand();
 
 		\WP_Mock::wpFunction( 'icl_unregister_string', array(
 			'times' => 1, // a string must be always unregistered contrary to a record in `icl_translate`
@@ -128,14 +152,13 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		) );
 
 
-
 		$factory_mock = $this->getMockBuilder( 'WPML_PB_Factory' )
-		                    ->disableOriginalConstructor()
-		                    ->getMock();
-
-		$strategy_mock = $this->getMockBuilder( 'IWPML_PB_Strategy' )
 		                     ->disableOriginalConstructor()
 		                     ->getMock();
+
+		$strategy_mock = $this->getMockBuilder( 'IWPML_PB_Strategy' )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
 
 		$wpdb = $this->stubs->wpdb();
 
@@ -143,7 +166,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		$wpdb->expects( $this->exactly( 2 ) )->method( 'get_var' )->willReturnOnConsecutiveCalls( $job_id, $job_translated );
 		$wpdb->expects( $this->exactly( $delete_count ) )->method( 'delete' )->with( $wpdb->prefix . 'icl_translate', array( 'field_type' => $field_type ), array( '%s' ) );
 		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb, $factory_mock, $strategy_mock );
-		$string_data = array(
+		$string_data           = array(
 			'context'    => $context,
 			'name'       => $name,
 			'package_id' => $string_package_id,
@@ -155,14 +178,14 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 	/**
 	 * @test
 	 * @group wpmlst-1215
-	 * @link https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlst-1215
+	 * @link  https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlst-1215
 	 */
 	public function it_should_remove_string_if_job_id_is_null() {
-		$context = rand_str();
-		$name = rand_str();
-		$job_id = null;
+		$context              = rand_str();
+		$name                 = rand_str();
+		$job_id               = null;
 		$translated_string_id = mt_rand();
-		$string_package_id = mt_rand();
+		$string_package_id    = mt_rand();
 
 		\WP_Mock::wpFunction( 'icl_unregister_string', array(
 			'times' => 1,
@@ -183,7 +206,7 @@ class Test_WPML_PB_String_Translation extends WPML_PB_TestCase {
 		$wpdb->expects( $this->exactly( 1 ) )->method( 'get_var' )->willReturn( $job_id );
 		$wpdb->expects( $this->exactly( 1 ) )->method( 'delete' )->with( $wpdb->prefix . 'icl_translate', array( 'field_type' => $field_type ), array( '%s' ) );
 		$pb_string_translation = new WPML_PB_String_Translation_By_Strategy( $wpdb, $factory_mock, $strategy_mock );
-		$string_data = array(
+		$string_data           = array(
 			'context'    => $context,
 			'name'       => $name,
 			'package_id' => $string_package_id,

--- a/tests/phpunit/tests/st/test-wpml-pb-update-post.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-update-post.php
@@ -95,6 +95,42 @@ class Test_WPML_PB_Update_Post extends WPML_PB_TestCase {
 		);
 	}
 
+	/**
+	 * @test
+	 */
+	public function it_updates_content() {
+		$content         = 'some content';
+		$updated_content = 'some content[updated]';
+		$lang            = 'de';
+		$strings         = [
+			'any' => 'thing'
+		];
+
+		$package = \Mockery::mock( 'WPML_Package' );
+		$package->shouldReceive( 'get_translated_strings' )->with( [] )->andReturn( $strings );
+
+		$updater = \Mockery::mock( 'WPML_PB_Update_Shortcodes_In_Content' );
+		$updater->shouldReceive( 'update_content' )
+		        ->with( $content, $strings, $lang )
+		        ->andReturn( $updated_content );
+
+		$strategy = \Mockery::mock( 'WPML_PB_Shortcode_Strategy' );
+		$strategy->shouldReceive( 'get_content_updater' )->andReturn( $updater );
+
+		$subject = new WPML_PB_Update_Post(
+			\Mockery::mock( 'wpdb' ),
+			\Mockery::mock( 'SitePress' ),
+			[ 'package' => $package ],
+			$strategy
+		);
+
+		$this->assertEquals(
+			$updated_content,
+			$subject->update_content( $content, $lang )
+		);
+
+	}
+
 	private function get_package_mock(
 		$post_id,
 		$string,

--- a/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
@@ -53,7 +53,7 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 				)
 			)
 		);
-		
+
 
 	}
 
@@ -77,7 +77,7 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$subject = new WPML_PB_Register_Shortcodes( $string_handler, $this->shortcode_strategy, new WPML_PB_Shortcode_Encoding(),$reuse_translations_mock );
-		$subject->register_shortcode_strings( $post_id, '' );
+		$subject->register_shortcode_strings( $post_id, '', true );
 	}
 
 	/**

--- a/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
@@ -77,7 +77,7 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 		$reuse_translations_mock->shouldReceive( 'find_and_reuse' );
 
 		$subject = new WPML_PB_Register_Shortcodes( $string_handler, $this->shortcode_strategy, new WPML_PB_Shortcode_Encoding(),$reuse_translations_mock );
-		$subject->register_shortcode_strings( $post_id, '', true );
+		$subject->register_shortcode_strings( $post_id, '', null );
 	}
 
 	/**

--- a/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-visual-composer-links.php
@@ -43,6 +43,7 @@ class Test_WPML_PB_Visual_Composer_Links extends WPML_PB_TestCase {
 		$this->shortcode_strategy->shouldReceive( 'get_package_key' )->andReturnNull();
 		$this->shortcode_strategy->shouldReceive( 'get_package_strings' )->andReturn( array() );
 		$this->shortcode_strategy->shouldReceive( 'get_shortcode_attributes' )->andReturn( array( 'title', 'link' ) );
+		$this->shortcode_strategy->shouldReceive( 'get_shortcodes' )->andReturn( [ 'vc_btn' ] );
 
 		\WP_Mock::wpFunction( 'shortcode_parse_atts',
 			array(

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
@@ -253,6 +253,19 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 		$not_json = 'do not escape these - \\ " \'';
 		$this->assertEquals( $not_json, WPML_PB_Handle_Custom_Fields::slash_json( $not_json ) );
 	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-7141
+	 */
+	public function it_does_NOT_slash_if_original_data_is_NOT_a_string() {
+		$not_string = [ 'some data' ];
+
+		\WP_Mock::userFunction( 'wp_slash', [ 'times' => 0 ] );
+
+		$this->assertEquals( $not_string, WPML_PB_Handle_Custom_Fields::slash_json( $not_string ) );
+	}
+
 	/**
 	 * @test
 	 */

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-custom-fields.php
@@ -23,19 +23,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_adds_hooks() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -55,19 +43,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_returns_true_when_post_has_the_custom_field() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -76,16 +52,10 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 		             ->getMock();
 
 		$post->ID    = 10;
-		$field       = 'my-custom-field';
-		$field_value = 'something';
 
-		$data_settings->method( 'get_meta_field' )
-		              ->willReturn( $field );
-
-		\WP_Mock::wpFunction( 'get_post_meta', array(
-			'args'   => array( $post->ID, $field ),
-			'return' => $field_value,
-		) );
+		$data_settings->method( 'is_handling_post' )
+			->with( $post->ID )
+			->willReturn( true );
 
 		$this->assertTrue( $subject->is_page_builder_page_filter( false, $post ) );
 	}
@@ -94,19 +64,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_returns_unfiltered_result_when_post_does_not_have_the_custom_field() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -115,15 +73,10 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 		             ->getMock();
 
 		$post->ID = 10;
-		$field    = 'my-custom-field';
 
-		$data_settings->method( 'get_meta_field' )
-		              ->willReturn( $field );
-
-		\WP_Mock::wpFunction( 'get_post_meta', array(
-			'args'   => array( $post->ID, $field ),
-			'return' => false,
-		) );
+		$data_settings->method( 'is_handling_post' )
+		              ->with( $post->ID )
+		              ->willReturn( false );
 
 		$this->assertFalse( $subject->is_page_builder_page_filter( false, $post ) );
 	}
@@ -132,19 +85,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_copies_custom_fields_when_original_custom_field_exists() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -173,19 +114,7 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 	 * @test
 	 */
 	public function it_does_not_copy_custom_fields_when_original_custom_field_does_not_exists() {
-		$data_settings = $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
-		                      ->setMethods( array(
-			                      'get_node_id_field',
-			                      'get_fields_to_copy',
-			                      'get_fields_to_save',
-			                      'get_meta_field',
-			                      'convert_data_to_array',
-			                      'prepare_data_for_saving',
-			                      'get_pb_name',
-			                      'add_hooks',
-		                      ) )
-		                      ->disableOriginalConstructor()
-		                      ->getMock();
+		$data_settings = $this->getDataSettings();
 
 		$subject = new WPML_PB_Handle_Custom_Fields( $data_settings );
 
@@ -274,5 +203,24 @@ class Test_WPML_PB_Handle_Custom_Fields extends \OTGS\PHPUnit\Tools\TestCase {
 		$json_string = json_encode( $json );
 
 		$this->assertEquals( addslashes( $json_string ), WPML_PB_Handle_Custom_Fields::slash_json( $json_string ) );
+	}
+
+	private function getDataSettings() {
+		return $this->getMockBuilder( 'IWPML_Page_Builders_Data_Settings' )
+		                      ->setMethods(
+								[
+									'get_node_id_field',
+									'get_fields_to_copy',
+									'get_fields_to_save',
+									'get_meta_field',
+									'convert_data_to_array',
+									'prepare_data_for_saving',
+									'get_pb_name',
+									'add_hooks',
+									'is_handling_post',
+								]
+		                      )
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
 	}
 }

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
@@ -5,7 +5,22 @@
  *
  * @group wpmlcore-5684
  */
-class Test_WPML_PB_Handle_Post_Body extends \OTGS\PHPUnit\Tools\TestCase {
+class Test_WPML_PB_Handle_Post_Body extends OTGS\PHPUnit\Tools\TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldLoadWithDicOnFrontendAndBackend() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+
+		$this->assertInstanceOf( \IWPML_Backend_Action::class, $subject );
+		$this->assertInstanceOf( IWPML_Frontend_Action::class, $subject );
+		$this->assertInstanceOf( IWPML_DIC_Action::class, $subject );
+	}
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -287,7 +287,22 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test
+	 * @group wpmlcore-7246
+	 */
+	public function pro_translation_completed_action_with_NOT_post_job() {
+		$subject = $this->get_subject();
+
+		$job = (object) [ 'element_type_prefix' => 'package'];
+
+		\WP_Mock::userFunction( 'do_action' )->never();
+
+		$subject->pro_translation_completed_action( 123, [ 'some fields' ], $job );
+	}
+
+	/**
+	 * @test
 	 * @dataProvider pro_translation_completed_action_data_provider
+	 * @group wpmlcore-7246
 	 *
 	 * @param array $fields
 	 * @param array $data
@@ -302,6 +317,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$job->translator_id       = rand( 1, 50 );
 		$job->translation_service = rand( 1, 50 );
 		$job->original_doc_id     = 20;
+		$job->element_type_prefix = 'post';
 
 		$field_string1 = $this->find_field_with_slug( $data['string1_field_name'], $fields );
 		$field_string2 = $this->find_field_with_slug( $data['string2_field_name'], $fields );

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -187,9 +187,12 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 
 	/**
 	 * @test
-	 * @group wpmlcore-6929)
+	 * @group wpmlcore-6929
 	 */
 	public function it_should_not_include_package_strings_if_body_should_be_translated() {
+		$this->markTestSkipped( 'This was temporarily reverted, will be fixed in short.' );
+		return;
+
 		$translation_package = $this->prepare_translation_package( 'post' );
 		$post                = $this->get_a_post_object();
 

--- a/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
+++ b/tests/phpunit/tests/tm/test-wpml-tm-page-builders.php
@@ -93,6 +93,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$translation_package = $this->prepare_translation_package( 'post' );
 		$post                = $this->get_a_post_object();
 
+		$this->mock_should_body_be_translated_filter( false, $translation_package['contents']['body']['translate'], $post );
 		$this->set_hardcoded_wpml_post_element( null, rand_str( 2 ) );
 
 		$strings    = $this->prepare_package_strings();
@@ -128,6 +129,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 			$strings[ $key ]->type = 'LINK';
 		}
 
+		$this->mock_should_body_be_translated_filter( false, $translation_package['contents']['body']['translate'], $post );
 		$this->set_hardcoded_wpml_post_element( null, rand_str( 2 ) );
 
 		$package_id = rand( 1, 100 );
@@ -152,6 +154,7 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$translation_package = $this->prepare_translation_package( 'post' );
 		$post                = $this->get_a_post_object();
 
+		$this->mock_should_body_be_translated_filter( false, $translation_package['contents']['body']['translate'], $post );
 		$this->set_hardcoded_wpml_post_element( $source_post_id, $job_lang_from );
 
 		$strings    = $this->prepare_package_strings();
@@ -180,6 +183,21 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$filtered_translation_package = $subject->translation_job_data_filter( $translation_package, $post );
 
 		$this->assertEquals( $expected_translation_package, $filtered_translation_package );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6929)
+	 */
+	public function it_should_not_include_package_strings_if_body_should_be_translated() {
+		$translation_package = $this->prepare_translation_package( 'post' );
+		$post                = $this->get_a_post_object();
+
+		$this->mock_should_body_be_translated_filter( true, $translation_package['contents']['body']['translate'], $post );
+
+		$subject = $this->get_subject();
+
+		$this->assertSame( $translation_package, $subject->translation_job_data_filter( $translation_package, $post ) );
 	}
 
 	private function set_hardcoded_wpml_post_element( $post_source_id, $job_lang_from ) {
@@ -562,5 +580,16 @@ class Test_WPML_TM_Page_Builders extends \OTGS\PHPUnit\Tools\TestCase {
 		$post->ID        = rand( 1, 100 );
 		$post->post_type = rand_str();
 		return $post;
+	}
+
+	/**
+	 * @param bool             $shouldBeTranslated
+	 * @param int              $originalValue
+	 * @param stdClass|WP_Post $post
+	 */
+	private function mock_should_body_be_translated_filter( $shouldBeTranslated, $originalValue, $post ) {
+		\WP_Mock::onFilter( 'wpml_pb_should_body_be_translated' )
+			->with( $originalValue, $post )
+			->reply( $shouldBeTranslated );
 	}
 }


### PR DESCRIPTION
PHP Warning: preg_replace(): Compilation failed: regular expression is too large with large text in page builders

It seems that not only $original value should be checked to be used in `preg_replace`
In case from ticket, $block was too long to perform `preg_replace`

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7032