### PR TITLE
Force to load TM element translations hooks with `wpml_tm_load_element_translations`

### DIFF
--- a/src/AutoUpdate/TranslationStatus.php
+++ b/src/AutoUpdate/TranslationStatus.php
@@ -15,6 +15,8 @@ class TranslationStatus {
 	 * @return int|null
 	 */
 	public static function get( WPML_Post_Element $element ) {
+		wpml_tm_load_element_translations();
+
 		return Maybe::fromNullable( make( '\WPML_TM_Translation_Status' ) )
 			->map( invoke( 'filter_translation_status' )->with( null, $element->get_trid(), $element->get_language_code() ) )
 			->getOrElse( null );

--- a/tests/phpunit/tests/AutoUpdate/TestTranslationStatus.php
+++ b/tests/phpunit/tests/AutoUpdate/TestTranslationStatus.php
@@ -14,6 +14,7 @@ class TestTranslationStatus extends TestCase {
 	 * @test
 	 */
 	public function itGetsAndReturnNullIfClassIsMissing() {
+		\WP_Mock::userFunction( 'wpml_tm_load_element_translations' )->times( 1 );
 		\WP_Mock::userFunction( 'WPML\Container\make' )->andReturn( null );
 
 		$this->assertNull( TranslationStatus::get( $this->getElement( 123, 'fr' ) ) );
@@ -26,6 +27,8 @@ class TestTranslationStatus extends TestCase {
 		$trid   = 123;
 		$lang   = 'fr';
 		$status = 999;
+
+		\WP_Mock::userFunction( 'wpml_tm_load_element_translations' )->times( 1 );
 
 		$statusObject = $this->getMockBuilder( '\WPML_TM_Translation_Status' )
 			->setMethods( [ 'filter_translation_status' ] )


### PR DESCRIPTION
This is required because some page builders (e.g. Cornerstone) might run
on the frontend and TM is not fully loaded in that context.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmltm-3867