### PR TITLE
Delegate only the translation statuses update from the original

### DIFF
--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -81,7 +81,7 @@ class WPML_PB_Loader {
 				$hooks,
 				[
 					WPML_PB_Handle_Post_Body::class,
-//					WPML\PB\AutoUpdate\Hooks::class, // see wpmlcore-7428
+					WPML\PB\AutoUpdate\Hooks::class,
 					WPML\PB\Shutdown\Hooks::class,
 				]
 			);

--- a/tests/phpunit/tests/st/test-wpml-pb-loader.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-loader.php
@@ -19,7 +19,7 @@ class Test_WPML_PB_Loader extends WPML_PB_TestCase {
 				$hooks,
 				[
 					WPML_PB_Handle_Post_Body::class,
-//					WPML\PB\AutoUpdate\Hooks::class,
+					WPML\PB\AutoUpdate\Hooks::class,
 					WPML\PB\Shutdown\Hooks::class,
 				]
 			);


### PR DESCRIPTION
Instead of defering the whole `wpml_tm_save_post` function to the
shutdown, we will just take control of the translation status updater (a
callable).

It also simplifies the logic because we don't need to rely on the post
save queue from the integration class.

Also added a commit to re-activate the "translation auto update" feature.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7422