### PR TITLE
Introduce logic to cleanup GB meta data in post content when it's built with a shortcode page builder

### DIFF
--- a/src/GutenbergCleanup/Package.php
+++ b/src/GutenbergCleanup/Package.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WPML\PB\GutenbergCleanup;
+
+use WPML\FP\Relation;
+
+class Package {
+
+	/**
+	 * @param int $postId
+	 *
+	 * @return \WPML_Package|null
+	 */
+	public static function get( $postId ) {
+		// $isGbPackage :: \WPML_Package -> bool
+		$isGbPackage = Relation::propEq( 'kind_slug', 'gutenberg' );
+
+		return wpml_collect( apply_filters( 'wpml_st_get_post_string_packages', [], $postId ) )
+			->filter( $isGbPackage )
+			->first();
+	}
+
+	/**
+	 * @param \WPML_Package|null $package
+	 */
+	public static function delete( $package ) {
+		$package && do_action( 'wpml_delete_package', $package->name, $package->kind );
+	}
+}

--- a/src/GutenbergCleanup/ShortcodeHooks.php
+++ b/src/GutenbergCleanup/ShortcodeHooks.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WPML\PB\GutenbergCleanup;
+
+use WPML\FP\Fns;
+use WPML\FP\Maybe;
+use WPML\FP\Obj;
+use WPML\LIB\WP\Gutenberg;
+use function WPML\FP\pipe;
+use function WPML\FP\tap as tap;
+
+class ShortcodeHooks implements \IWPML_Backend_Action {
+
+	public function add_hooks() {
+		add_action(
+			'wp_insert_post',
+			Fns::withoutRecursion( Fns::noop(), [ $this, 'removeGutenbergFootprint' ] ),
+			10, 2
+		);
+	}
+
+	/**
+	 * @param int      $post_ID
+	 * @param \WP_Post $post
+	 */
+	public function removeGutenbergFootprint( $post_ID, \WP_Post $post ) {
+		// $isBuiltWithShortcodes :: \WP_Post -> bool
+		$isBuiltWithShortcodes = function( \WP_Post $post ) {
+			/**
+			 * @since WPML 4.4.9
+			 *
+			 * @param bool     false
+			 * @param \WP_Post $post
+			 */
+			return apply_filters( 'wpml_pb_is_post_built_with_shortcodes', false, $post );
+		};
+
+		// $hasGutenbergMetaData :: \WP_Post -> bool
+		$hasGutenbergMetaData = pipe(
+			Obj::prop( 'post_content' ),
+			Gutenberg::hasBlock()
+		);
+
+		// $removeHtmlComments :: \WP_Post -> \WP_Post
+		$removeHtmlComments = tap( pipe(
+			Obj::over( Obj::lensProp( 'post_content' ), Gutenberg::stripBlockData() ),
+			'wp_update_post'
+		) );
+
+		// $deleteGutenbergPackage :: \WP_Post -> void
+		$deleteGutenbergPackage = pipe(
+			Obj::prop( 'ID' ),
+			[ Package::class, 'get' ],
+			[ Package::class, 'delete' ]
+		);
+
+		Maybe::of( $post )
+			->filter( $isBuiltWithShortcodes )
+			->filter( $hasGutenbergMetaData )
+			->map( $removeHtmlComments )
+			->map( $deleteGutenbergPackage );
+	}
+}

--- a/src/st/class-wpml-pb-loader.php
+++ b/src/st/class-wpml-pb-loader.php
@@ -83,6 +83,7 @@ class WPML_PB_Loader {
 					WPML_PB_Handle_Post_Body::class,
 //					WPML\PB\AutoUpdate\Hooks::class, // see wpmlcore-7428
 					WPML\PB\Shutdown\Hooks::class,
+					WPML\PB\GutenbergCleanup\ShortcodeHooks::class,
 				]
 			);
 		}

