### PR TITLE
Introduce logic to extract and save API PB configuration from the general config file

### DIFF
--- a/src/Config/Hooks.php
+++ b/src/Config/Hooks.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WPML\PB\Config;
+
+use function WPML\FP\tap as tap;
+
+class Hooks implements \IWPML_Action {
+
+	/** @var Parser $parser */
+	private $parser;
+
+	/** @var Storage $storage */
+	private $storage;
+
+	public function __construct(
+		Parser $parser,
+		Storage $storage
+	) {
+		$this->parser  = $parser;
+		$this->storage = $storage;
+	}
+
+	public function add_hooks() {
+		add_filter( 'wpml_config_array', tap( [ $this, 'extractConfig' ] ) );
+	}
+
+	public function extractConfig( array $allConfig ) {
+		$this->storage->update( $this->parser->extract( $allConfig ) );
+	}
+}

--- a/src/Config/Parser.php
+++ b/src/Config/Parser.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace WPML\PB\Config;
+
+use WPML\FP\Fns;
+use WPML\FP\Lst;
+use WPML\FP\Maybe;
+use WPML\FP\Obj;
+
+class Parser {
+
+	/** @var string $configRoot */
+	private $configRoot;
+
+	/** @var string $defaultConditionKey */
+	private $defaultConditionKey;
+
+	public function __construct( $configRoot, $defaultConditionKey ) {
+		$this->configRoot          = $configRoot;
+		$this->defaultConditionKey = $defaultConditionKey;
+	}
+
+	/**
+	 * Receives a raw config array (from XML) and convert it into
+	 * a page builder configuration array.
+	 *
+	 * @see WPML_Elementor_Translatable_Nodes::get_nodes_to_translate()
+	 *
+	 * @param array $allConfig
+	 *
+	 * @return array
+	 */
+	public function extract( array $allConfig ) {
+		$pbConfig   = [];
+		$allWidgets = Obj::pathOr( [], [ 'wpml-config', $this->configRoot, 'widget' ], $allConfig );
+
+		foreach ( $allWidgets as $widget ) {
+			$widgetName = Obj::path( ['attr', 'name'], $widget );
+
+			$pbConfig[ $widgetName ] = [
+				'conditions' => $this->parseConditions( $widget, $widgetName ),
+				'fields'     => $this->parseFields( $widget ),
+			];
+
+			$fieldsInItem = Obj::prop( 'fields-in-item', $widget );
+
+			if ( $fieldsInItem ) {
+				$itemOf                                    = Obj::path( [ 'attr', 'items_of' ], $fieldsInItem );
+				$pbConfig[ $widgetName ]['fields_in_item'] = [ $itemOf => $this->parseFieldsInItem( $fieldsInItem ) ];
+			}
+
+			$integrationClasses = $this->parseIntegrationClasses( $widget );
+
+			if ( $integrationClasses ) {
+				$pbConfig[ $widgetName ]['integration-class'] = $integrationClasses;
+			}
+		}
+
+		return $pbConfig;
+	}
+
+	/**
+	 * @param array  $widget
+	 * @param string $widgetName
+	 *
+	 * @return array
+	 */
+	private function parseConditions( array $widget, $widgetName ) {
+		$makePair = function( $condition ) {
+			return [ Obj::pathOr( $this->defaultConditionKey, ['attr', 'key'], $condition ), $condition['value'] ];
+		};
+
+		return Maybe::fromNullable( Obj::path( ['conditions', 'condition'], $widget ) )
+			->map( [ $this, 'normalize' ] )
+			->map( Fns::map( $makePair ) )
+			->map( Lst::fromPairs() )
+			->getOrElse( [ $this->defaultConditionKey => $widgetName ] );
+	}
+
+	/**
+	 * @param array $widget
+	 *
+	 * @return array
+	 */
+	private function parseFields( array $widget ) {
+		$rawFields    = Obj::pathOr( [], ['fields', 'field'], $widget );
+		$parsedFields = [];
+
+		foreach ( $this->normalize( $rawFields ) as $field ) {
+			$key     = Obj::path( [ 'attr', 'key_of' ], $field );
+			$fieldId = Obj::path( [ 'attr', 'field_id' ], $field );
+
+			$parsedField = [
+				'field'       => $field['value'],
+				'type'        => Obj::pathOr( $field['value'], [ 'attr', 'type' ], $field ),
+				'editor_type' => Obj::pathOr( 'LINE', [ 'attr', 'editor_type' ], $field ),
+			];
+
+			if ( $fieldId ) {
+				$parsedField['field_id'] = $fieldId;
+			}
+
+			if ( $key ) {
+				$parsedFields[ $key ] = $parsedField;
+			} else {
+				$parsedFields[] = $parsedField;
+			}
+		}
+
+		return $parsedFields;
+	}
+
+	/**
+	 * @param array $fieldsInItem
+	 *
+	 * @return array
+	 */
+	private function parseFieldsInItem( array $fieldsInItem ) {
+		$rawFieldsInItem    = Obj::propOr( [], 'field', $fieldsInItem );
+		$parsedFieldsInItem = [];
+
+		foreach ( $this->normalize( $rawFieldsInItem ) as $field ) {
+			$parsedField = [
+				'field'       => $field['value'],
+				'type'        => Obj::pathOr( $field['value'], [ 'attr', 'type' ], $field ),
+				'editor_type' => Obj::pathOr( 'LINE', [ 'attr', 'editor_type' ], $field ),
+			];
+
+			$parsedFieldsInItem[] = $parsedField;
+		}
+
+		return $parsedFieldsInItem;
+	}
+
+	/**
+	 * @param array $widget
+	 *
+	 * @return array
+	 */
+	private function parseIntegrationClasses( array $widget ) {
+		return Maybe::fromNullable( Obj::path( [ 'integration-classes', 'integration-class' ], $widget ) )
+			->map( [ $this, 'normalize' ] )
+			->map( Lst::pluck( 'value' ) )
+			->getOrElse( [] );
+	}
+
+	/**
+	 * If a sequence has only one element, we will wrap it
+	 * in order to have the same data shape as for multiple elements.
+	 *
+	 * @param array $partialConfig
+	 *
+	 * @return array
+	 */
+	public function normalize( array $partialConfig ) {
+		return isset( $partialConfig['value'] ) ? [ $partialConfig ] : $partialConfig;
+	}
+}

