### PR TITLE
Transform class `WPML_PB_Last_Translation_Edit_Mode` to use only static methods

### DIFF
--- a/src/st/class-wpml-pb-last-translation-edit-mode.php
+++ b/src/st/class-wpml-pb-last-translation-edit-mode.php
@@ -11,8 +11,8 @@ class WPML_PB_Last_Translation_Edit_Mode {
 	 *
 	 * @return bool
 	 */
-	public function is_native_editor( $post_id ) {
-		return $this->get_last_mode( $post_id ) === self::NATIVE_EDITOR;
+	public static function is_native_editor( $post_id ) {
+		return self::get_last_mode( $post_id ) === self::NATIVE_EDITOR;
 	}
 
 	/**
@@ -20,8 +20,8 @@ class WPML_PB_Last_Translation_Edit_Mode {
 	 *
 	 * @return bool
 	 */
-	public function is_translation_editor( $post_id ) {
-		return $this->get_last_mode( $post_id ) === self::TRANSLATION_EDITOR;
+	public static function is_translation_editor( $post_id ) {
+		return self::get_last_mode( $post_id ) === self::TRANSLATION_EDITOR;
 	}
 
 	/**
@@ -29,29 +29,29 @@ class WPML_PB_Last_Translation_Edit_Mode {
 	 *
 	 * @return mixed
 	 */
-	private function get_last_mode( $post_id ) {
+	private static function get_last_mode( $post_id ) {
 		return get_post_meta( $post_id, self::POST_META_KEY, true );
 	}
 
 	/**
 	 * @param int $post_id
 	 */
-	public function set_native_editor( $post_id ) {
-		$this->set_mode( $post_id, self::NATIVE_EDITOR );
+	public static function set_native_editor( $post_id ) {
+		self::set_mode( $post_id, self::NATIVE_EDITOR );
 	}
 
 	/**
 	 * @param int $post_id
 	 */
-	public function set_translation_editor( $post_id ) {
-		$this->set_mode( $post_id, self::TRANSLATION_EDITOR );
+	public static function set_translation_editor( $post_id ) {
+		self::set_mode( $post_id, self::TRANSLATION_EDITOR );
 	}
 
 	/**
 	 * @param int    $post_id
 	 * @param string $mode
 	 */
-	private function set_mode( $post_id, $mode ) {
+	private static function set_mode( $post_id, $mode ) {
 		update_post_meta( $post_id, self::POST_META_KEY, $mode );
 	}
 }

--- a/tests/phpunit/tests/st/test-wpml-pb-last-edit-mode.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-last-edit-mode.php
@@ -20,6 +20,9 @@ class Test_WPML_PB_Last_Edit_Mode extends \OTGS\PHPUnit\Tools\TestCase {
 
 		$this->assertTrue( $subject->is_native_editor( $post_id ) );
 		$this->assertFalse( $subject->is_translation_editor( $post_id ) );
+
+		$this->assertTrue( WPML_PB_Last_Translation_Edit_Mode::is_native_editor( $post_id ) );
+		$this->assertFalse( WPML_PB_Last_Translation_Edit_Mode::is_translation_editor( $post_id ) );
 	}
 
 	/**
@@ -37,6 +40,9 @@ class Test_WPML_PB_Last_Edit_Mode extends \OTGS\PHPUnit\Tools\TestCase {
 
 		$this->assertFalse( $subject->is_native_editor( $post_id ) );
 		$this->assertTrue( $subject->is_translation_editor( $post_id ) );
+
+		$this->assertFalse( WPML_PB_Last_Translation_Edit_Mode::is_native_editor( $post_id ) );
+		$this->assertTrue( WPML_PB_Last_Translation_Edit_Mode::is_translation_editor( $post_id ) );
 	}
 
 	/**
@@ -62,6 +68,24 @@ class Test_WPML_PB_Last_Edit_Mode extends \OTGS\PHPUnit\Tools\TestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_set_native_editor_as_static() {
+		$post_id = 123;
+
+		\WP_Mock::userFunction( 'update_post_meta', array(
+			'times' => 1,
+			'args'  => array(
+				$post_id,
+				WPML_PB_Last_Translation_Edit_Mode::POST_META_KEY,
+				WPML_PB_Last_Translation_Edit_Mode::NATIVE_EDITOR,
+			),
+		));
+
+		WPML_PB_Last_Translation_Edit_Mode::set_native_editor( $post_id );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_should_set_translation_editor() {
 		$post_id = 123;
 
@@ -77,6 +101,24 @@ class Test_WPML_PB_Last_Edit_Mode extends \OTGS\PHPUnit\Tools\TestCase {
 		$subject = $this->get_subject();
 
 		$subject->set_translation_editor( $post_id );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_set_translation_editor_as_static() {
+		$post_id = 123;
+
+		\WP_Mock::userFunction( 'update_post_meta', array(
+			'times' => 1,
+			'args'  => array(
+				$post_id,
+				WPML_PB_Last_Translation_Edit_Mode::POST_META_KEY,
+				WPML_PB_Last_Translation_Edit_Mode::TRANSLATION_EDITOR,
+			),
+		));
+
+		WPML_PB_Last_Translation_Edit_Mode::set_translation_editor( $post_id );
 	}
 
 	private function get_subject() {


### PR DESCRIPTION
**Goes with https://git.onthegosystems.com/wpml/sitepress-multilingual-cms/-/merge_requests/3021**

This class has no state and it was passed too early to
`WPML\Compatibility\WPBakery\Styles` as a dependency. Now it will just
be used as a static call there.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7852

Note: This class is already covered in `Test_WPML_PB_Last_Edit_Mode`.