### PR TITLE
Introduce filter hook `wpml_pb_is_auto_update_activated`

### DIFF
--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -35,6 +35,7 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 
 	public function add_hooks() {
 		if ( $this->isTmLoaded() ) {
+			add_filter( 'wpml_pb_auto_update_enabled', '__return_true' );
 			add_filter( 'wpml_tm_delegate_translation_statuses_update', [ $this, 'enqueueTranslationStatusUpdate'], 10, 3 );
 			add_filter( 'wpml_tm_post_md5_content', [ $this, 'getMd5ContentFromPackageStrings' ], 10, 2 );
 			add_action( 'shutdown', [ $this, 'afterRegisterAllStringsInShutdown' ], ShutdownHooks::PRIORITY_REGISTER_STRINGS + 1 );

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -18,6 +18,7 @@ class TestHooks extends  TestCase {
 
 		$subject = $this->getSubject();
 
+		\WP_Mock::expectFilterNotAdded( 'wpml_pb_auto_update_enabled', '__return_true' );
 		\WP_Mock::expectFilterNotAdded( 'wpml_tm_delegate_translation_statuses_update', [ $subject, 'enqueueTranslationStatusUpdate'], 10, 3 );
 		\WP_Mock::expectFilterNotAdded( 'wpml_tm_post_md5_content', [ $subject, 'getMd5ContentFromPackageStrings' ], 10, 2 );
 		\WP_Mock::expectActionNotAdded( 'shutdown', [ $subject, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );
@@ -35,6 +36,7 @@ class TestHooks extends  TestCase {
 
 		$subject = $this->getSubject();
 
+		\WP_Mock::expectFilterAdded( 'wpml_pb_auto_update_enabled', '__return_true' );
 		\WP_Mock::expectFilterAdded( 'wpml_tm_delegate_translation_statuses_update', [ $subject, 'enqueueTranslationStatusUpdate'], 10, 3 );
 		\WP_Mock::expectFilterAdded( 'wpml_tm_post_md5_content', [ $subject, 'getMd5ContentFromPackageStrings' ], 10, 2 );
 		\WP_Mock::expectActionAdded( 'shutdown', [ $subject, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );


### PR DESCRIPTION
**Goes with https://github.com/OnTheGoSystems/wpml-page-builders-elementor/pull/123**

This filter will return `true` when the "translation auto-update"
feature is activated. This helps to keep an "atomic" logic inside the
`WPML\PB\AutoUpdate\Hooks` class and make it easy to deactivate if we
have any kind of trouble.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7544