--- a/src/Config/Storage.php
+++ b/src/Config/Storage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WPML\PB\Config;
+
+use WPML\WP\OptionManager;
+
+class Storage {
+
+	const OPTION_GROUP = 'api-pb-config';
+
+	/** @var OptionManager $optionManager */
+	private $optionManager;
+
+	/** @var string $pbKey */
+	private $pbKey;
+
+	public function __construct(
+		OptionManager $optionManager,
+		$pbKey
+	) {
+		$this->optionManager = $optionManager;
+		$this->pbKey         = $pbKey;
+	}
+
+	public function get() {
+		return $this->optionManager->get( self::OPTION_GROUP, $this->pbKey, [] );
+	}
+
+	public function update( array $pbConfig ) {
+		$this->optionManager->set( self::OPTION_GROUP, $this->pbKey, $pbConfig, false );
+	}
+}

--- a/tests/phpunit/tests/Config/TestHooks.php
+++ b/tests/phpunit/tests/Config/TestHooks.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace WPML\PB\Config;
+
+use OTGS\PHPUnit\Tools\TestCase;
+use function WPML\FP\tap as tap;
+
+/**
+ * @group config
+ */
+class TestHooks extends TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = $this->getSubject();
+
+		\WP_Mock::expectFilterAdded( 'wpml_config_array', tap( [ $subject, 'extractConfig' ] ) );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldExtractConfig() {
+		$allConfig = [ 'all the config' ];
+		$pbConfig  = [ 'the PB config' ];
+
+		$parser = $this->getParser();
+		$parser->method( 'extract' )
+			->with( $allConfig )
+			->willReturn( $pbConfig );
+
+		$storage = $this->getStorage();
+		$storage->expects( $this->once() )
+			->method( 'update' )
+			->with( $pbConfig );
+
+		$subject = $this->getSubject( $parser, $storage );
+		$subject->extractConfig( $allConfig );
+	}
+
+	private function getSubject( $parser = null, $storage = null ) {
+		$parser  = $parser ?: $this->getParser();
+		$storage = $storage ?: $this->getStorage();
+
+		return new Hooks( $parser, $storage );
+	}
+
+	private function getParser() {
+		return $this->getMockBuilder( Parser::class )
+			->setMethods( [ 'extract' ] )
+			->disableOriginalConstructor()->getMock();
+	}
+
+	private function getStorage() {
+		return $this->getMockBuilder( Storage::class )
+			->setMethods( [ 'get', 'update' ] )
+			->disableOriginalConstructor()->getMock();
+
+	}
+}

