### PR TITLE
Let the auto-update process use its own save post queue based on `wpml_tm_save_post`

### DIFF
--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -99,9 +99,13 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 	 * to make sure we build the content hash with the new strings.
 	 */
 	public function afterRegisterAllStringsInShutdown() {
-		foreach ( $this->savePostQueue as $post ) {
-			wpml_tm_save_post( $post->ID, $post );
-			$this->resaveTranslations( $post->ID );
+		if ( $this->savePostQueue ) {
+			do_action( 'wpml_cache_clear' );
+
+			foreach ( $this->savePostQueue as $post ) {
+				wpml_tm_save_post( $post->ID, $post );
+				$this->resaveTranslations( $post->ID );
+			}
 		}
 	}
 

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -181,7 +181,7 @@ class WPML_PB_Integration {
 	 */
 	public function add_hooks() {
 		add_action( 'pre_post_update', array( $this, 'migrate_location' ) );
-		add_action( 'wpml_tm_save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
+		add_action( 'save_post', array( $this, 'queue_save_post_actions' ), PHP_INT_MAX, 2 );
 		add_action( 'wpml_pb_resave_post_translation', array( $this, 'resave_post_translation_in_shutdown' ), 10, 1 );
 		add_action( 'icl_st_add_string_translation', array( $this, 'new_translation' ), 10, 1 );
 		add_action( 'wpml_pb_finished_adding_string_translations', array( $this, 'process_pb_content_with_hidden_strings_only' ), 9, 2 );

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -110,6 +110,8 @@ class TestHooks extends  TestCase {
 	public function itDoesNotResaveTranslationsIfNotOriginal() {
 		$post = $this->getPost( 123 );
 
+		\WP_Mock::expectAction( 'wpml_cache_clear' );
+
 		\WP_Mock::userFunction( 'wpml_tm_save_post' )
 			->times( 1 )
 			->with( $post->ID, $post );
@@ -131,6 +133,8 @@ class TestHooks extends  TestCase {
 	 */
 	public function itDoesNotResaveTranslationsIfNoPackage() {
 		$post = $this->getPost( 123 );
+
+		\WP_Mock::expectAction( 'wpml_cache_clear' );
 
 		\WP_Mock::userFunction( 'wpml_tm_save_post' )
 		        ->times( 1 )
@@ -157,6 +161,8 @@ class TestHooks extends  TestCase {
 	 */
 	public function itResavesTranslationsAfterSavePost() {
 		$post1 = $this->getPost( 123 );
+
+		\WP_Mock::expectAction( 'wpml_cache_clear' );
 
 		\WP_Mock::userFunction( 'wpml_tm_save_post' )
 		        ->times( 1 )

--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -151,7 +151,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 			$pb_integration,
 			'migrate_location'
 		) );
-		\WP_Mock::expectActionAdded( 'wpml_tm_save_post', array(
+		\WP_Mock::expectActionAdded( 'save_post', array(
 			$pb_integration,
 			'queue_save_post_actions'
 		), PHP_INT_MAX, 2 );


### PR DESCRIPTION
First I reverted the commit afbad61, it was an optimization and this is the reason of the defect.

The main save post queue in the integration class is built with the `save_post` action which has a very wide scope.

For the auto-update feature we need a queue built with the
`wpml_tm_save_post` action which is more restrictive (excluding
attachments and nav items for instance). Also, it's not always fired
depending on the context and we'll catch only the needed posts.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7412