### PR TITLE
Use string values instead of string names to build the hash

### DIFF
--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -57,7 +57,7 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 		// $joinPackageStringHashes :: \WPML_Package → string
 		$joinPackageStringHashes = pipe(
 			invoke( 'get_package_strings' )->with( true ),
-			Lst::pluck( 'name' ),
+			Lst::pluck( 'value' ),
 			Lst::sort( Relation::gt() ),
 			Lst::join( self::HASH_SEP )
 		);

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -181,7 +181,7 @@ class WPML_PB_Integration {
 	 */
 	public function add_hooks() {
 		add_action( 'pre_post_update', array( $this, 'migrate_location' ) );
-		add_action( 'save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
+		add_action( 'wpml_tm_save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
 		add_action( 'wpml_pb_resave_post_translation', array( $this, 'resave_post_translation_in_shutdown' ), 10, 1 );
 		add_action( 'icl_st_add_string_translation', array( $this, 'new_translation' ), 10, 1 );
 		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'process_pb_content_with_hidden_strings_only' ), 9, 2 );

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -70,7 +70,7 @@ class TestHooks extends  TestCase {
 		$packageWithMissingStringData = $this->getPackage( [] );
 
 		// keys are sorted inside each package
-		$expectedPostContentMd5 = 'string1A' . Hooks::HASH_SEP . 'string1B' . Hooks::HASH_SEP . 'string2A' . Hooks::HASH_SEP . 'string2B-';
+		$expectedPostContentMd5 = 'The string 1A' . Hooks::HASH_SEP . 'The string 1B' . Hooks::HASH_SEP . 'The string 2A' . Hooks::HASH_SEP . 'The string 2B-';
 
 		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
 			->with( [], $post->ID )

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -151,7 +151,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 			$pb_integration,
 			'migrate_location'
 		) );
-		\WP_Mock::expectActionAdded( 'save_post', array(
+		\WP_Mock::expectActionAdded( 'wpml_tm_save_post', array(
 			$pb_integration,
 			'queue_save_post_actions'
 		), PHP_INT_MAX, 2 );


### PR DESCRIPTION
In API page builders, the string name depends on the node id, not the
node content. This is different in other page builders where the name is
a hash of the value.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7373