--- a/tests/phpunit/tests/Config/TestParser.php
+++ b/tests/phpunit/tests/Config/TestParser.php
@@ -1,0 +1,367 @@
+<?php
+
+namespace WPML\PB\Config;
+
+use OTGS\PHPUnit\Tools\TestCase;
+
+/**
+ * @group config
+ */
+class TestParser extends TestCase {
+
+	const CONFIG_ROOT           = 'super-pb-widgets';
+	const DEFAULT_CONDITION_KEY = 'WidgetKind';
+
+	/**
+	 * @test
+	 * @dataProvider dpShouldExtract
+	 *
+	 * @param array $allConfig
+	 * @param array $expectedPbConfig
+	 */
+	public function itShouldExtract( array $allConfig, array $expectedPbConfig ) {
+		$this->assertEquals( $expectedPbConfig, $this->getSubject()->extract( $allConfig ) );
+	}
+
+	public function dpShouldExtract() {
+		return [
+			'no PB config' => [
+				$this->getAllConfig(),
+				[],
+			],
+			'empty PB config' => [
+				$this->getAllConfig( [] ),
+				[],
+			],
+			'No specified widget condition' => [
+				$this->getAllConfig( [
+					[
+						'attr'   => [
+							'name' => 'some-widget',
+						],
+						'fields' => [
+							'field' => [
+								'value' => 'title',
+								'attr'  => [
+									'type'        => 'The Widget Title',
+									'editor_type' => 'TEXTAREA',
+								],
+							],
+						],
+					],
+				] ),
+				[
+					'some-widget' => [
+						'conditions' => [
+							self::DEFAULT_CONDITION_KEY => 'some-widget',
+						],
+						'fields' => [
+							[
+								'field'       => 'title',
+								'type'        => 'The Widget Title',
+								'editor_type' => 'TEXTAREA',
+							],
+						],
+					],
+				],
+			],
+			'1 specified widget condition' => [
+				$this->getAllConfig( [
+					[
+						'attr'   => [
+							'name' => 'some-widget',
+						],
+						'conditions' => [
+							'condition' => [
+								'value' => 'the-condition-value',
+								'attr'  => [
+									'key' => 'the-condition-key',
+								],
+							],
+						],
+						'fields' => [
+							'field' => [
+								'value' => 'title',
+								'attr'  => [
+									'type'        => 'The Widget Title',
+									'editor_type' => 'TEXTAREA',
+								],
+							],
+						],
+					],
+				] ),
+				[
+					'some-widget' => [
+						'conditions' => [
+							'the-condition-key' => 'the-condition-value',
+						],
+						'fields' => [
+							[
+								'field'       => 'title',
+								'type'        => 'The Widget Title',
+								'editor_type' => 'TEXTAREA',
+							],
+						],
+					],
+				],
+			],
+			'with field having "key_of"' => [
+				$this->getAllConfig( [
+					[
+						'attr'   => [
+							'name' => 'some-widget',
+						],
+						'fields' => [
+							'field' => [
+								'value' => 'title',
+								'attr'  => [
+									'type'        => 'The Widget Title',
+									'editor_type' => 'TEXTAREA',
+									'key_of'      => 'the-key-of-the-field',
+								],
+							],
+						],
+					],
+				] ),
+				[
+					'some-widget' => [
+						'conditions' => [
+							self::DEFAULT_CONDITION_KEY => 'some-widget',
+						],
+						'fields' => [
+							'the-key-of-the-field' => [
+								'field'       => 'title',
+								'type'        => 'The Widget Title',
+								'editor_type' => 'TEXTAREA',
+							],
+						],
+					],
+				],
+			],
+			'with field having "field_id"' => [
+				$this->getAllConfig( [
+					[
+						'attr'   => [
+							'name' => 'some-widget',
+						],
+						'fields' => [
+							'field' => [
+								'value' => 'title',
+								'attr'  => [
+									'type'        => 'The Widget Title',
+									'editor_type' => 'TEXTAREA',
+									'field_id'    => 'the-id-of-the-field',
+								],
+							],
+						],
+					],
+				] ),
+				[
+					'some-widget' => [
+						'conditions' => [
+							self::DEFAULT_CONDITION_KEY => 'some-widget',
+						],
+						'fields' => [
+							[
+								'field'       => 'title',
+								'type'        => 'The Widget Title',
+								'editor_type' => 'TEXTAREA',
+								'field_id'    => 'the-id-of-the-field',
+							],
+						],
+					],
+				],
+			],
+			'with "fields in item"' => [
+				$this->getAllConfig( [
+					[
+						'attr'   => [
+							'name' => 'some-widget',
+						],
+						'fields-in-item' => [
+							'attr' => [
+								'items_of' => 'the-key-of-item',
+							],
+							'field' => [
+								'value' => 'title',
+								'attr'  => [
+									'type'        => 'The Widget Title',
+									'editor_type' => 'TEXTAREA',
+								],
+							],
+						],
+					],
+				] ),
+				[
+					'some-widget' => [
+						'conditions' => [
+							self::DEFAULT_CONDITION_KEY => 'some-widget',
+						],
+						'fields' => [],
+						'fields_in_item' => [
+							'the-key-of-item' => [
+								[
+									'field'       => 'title',
+									'type'        => 'The Widget Title',
+									'editor_type' => 'TEXTAREA',
+								]
+							],
+						],
+					],
+				],
+			],
+			'with "integration-classes"' => [
+				$this->getAllConfig( [
+					[
+						'attr'   => [
+							'name' => 'some-widget',
+						],
+						'integration-classes' => [
+							'integration-class' => [
+								'value' => 'TheIntegrationClass',
+							],
+						],
+					],
+				] ),
+				[
+					'some-widget' => [
+						'conditions' => [
+							self::DEFAULT_CONDITION_KEY => 'some-widget',
+						],
+						'fields' => [],
+						'integration-class' => [
+							'TheIntegrationClass'
+						],
+					],
+				],
+			],
+			'with all in more than occurrences' => [
+				$this->getAllConfig( [
+					[
+						'attr'   => [
+							'name' => 'some-widget',
+						],
+						'conditions' => [
+							'condition' => [
+								[
+									'value' => 'the-condition-value',
+									'attr'  => [
+										'key' => 'the-condition-key',
+									],
+								],
+								[
+									'value' => 'the-condition-value2',
+									'attr'  => [
+										'key' => 'the-condition-key2',
+									],
+								],
+							],
+						],
+						'fields' => [
+							'field' => [
+								[
+									'value' => 'title',
+									'attr'  => [
+										'type'        => 'The Widget Title',
+										'editor_type' => 'TEXTAREA',
+									],
+								],
+								[
+									'value' => 'sub-title',
+									'attr'  => [
+										'type'        => 'The Widget Sub-Title',
+										'editor_type' => 'TEXTAREA',
+									],
+								],
+							],
+						],
+						'fields-in-item' => [
+							'attr' => [
+								'items_of' => 'the-key-of-item',
+							],
+							'field' => [
+								[
+									'value' => 'title',
+									'attr'  => [
+										'type'        => 'The Item Title',
+										'editor_type' => 'TEXTAREA',
+									],
+								],
+								[
+									'value' => 'sub-title',
+									'attr'  => [
+										'type'        => 'The Item Sub-Title',
+										'editor_type' => 'TEXTAREA',
+									],
+								],
+							],
+						],
+						'integration-classes' => [
+							'integration-class' => [
+								[ 'value' => 'TheIntegrationClass' ],
+								[ 'value' => 'TheIntegrationClass2' ],
+							],
+						],
+					],
+				] ),
+				[
+					'some-widget' => [
+						'conditions' => [
+							'the-condition-key'  => 'the-condition-value',
+							'the-condition-key2' => 'the-condition-value2',
+						],
+						'fields' => [
+							[
+								'field'       => 'title',
+								'type'        => 'The Widget Title',
+								'editor_type' => 'TEXTAREA',
+							],
+							[
+								'field'       => 'sub-title',
+								'type'        => 'The Widget Sub-Title',
+								'editor_type' => 'TEXTAREA',
+							],
+						],
+						'fields_in_item' => [
+							'the-key-of-item' => [
+								[
+									'field'       => 'title',
+									'type'        => 'The Item Title',
+									'editor_type' => 'TEXTAREA',
+								],
+								[
+									'field'       => 'sub-title',
+									'type'        => 'The Item Sub-Title',
+									'editor_type' => 'TEXTAREA',
+								],
+							],
+						],
+						'integration-class' => [
+							'TheIntegrationClass',
+							'TheIntegrationClass2',
+						],
+					],
+				],
+			],
+		];
+	}
+
+	private function getSubject() {
+		return new Parser( self::CONFIG_ROOT, self::DEFAULT_CONDITION_KEY );
+	}
+
+	private function getAllConfig( array $widgetsConfig = null ) {
+		$allConfig = [
+			'wpml-config' => [
+				'custom-types' => [],
+				'taxonomies'   => [],
+			],
+		];
+
+		if ( is_array( $widgetsConfig ) ) {
+			$allConfig['wpml-config'][ self::CONFIG_ROOT ]['widget'] = $widgetsConfig;
+		}
+
+		return $allConfig;
+	}
+}

