### PR TITLE
Introduce `WPML\PB\AutoUpdate\Settings` and constant `WPML_TRANSLATION_AUTO_UPDATE_ENABLED`

### DIFF
--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -39,7 +39,7 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 	}
 
 	public function add_hooks() {
-		if ( $this->isTmLoaded() ) {
+		if ( Settings::isEnabled() && $this->isTmLoaded() ) {
 			add_filter( 'wpml_tm_delegate_translation_statuses_update', [ $this, 'enqueueTranslationStatusUpdate'], 10, 3 );
 			add_filter( 'wpml_tm_post_md5_content', [ $this, 'getMd5ContentFromPackageStrings' ], 10, 2 );
 			add_action( 'shutdown', [ $this, 'afterRegisterAllStringsInShutdown' ], ShutdownHooks::PRIORITY_REGISTER_STRINGS + 1 );

--- a/src/AutoUpdate/Settings.php
+++ b/src/AutoUpdate/Settings.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WPML\PB\AutoUpdate;
+
+class Settings {
+
+	/**
+	 * This is part of the "Translation Auto-Update" feature
+	 * The "Translation Auto-Update" feature will be released in the next major version.
+	 * We need a way for users to allow disabling it quickly, if necessary.
+	 *
+	 * @return bool
+	 */
+	public static function isEnabled() {
+		if ( defined( 'WPML_TRANSLATION_AUTO_UPDATE_ENABLED' ) ) {
+			return (bool) constant( 'WPML_TRANSLATION_AUTO_UPDATE_ENABLED' );
+		}
+
+		return true;
+	}
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -46,6 +46,7 @@ FunctionMocker::init(
 		'blacklist' => [],
 		'whitelist' => [],
 		'redefinable-internals' => [
+			'constant',
 			'defined',
 		],
 	]

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -13,7 +13,26 @@ class TestHooks extends  TestCase {
 	/**
 	 * @test
 	 */
+	public function itDoesNotAddHooksIfAutoUpdateNotEnabled() {
+		FunctionMocker::replace( Settings::class . '::isEnabled', false );
+
+		$constant = FunctionMocker::replace( 'defined', true );
+
+		$subject = $this->getSubject();
+
+		\WP_Mock::expectFilterNotAdded( 'wpml_tm_delegate_translation_statuses_update', [ $subject, 'enqueueTranslationStatusUpdate'], 10, 3 );
+		\WP_Mock::expectFilterNotAdded( 'wpml_tm_post_md5_content', [ $subject, 'getMd5ContentFromPackageStrings' ], 10, 2 );
+		\WP_Mock::expectActionNotAdded( 'shutdown', [ $subject, 'afterRegisterAllStringsInShutdown' ], \WPML\PB\Shutdown\Hooks::PRIORITY_REGISTER_STRINGS + 1 );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
 	public function itDoesNotAddHooksIfTmIsNotActive() {
+		FunctionMocker::replace( Settings::class . '::isEnabled', true );
+
 		$constant = FunctionMocker::replace( 'defined', false );
 
 		$subject = $this->getSubject();
@@ -31,6 +50,8 @@ class TestHooks extends  TestCase {
 	 * @test
 	 */
 	public function itAddsHooks() {
+		FunctionMocker::replace( Settings::class . '::isEnabled', true );
+
 		$constant = FunctionMocker::replace( 'defined', true );
 
 		$subject = $this->getSubject();

--- a/tests/phpunit/tests/AutoUpdate/TestSettings.php
+++ b/tests/phpunit/tests/AutoUpdate/TestSettings.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WPML\PB\AutoUpdate;
+
+use OTGS\PHPUnit\Tools\TestCase;
+use tad\FunctionMocker\FunctionMocker;
+
+/**
+ * @group auto-update
+ */
+class TestSettings extends TestCase{
+
+	/**
+	 * @test
+	 */
+	public function itShouldBeEnabledByDefault() {
+		$defined = FunctionMocker::replace( 'defined', false );
+
+		$this->assertTrue( Settings::isEnabled() );
+
+		$defined->wasCalledWithOnce( [ 'WPML_TRANSLATION_AUTO_UPDATE_ENABLED' ] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldBeDisabledByConstant() {
+		$defined  = FunctionMocker::replace( 'defined', true );
+		$constant = FunctionMocker::replace( 'constant', true );
+
+		$this->assertTrue( Settings::isEnabled() );
+
+		$defined->wasCalledWithOnce( [ 'WPML_TRANSLATION_AUTO_UPDATE_ENABLED' ] );
+		$constant->wasCalledWithOnce( [ 'WPML_TRANSLATION_AUTO_UPDATE_ENABLED' ] );
+	}
+}


### PR DESCRIPTION
This helps to keep an "atomic" logic for the whole feature and make it easy to disable if we
have any kind of trouble. We just need to define the constant in the
`wp-config.php` file.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7544