### PR TITLE
Allow multiple occurrences of `fields-in-item` in XML config

### DIFF
--- a/src/Config/Hooks.php
+++ b/src/Config/Hooks.php
@@ -6,6 +6,8 @@ use function WPML\FP\tap as tap;
 
 class Hooks implements \IWPML_Action {
 
+	const PRIORITY_AFTER_DEFAULT = 20;
+
 	/** @var Parser $parser */
 	private $parser;
 
@@ -27,7 +29,7 @@ class Hooks implements \IWPML_Action {
 
 	public function add_hooks() {
 		add_filter( 'wpml_config_array', tap( [ $this, 'extractConfig' ] ) );
-		add_filter( $this->translatableWidgetsHook , [ $this, 'extendTranslatableWidgets' ] );
+		add_filter( $this->translatableWidgetsHook , [ $this, 'extendTranslatableWidgets' ], self::PRIORITY_AFTER_DEFAULT );
 	}
 
 	public function extractConfig( array $allConfig ) {

--- a/src/Config/Parser.php
+++ b/src/Config/Parser.php
@@ -42,11 +42,16 @@ class Parser {
 				'fields'     => $this->parseFields(  Obj::pathOr( [], ['fields', 'field'], $widget ) ),
 			];
 
-			$fieldsInItem = Obj::prop( 'fields-in-item', $widget );
+			$fieldsInItems = Obj::prop( 'fields-in-item', $widget );
 
-			if ( $fieldsInItem ) {
-				$itemOf                                    = Obj::path( [ 'attr', 'items_of' ], $fieldsInItem );
-				$pbConfig[ $widgetName ]['fields_in_item'] = [ $itemOf => $this->parseFields( Obj::propOr( [], 'field', $fieldsInItem ) ) ];
+			if ( $fieldsInItems ) {
+				$pbConfig[ $widgetName ]['fields_in_item'] = [];
+				$fieldsInItems                             = $this->normalize( $fieldsInItems );
+
+				foreach ( $fieldsInItems as $fieldsInItem ) {
+					$itemOf                                               = Obj::path( [ 'attr', 'items_of' ], $fieldsInItem );
+					$pbConfig[ $widgetName ]['fields_in_item'][ $itemOf ] = $this->parseFields( Obj::propOr( [], 'field', $fieldsInItem ) );
+				}
 			}
 
 			$integrationClasses = $this->parseIntegrationClasses( $widget );
@@ -130,6 +135,10 @@ class Parser {
 	 * @return array
 	 */
 	public function normalize( array $partialConfig ) {
-		return isset( $partialConfig['value'] ) ? [ $partialConfig ] : $partialConfig;
+		$isAssocArray = function( array $array ) {
+			return count( array_filter( array_keys( $array ), 'is_string' ) ) > 0;
+		};
+
+		return $isAssocArray( $partialConfig ) ? [ $partialConfig ] : $partialConfig;
 	}
 }

--- a/src/Config/Parser.php
+++ b/src/Config/Parser.php
@@ -135,10 +135,8 @@ class Parser {
 	 * @return array
 	 */
 	public function normalize( array $partialConfig ) {
-		$isAssocArray = function( array $array ) {
-			return count( array_filter( array_keys( $array ), 'is_string' ) ) > 0;
-		};
+		$isAssocArray = count( array_filter( array_keys( $partialConfig ), 'is_string' ) ) > 0;
 
-		return $isAssocArray( $partialConfig ) ? [ $partialConfig ] : $partialConfig;
+		return $isAssocArray ? [ $partialConfig ] : $partialConfig;
 	}
 }

--- a/tests/phpunit/tests/Config/TestHooks.php
+++ b/tests/phpunit/tests/Config/TestHooks.php
@@ -20,7 +20,7 @@ class TestHooks extends TestCase {
 		$subject = $this->getSubject();
 
 		\WP_Mock::expectFilterAdded( 'wpml_config_array', tap( [ $subject, 'extractConfig' ] ) );
-		\WP_Mock::expectFilterAdded( self::TRANSLATABLE_WIDGETS_HOOK, [ $subject, 'extendTranslatableWidgets' ] );
+		\WP_Mock::expectFilterAdded( self::TRANSLATABLE_WIDGETS_HOOK, [ $subject, 'extendTranslatableWidgets' ], Hooks::PRIORITY_AFTER_DEFAULT );
 
 		$subject->add_hooks();
 	}

--- a/tests/phpunit/tests/Config/TestParser.php
+++ b/tests/phpunit/tests/Config/TestParser.php
@@ -210,6 +210,66 @@ class TestParser extends TestCase {
 					],
 				],
 			],
+			// https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7337
+			'with multiple occurrences of "fields in item"' => [
+				$this->getAllConfig( [
+					[
+						'attr'   => [
+							'name' => 'some-widget',
+						],
+						'fields-in-item' => [
+							[
+								'attr' => [
+									'items_of' => 'the-first-key-of-item',
+								],
+								'field' => [
+									'value' => 'first',
+									'attr'  => [
+										'type'        => 'The first key field',
+										'editor_type' => 'TEXTAREA',
+									],
+								],
+							],
+							[
+								'attr' => [
+									'items_of' => 'the-second-key-of-item',
+								],
+								'field' => [
+									'value' => 'second',
+									'attr'  => [
+										'type'        => 'The second key field',
+										'editor_type' => 'LINE',
+									],
+								],
+							],
+						],
+					],
+				] ),
+				[
+					'some-widget' => [
+						'conditions' => [
+							self::DEFAULT_CONDITION_KEY => 'some-widget',
+						],
+						'fields' => [],
+						'fields_in_item' => [
+							'the-first-key-of-item' => [
+								[
+									'field'       => 'first',
+									'type'        => 'The first key field',
+									'editor_type' => 'TEXTAREA',
+								],
+							],
+							'the-second-key-of-item' => [
+								[
+									'field'       => 'second',
+									'type'        => 'The second key field',
+									'editor_type' => 'LINE',
+								],
+							],
+						],
+					],
+				],
+			],
 			'with "integration-classes"' => [
 				$this->getAllConfig( [
 					[


### PR DESCRIPTION
This is a new data shape used in Ultimate Addons for Elementor and it was not supported yet.

![multiple-fields-in-items](https://user-images.githubusercontent.com/1941656/96633672-cfef9200-12ef-11eb-9a57-672985f953b3.png)

It will be now possible to support it with the XML config.

I also added a second commit to lower the priority of the XML config so it can overwrite the PHP config.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7337