--- a/tests/phpunit/tests/Config/TestStorage.php
+++ b/tests/phpunit/tests/Config/TestStorage.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace WPML\PB\Config;
+
+use OTGS\PHPUnit\Tools\TestCase;
+use WPML\WP\OptionManager;
+
+/**
+ * @group config
+ */
+class TestStorage extends TestCase {
+
+	const PB_KEY = 'the-pb-key';
+
+	/**
+	 * @test
+	 */
+	public function itShouldGet() {
+		$pbConfig = [ 'some PB config' ];
+
+		$optionManager = $this->getOptionManager();
+		$optionManager->method( 'get' )
+			->with( Storage::OPTION_GROUP, self::PB_KEY, [] )
+			->willReturn( $pbConfig );
+
+		$subject = $this->getSubject( $optionManager );
+
+		$this->assertEquals( $pbConfig, $subject->get() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldUpdate() {
+		$pbConfig = [ 'some PB config' ];
+
+		$optionManager = $this->getOptionManager();
+		$optionManager->expects( $this->once() )
+			->method( 'set' )
+			->with( Storage::OPTION_GROUP, self::PB_KEY, $pbConfig, false );
+
+		$subject = $this->getSubject( $optionManager );
+
+		$subject->update( $pbConfig );
+	}
+
+	private function getSubject( $optionManager ) {
+		return new Storage( $optionManager, self::PB_KEY );
+	}
+
+	private function getOptionManager() {
+		return $this->getMockBuilder( OptionManager::class )
+			->setMethods( [ 'get', 'set' ] )
+			->disableOriginalConstructor()->getMock();
+	}
+}


### PR DESCRIPTION
The `Hooks` claas will be implemented later in the API PB packages with a shared factory.

Please check the [reference for new allow items in the config file](https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7560).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7561