--- a/tests/phpunit/tests/GutenbergCleanup/TestShortcodeHooks.php
+++ b/tests/phpunit/tests/GutenbergCleanup/TestShortcodeHooks.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace WPML\PB\GutenbergCleanup;
+
+use OTGS\PHPUnit\Tools\TestCase;
+use WPML\FP\Fns;
+
+/**
+ * @group gutenberg-cleanup
+ */
+class TestShortcodeHooks extends TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = new ShortcodeHooks();
+
+		\WP_Mock::expectActionAdded(
+			'wp_insert_post',
+			Fns::withoutRecursion( Fns::noop(), [ $subject, 'removeGutenbergFootprint' ] ),
+			10, 2
+		);
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldNotRemoveGutenbergFootprintIfNotBuiltWithShortcodes() {
+		$post = $this->getPost( '<!-- wp:paragraph -->Something<!-- /wp:paragraph -->' );
+
+		\WP_Mock::onFilter( 'wpml_pb_is_post_built_with_shortcodes' )
+			->with( false, $post )
+			->reply( false );
+
+		\WP_Mock::userFunction( 'wp_update_post' )->times( 0 );
+
+		$subject = new ShortcodeHooks();
+
+		$subject->removeGutenbergFootprint( $post->ID, $post );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldNotRemoveGutenbergFootprintIfNoGbMetaData() {
+		$post = $this->getPost( 'Something' );
+
+		\WP_Mock::onFilter( 'wpml_pb_is_post_built_with_shortcodes' )
+			->with( false, $post )
+			->reply( true );
+
+		\WP_Mock::userFunction( 'wp_update_post' )->times( 0 );
+
+		$subject = new ShortcodeHooks();
+
+		$subject->removeGutenbergFootprint( $post->ID, $post );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldRemoveGutenbergFootprint() {
+		$cleanContent = 'Something';
+		$rawContent   = '
+<!-- wp:auto-closing-block block which will wrap all its content in <code> html tag -->
+<!-- wp:paragraph
+-->'
+. $cleanContent .
+'<!-- /wp:paragraph -->';
+
+		$originalPost = $this->getPost( $rawContent );
+
+		$extraPackage = $this->getPackage( 'extra', '123' );
+		$gbPackage    = $this->getPackage( 'gutenberg', '123' );
+
+		\WP_Mock::onFilter( 'wpml_pb_is_post_built_with_shortcodes' )
+			->with( false, $originalPost )
+			->reply( true );
+
+		\WP_Mock::userFunction( 'wp_update_post' )
+			->times( 1 )
+			->andReturn( function( $savedPost ) use ( $originalPost, $cleanContent ) {
+				$this->assertSame( $originalPost->ID, $savedPost->ID );
+				$this->assertSame( $cleanContent, $savedPost->post_content );
+			} );
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( [], $originalPost->ID )
+			->reply( [ $extraPackage, $gbPackage ] );
+
+		\WP_Mock::expectAction( 'wpml_delete_package', $gbPackage->name, $gbPackage->kind );
+
+		$subject = new ShortcodeHooks();
+
+		$subject->removeGutenbergFootprint( $originalPost->ID, $originalPost );
+	}
+
+	/**
+	 * @param string $content
+	 *
+	 * @return \WP_Post|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getPost( $content ) {
+		$post               = $this->createMock( \WP_Post::class );
+		$post->ID           = 123;
+		$post->post_content = $content;
+
+		return $post;
+	}
+
+	/**
+	 * @param string $kind
+	 * @param string $name
+	 *
+	 * @return \WPML_Package|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getPackage( $kind, $name ) {
+		$package            = $this->createMock( \WPML_Package::class );
+		$package->kind_slug = strtolower( $kind );
+		$package->kind      = strtoupper( $kind );
+		$package->name      = $name;
+
+		return $package;
+	}
+}

--- a/tests/phpunit/tests/st/test-wpml-pb-loader.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-loader.php
@@ -21,6 +21,7 @@ class Test_WPML_PB_Loader extends WPML_PB_TestCase {
 					WPML_PB_Handle_Post_Body::class,
 //					WPML\PB\AutoUpdate\Hooks::class,
 					WPML\PB\Shutdown\Hooks::class,
+					WPML\PB\GutenbergCleanup\ShortcodeHooks::class,
 				]
 			);
 		}


### PR DESCRIPTION
For now, this will be used only for Enfold Avia Builder ( [see MR3046 in Core](https://git.onthegosystems.com/wpml/sitepress-multilingual-cms/-/merge_requests/3046)), but we should be able to reuse it also for other shortcode page builders.

The code located in the new `WPML\PB\GutenbergCleanup\Utils` class is inspired from some code we already have in the Elementor package (see https://github.com/OnTheGoSystems/wpml-page-builders-elementor/pull/121/files#diff-039918ee390a9373a7ba3ff801eb19e629d0d7ac36df0eeeaa768372b8ed6aa1R37). I will create a separate ticket to refactor the code in Elementor and reuse the new pieces in this main package.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7870