### PR TITLE
Hook on `wpml_tm_save_post` instead of `save_post` to queue posts

### DIFF
--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -181,7 +181,7 @@ class WPML_PB_Integration {
 	 */
 	public function add_hooks() {
 		add_action( 'pre_post_update', array( $this, 'migrate_location' ) );
-		add_action( 'save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
+		add_action( 'wpml_tm_save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
 		add_action( 'wpml_pb_resave_post_translation', array( $this, 'resave_post_translation_in_shutdown' ), 10, 1 );
 		add_action( 'icl_st_add_string_translation', array( $this, 'new_translation' ), 10, 1 );
 		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'process_pb_content_with_hidden_strings_only' ), 9, 2 );

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -151,7 +151,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 			$pb_integration,
 			'migrate_location'
 		) );
-		\WP_Mock::expectActionAdded( 'save_post', array(
+		\WP_Mock::expectActionAdded( 'wpml_tm_save_post', array(
 			$pb_integration,
 			'queue_save_post_actions'
 		), PHP_INT_MAX, 2 );


### PR DESCRIPTION
`wpml_tm_save_post` is not called for 'nav_menu_item' and 'attachment'
post types, so we reduce the process.

See `wpml_tm_save_post` called in
`\WPML_Post_Translation::after_save_post`.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7373