### PR TITLE
Fix defects in the auto-update feature

### DIFF
--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -30,9 +30,15 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 	}
 
 	public function add_hooks() {
-		add_action( 'init', [ $this, 'init' ] );
-		add_filter( 'wpml_tm_post_md5_content', [ $this, 'getMd5ContentFromPackageStrings' ], 10, 2 );
-		add_action( 'shutdown', [ $this, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );
+		if ( $this->isTmLoaded() ) {
+			add_action( 'init', [ $this, 'init' ] );
+			add_filter( 'wpml_tm_post_md5_content', [ $this, 'getMd5ContentFromPackageStrings' ], 10, 2 );
+			add_action( 'shutdown', [ $this, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );
+		}
+	}
+
+	public function isTmLoaded() {
+		return defined( 'WPML_TM_VERSION' );
 	}
 
 	/**

--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -54,7 +54,7 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 		// $joinPackageStringHashes :: \WPML_Package → string
 		$joinPackageStringHashes = pipe(
 			invoke( 'get_package_strings' )->with( true ),
-			Lst::pluck( 'name' ),
+			Lst::pluck( 'value' ),
 			Lst::sort( Relation::gt() ),
 			Lst::join( self::HASH_SEP )
 		);

--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -6,9 +6,9 @@ use WPML\FP\Fns;
 use WPML\FP\Logic;
 use WPML\FP\Lst;
 use WPML\FP\Maybe;
-use WPML\FP\Obj;
 use WPML\FP\Relation;
 use function WPML\FP\invoke;
+use function WPML\FP\partialRight;
 use function WPML\FP\pipe;
 
 class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC_Action {
@@ -25,13 +25,23 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 		\WPML_PB_Integration $pbIntegration,
 		\WPML_Translation_Element_Factory $elementFactory
 	) {
-		$this->pbIntegration     = $pbIntegration;
-		$this->elementFactory    = $elementFactory;
+		$this->pbIntegration             = $pbIntegration;
+		$this->elementFactory            = $elementFactory;
 	}
 
 	public function add_hooks() {
+		add_action( 'init', [ $this, 'init' ] );
 		add_filter( 'wpml_tm_post_md5_content', [ $this, 'getMd5ContentFromPackageStrings' ], 10, 2 );
-		add_action( 'wpml_after_save_post', [ $this, 'resaveTranslationsAfterSavePost' ], 10, 4 );
+		add_action( 'shutdown', [ $this, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );
+	}
+
+	/**
+	 * We remove the action callback because it will be
+	 * called manually for each of the saved posts in the
+	 * shutdown when the original strings are registered.
+	 */
+	public function init() {
+		remove_action( 'wpml_tm_save_post', 'wpml_tm_save_post', 10 );
 	}
 
 	/**
@@ -67,13 +77,21 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 	}
 
 	/**
-	 * @param int         $postId
-	 * @param int         $trid
-	 * @param string      $lang
-	 * @param string|null $sourceLang
+	 * We need to call `wpml_tm_save_post` after string registration
+	 * to make sure we build the content hash with the new strings.
 	 */
-	public function resaveTranslationsAfterSavePost( $postId, $trid, $lang, $sourceLang ) {
-		if ( $sourceLang || ! self::getPackages( $postId ) ) {
+	public function afterRegisterAllStringsInShutdown() {
+		foreach ( $this->pbIntegration->get_save_post_queue() as $post ) {
+			wpml_tm_save_post( $post->ID, $post );
+			$this->resaveTranslations( $post->ID );
+		}
+	}
+
+	/**
+	 * @param int $postId
+	 */
+	private function resaveTranslations( $postId ) {
+		if ( ! self::getPackages( $postId ) ) {
 			return;
 		}
 
@@ -84,7 +102,7 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 		$ifCompleted = pipe( [ TranslationStatus::class, 'get' ], Relation::equals( ICL_TM_COMPLETE ) );
 
 		// $resaveElement :: \WPML_Post_Element → null
-		$resaveElement = [ $this->pbIntegration, 'resave_post_translation_in_shutdown' ];
+		$resaveElement = \WPML\FP\Fns::unary( partialRight( [ $this->pbIntegration, 'resave_post_translation_in_shutdown' ], false ) );
 
 		wpml_collect( $this->elementFactory->create_post( $postId )->get_translations() )
 			->reject( $ifOriginal )

--- a/src/Shutdown/Hooks.php
+++ b/src/Shutdown/Hooks.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace WPML\PB\Shutdown;
+
+class Hooks implements \IWPML_Frontend_Action, \IWPML_Backend_Action, \IWPML_DIC_Action {
+
+	const PRIORITY_REGISTER_STRINGS          = 10;
+	const PRIORITY_SAVE_TRANSLATIONS_TO_POST = 20;
+	const PRIORITY_TRANSLATE_MEDIA           = 30;
+
+	/** @var \WPML_PB_Integration $pbIntegration */
+	private $pbIntegration;
+
+	public function __construct( \WPML_PB_Integration $pbIntegration ) {
+		$this->pbIntegration = $pbIntegration;
+	}
+
+	public function add_hooks() {
+		add_action( 'shutdown', [ $this, 'registerStrings' ], self::PRIORITY_REGISTER_STRINGS );
+		add_action( 'shutdown', [ $this->pbIntegration, 'save_translations_to_post' ], self::PRIORITY_SAVE_TRANSLATIONS_TO_POST );
+		add_action( 'shutdown', [ $this, 'translateMedias' ], self::PRIORITY_TRANSLATE_MEDIA );
+	}
+
+	/**
+	 * This applies only on original posts.
+	 */
+	public function registerStrings() {
+		foreach( $this->pbIntegration->get_save_post_queue() as $post ) {
+			$this->pbIntegration->register_all_strings_for_translation( $post );
+		}
+	}
+
+	/**
+	 * This applies only on post translations.
+	 */
+	public function translateMedias() {
+		if ( defined( 'WPML_MEDIA_VERSION' ) ) {
+			foreach( $this->pbIntegration->get_save_post_queue() as $post ) {
+				$this->pbIntegration->translate_media( $post );
+			}
+		}
+	}
+}

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -181,7 +181,7 @@ class WPML_PB_Integration {
 	 */
 	public function add_hooks() {
 		add_action( 'pre_post_update', array( $this, 'migrate_location' ) );
-		add_action( 'save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
+		add_action( 'wpml_tm_save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
 		add_action( 'wpml_pb_resave_post_translation', array( $this, 'resave_post_translation_in_shutdown' ), 10, 1 );
 		add_action( 'icl_st_add_string_translation', array( $this, 'new_translation' ), 10, 1 );
 		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'process_pb_content_with_hidden_strings_only' ), 9, 2 );

--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -82,6 +82,7 @@ class WPML_PB_Loader {
 				[
 					WPML_PB_Handle_Post_Body::class,
 					WPML\PB\AutoUpdate\Hooks::class,
+					WPML\PB\Shutdown\Hooks::class,
 				]
 			);
 		}

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -16,10 +16,22 @@ class TestHooks extends  TestCase {
 	public function itAddsHooks() {
 		$subject = $this->getSubject();
 
+		\WP_Mock::expectActionAdded( 'init', [ $subject, 'init' ] );
 		\WP_Mock::expectFilterAdded( 'wpml_tm_post_md5_content', [ $subject, 'getMd5ContentFromPackageStrings' ], 10, 2 );
-		\WP_Mock::expectActionAdded( 'wpml_after_save_post', [ $subject, 'resaveTranslationsAfterSavePost' ], 10, 4 );
+		\WP_Mock::expectActionAdded( 'shutdown', [ $subject, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );
 
 		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldInit() {
+		\WP_Mock::userFunction( 'remove_action' )
+			->with( 'wpml_tm_save_post', 'wpml_tm_save_post', 10 )
+			->times( 1 );
+
+		$this->getSubject()->init();
 	}
 
 	/**
@@ -73,7 +85,14 @@ class TestHooks extends  TestCase {
 	 * @test
 	 */
 	public function itDoesNotResaveTranslationsIfNotOriginal() {
+		$post = $this->getPost( 123 );
+
+		\WP_Mock::userFunction( 'wpml_tm_save_post' )
+			->times( 1 )
+			->with( $post->ID, $post );
+
 		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->method( 'get_save_post_queue' )->willReturn( [ $post ] );
 		$pbIntegration->expects( $this->never() )->method( 'resave_post_translation_in_shutdown' );
 
 		$factory = $this->getElementFactory();
@@ -81,20 +100,25 @@ class TestHooks extends  TestCase {
 
 		$subject = $this->getSubject( $pbIntegration, $factory );
 
-		$subject->resaveTranslationsAfterSavePost( 123, 456, 'fr', 'en' );
+		$subject->afterRegisterAllStringsInShutdown();
 	}
 
 	/**
 	 * @test
 	 */
 	public function itDoesNotResaveTranslationsIfNoPackage() {
-		$postId = 123;
+		$post = $this->getPost( 123 );
+
+		\WP_Mock::userFunction( 'wpml_tm_save_post' )
+		        ->times( 1 )
+		        ->with( $post->ID, $post );
 
 		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
-			->with( [], $postId )
+			->with( [], $post->ID )
 			->reply( [] );
 
 		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->method( 'get_save_post_queue' )->willReturn( [ $post ] );
 		$pbIntegration->expects( $this->never() )->method( 'resave_post_translation_in_shutdown' );
 
 		$factory = $this->getElementFactory();
@@ -102,17 +126,21 @@ class TestHooks extends  TestCase {
 
 		$subject = $this->getSubject( $pbIntegration, $factory );
 
-		$subject->resaveTranslationsAfterSavePost( $postId, 456, 'fr', null );
+		$subject->afterRegisterAllStringsInShutdown();
 	}
 
 	/**
 	 * @test
 	 */
 	public function itResavesTranslationsAfterSavePost() {
-		$postId = 123;
+		$post1 = $this->getPost( 123 );
+
+		\WP_Mock::userFunction( 'wpml_tm_save_post' )
+		        ->times( 1 )
+		        ->with( $post1->ID, $post1 );
 
 		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
-			->with( [], $postId )
+			->with( [], $post1->ID )
 			->reply( [ 'some package' ] );
 
 		$translation1            = $this->getElement( 'en' );
@@ -122,6 +150,7 @@ class TestHooks extends  TestCase {
 		$original = $this->getElement( null, [ $translation1, $translation2, $translationNotCompleted ] );
 
 		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->method( 'get_save_post_queue' )->willReturn( [ $post1 ] );
 		$pbIntegration->expects( $this->exactly( 2 ) )
 			->method( 'resave_post_translation_in_shutdown' )
 			->withConsecutive(
@@ -130,7 +159,7 @@ class TestHooks extends  TestCase {
 			);
 
 		$factory = $this->getElementFactory();
-		$factory->method( 'create_post' )->with( $postId )->willReturn( $original );
+		$factory->method( 'create_post' )->with( $post1->ID )->willReturn( $original );
 
 		FunctionMocker::replace(
 			TranslationStatus::class . '::get',
@@ -141,7 +170,7 @@ class TestHooks extends  TestCase {
 
 		$subject = $this->getSubject( $pbIntegration, $factory );
 
-		$subject->resaveTranslationsAfterSavePost( $postId, 456, 'fr', null );
+		$subject->afterRegisterAllStringsInShutdown();
 	}
 
 	private function getSubject( $pbIntegration = null, $elementFactory = null ) {
@@ -153,7 +182,7 @@ class TestHooks extends  TestCase {
 
 	private function getPbIntegration() {
 		return $this->getMockBuilder( '\WPML_PB_Integration' )
-			->setMethods( [ 'resave_post_translation_in_shutdown' ] )
+			->setMethods( [ 'resave_post_translation_in_shutdown', 'get_save_post_queue' ] )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -206,5 +235,12 @@ class TestHooks extends  TestCase {
 			->willReturn( $stringsData );
 
 		return $package;
+	}
+
+	private function getPost( $id ) {
+		$post = $this->getMockBuilder( '\WP_Post' )->getMock();
+		$post->ID = $id;
+
+		return $post;
 	}
 }

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -13,7 +13,26 @@ class TestHooks extends  TestCase {
 	/**
 	 * @test
 	 */
+	public function itDoesNotAddHooksIfTmIsNotActive() {
+		$constant = FunctionMocker::replace( 'defined', false );
+
+		$subject = $this->getSubject();
+
+		\WP_Mock::expectActionNotAdded( 'init', [ $subject, 'init' ] );
+		\WP_Mock::expectFilterNotAdded( 'wpml_tm_post_md5_content', [ $subject, 'getMd5ContentFromPackageStrings' ], 10, 2 );
+		\WP_Mock::expectActionNotAdded( 'shutdown', [ $subject, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );
+
+		$subject->add_hooks();
+
+		$constant->wasCalledWithOnce( [ 'WPML_TM_VERSION' ] );
+	}
+
+	/**
+	 * @test
+	 */
 	public function itAddsHooks() {
+		$constant = FunctionMocker::replace( 'defined', true );
+
 		$subject = $this->getSubject();
 
 		\WP_Mock::expectActionAdded( 'init', [ $subject, 'init' ] );
@@ -21,6 +40,8 @@ class TestHooks extends  TestCase {
 		\WP_Mock::expectActionAdded( 'shutdown', [ $subject, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );
 
 		$subject->add_hooks();
+
+		$constant->wasCalledWithOnce( [ 'WPML_TM_VERSION' ] );
 	}
 
 	/**

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -70,7 +70,7 @@ class TestHooks extends  TestCase {
 		$packageWithMissingStringData = $this->getPackage( [] );
 
 		// keys are sorted inside each package
-		$expectedPostContentMd5 = 'string1A' . Hooks::HASH_SEP . 'string1B' . Hooks::HASH_SEP . 'string2A' . Hooks::HASH_SEP . 'string2B-';
+		$expectedPostContentMd5 = 'The string 1A' . Hooks::HASH_SEP . 'The string 1B' . Hooks::HASH_SEP . 'The string 2A' . Hooks::HASH_SEP . 'The string 2B-';
 
 		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
 			->with( [], $post->ID )

--- a/tests/phpunit/tests/Shutdown/TestHooks.php
+++ b/tests/phpunit/tests/Shutdown/TestHooks.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace WPML\PB\Shutdown;
+
+use tad\FunctionMocker\FunctionMocker;
+
+/**
+ * @group shutdown
+ */
+class TestHooks extends \OTGS\PHPUnit\Tools\TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$pbIntegration = $this->getPbIntegration();
+		$subject       = $this->getSubject( $pbIntegration );
+
+		\WP_Mock::expectActionAdded( 'shutdown', [ $subject, 'registerStrings' ], Hooks::PRIORITY_REGISTER_STRINGS );
+		\WP_Mock::expectActionAdded( 'shutdown', [ $pbIntegration, 'save_translations_to_post' ], Hooks::PRIORITY_SAVE_TRANSLATIONS_TO_POST );
+		\WP_Mock::expectActionAdded( 'shutdown', [ $subject, 'translateMedias' ], Hooks::PRIORITY_TRANSLATE_MEDIA );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldRegisterStrings() {
+		$post = \Mockery::mock( '\WP_Post' );
+
+		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->method( 'get_save_post_queue' )->willReturn( [ $post ] );
+		$pbIntegration->expects( $this->once() )
+			->method( 'register_all_strings_for_translation' )
+			->with( $post );
+
+		$subject = $this->getSubject( $pbIntegration );
+
+		$subject->registerStrings();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldNOTTranslateMediasIfDisabled() {
+		$post = \Mockery::mock( '\WP_Post' );
+
+		$defined = FunctionMocker::replace( 'defined', false );
+
+		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->method( 'get_save_post_queue' )->willReturn( [ $post ] );
+		$pbIntegration->expects( $this->never() )->method( 'translate_media' );
+
+		$subject = $this->getSubject( $pbIntegration );
+
+		$subject->translateMedias();
+
+		$defined->wasCalledWithOnce( [ 'WPML_MEDIA_VERSION' ] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldTranslateMedias() {
+		$post = \Mockery::mock( '\WP_Post' );
+
+		$defined = FunctionMocker::replace( 'defined', true );
+
+		$pbIntegration = $this->getPbIntegration();
+		$pbIntegration->method( 'get_save_post_queue' )->willReturn( [ $post ] );
+		$pbIntegration->expects( $this->once() )
+			->method( 'translate_media' )
+			->with( $post );
+
+		$subject = $this->getSubject( $pbIntegration );
+
+		$subject->translateMedias();
+
+		$defined->wasCalledWithOnce( [ 'WPML_MEDIA_VERSION' ] );
+	}
+
+	private function getSubject( $pbIntegration ) {
+		return new Hooks( $pbIntegration );
+	}
+
+	private function getPbIntegration() {
+		return $this->getMockBuilder( '\WPML_PB_Integration' )
+			->setMethods( [
+				'get_save_post_queue',
+				'register_all_strings_for_translation',
+				'translate_media',
+			] )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+}

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -151,7 +151,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 			$pb_integration,
 			'migrate_location'
 		) );
-		\WP_Mock::expectActionAdded( 'save_post', array(
+		\WP_Mock::expectActionAdded( 'wpml_tm_save_post', array(
 			$pb_integration,
 			'queue_save_post_actions'
 		), PHP_INT_MAX, 2 );

--- a/tests/phpunit/tests/st/test-wpml-pb-loader.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-loader.php
@@ -20,6 +20,7 @@ class Test_WPML_PB_Loader extends WPML_PB_TestCase {
 				[
 					WPML_PB_Handle_Post_Body::class,
 					WPML\PB\AutoUpdate\Hooks::class,
+					WPML\PB\Shutdown\Hooks::class,
 				]
 			);
 		}


### PR DESCRIPTION
1. I had to refactor the shutdown process. First I extracted the shutdown
actions to a separate class to have a better overview and I separated
the tasks with different priorities.

2. We are now registering the strings before to save translations to
post.

3. We are now defering the call to `wpml_tm_save_post` just after
registering the strings. That way we are sure the content hash will be
computed from the new registered strings.