### PR TITLE
Simplify/unify parsing of field in fields or fields-in-item

### DIFF
--- a/src/Config/Parser.php
+++ b/src/Config/Parser.php
@@ -39,14 +39,14 @@ class Parser {
 
 			$pbConfig[ $widgetName ] = [
 				'conditions' => $this->parseConditions( $widget, $widgetName ),
-				'fields'     => $this->parseFields( $widget ),
+				'fields'     => $this->parseFields(  Obj::pathOr( [], ['fields', 'field'], $widget ) ),
 			];
 
 			$fieldsInItem = Obj::prop( 'fields-in-item', $widget );
 
 			if ( $fieldsInItem ) {
 				$itemOf                                    = Obj::path( [ 'attr', 'items_of' ], $fieldsInItem );
-				$pbConfig[ $widgetName ]['fields_in_item'] = [ $itemOf => $this->parseFieldsInItem( $fieldsInItem ) ];
+				$pbConfig[ $widgetName ]['fields_in_item'] = [ $itemOf => $this->parseFields( Obj::propOr( [], 'field', $fieldsInItem ) ) ];
 			}
 
 			$integrationClasses = $this->parseIntegrationClasses( $widget );
@@ -78,12 +78,11 @@ class Parser {
 	}
 
 	/**
-	 * @param array $widget
+	 * @param array $rawFields
 	 *
 	 * @return array
 	 */
-	private function parseFields( array $widget ) {
-		$rawFields    = Obj::pathOr( [], ['fields', 'field'], $widget );
+	private function parseFields( array $rawFields ) {
 		$parsedFields = [];
 
 		foreach ( $this->normalize( $rawFields ) as $field ) {
@@ -108,28 +107,6 @@ class Parser {
 		}
 
 		return $parsedFields;
-	}
-
-	/**
-	 * @param array $fieldsInItem
-	 *
-	 * @return array
-	 */
-	private function parseFieldsInItem( array $fieldsInItem ) {
-		$rawFieldsInItem    = Obj::propOr( [], 'field', $fieldsInItem );
-		$parsedFieldsInItem = [];
-
-		foreach ( $this->normalize( $rawFieldsInItem ) as $field ) {
-			$parsedField = [
-				'field'       => $field['value'],
-				'type'        => Obj::pathOr( $field['value'], [ 'attr', 'type' ], $field ),
-				'editor_type' => Obj::pathOr( 'LINE', [ 'attr', 'editor_type' ], $field ),
-			];
-
-			$parsedFieldsInItem[] = $parsedField;
-		}
-
-		return $parsedFieldsInItem;
 	}
 
 	/**

--- a/tests/phpunit/tests/Config/TestParser.php
+++ b/tests/phpunit/tests/Config/TestParser.php
@@ -294,6 +294,14 @@ class TestParser extends TestCase {
 										'editor_type' => 'TEXTAREA',
 									],
 								],
+								[
+									'value' => 'url',
+									'attr'  => [
+										'type'        => 'The Item URL',
+										'editor_type' => 'LINK',
+										'key_of'      => 'the-key-of-item-url',
+									],
+								],
 							],
 						],
 						'integration-classes' => [
@@ -333,6 +341,11 @@ class TestParser extends TestCase {
 									'field'       => 'sub-title',
 									'type'        => 'The Item Sub-Title',
 									'editor_type' => 'TEXTAREA',
+								],
+								'the-key-of-item-url' => [
+									'field'       => 'url',
+									'type'        => 'The Item URL',
+									'editor_type' => 'LINK',
 								],
 							],
 						],


### PR DESCRIPTION
The way we handle the `key_of` attribute in `fields` field is not
optimal because we use it a non-numeric key. But it's also used in
several places in our code (and derived PB packages) so I decided to
continue with the same pattern for `fields-in-item`. At least we will be
consistent and we'll have only one way to parse a field.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7565