### PR TITLE
WIP Register original strings in `post_save` instead of `shutdown`

### DIFF
--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -6,7 +6,6 @@ use WPML\FP\Fns;
 use WPML\FP\Logic;
 use WPML\FP\Lst;
 use WPML\FP\Maybe;
-use WPML\FP\Obj;
 use WPML\FP\Relation;
 use function WPML\FP\invoke;
 use function WPML\FP\pipe;


### PR DESCRIPTION
I tried to understand why we were registering the strings in the shutdown ([here's the first commit since we moved to packages](https://github.com/OnTheGoSystems/wpml-page-builders/commit/c2fbbe68a466fae971478bc71119fdd65d2d827d#diff-676bae29b174e7970cdcf9e02045ec3dR126)), but I didn't find a valid reason. I guess we did this only to defer the process as late as possible (to "hide" it for the user).

Now we need to register these string earlier so that we can use the new content hash (base on strings) a bit earlier.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7373