### PR TITLE
Fix the error notices in TM Integration tests

### DIFF
--- a/src/AutoUpdate/Hooks.php
+++ b/src/AutoUpdate/Hooks.php
@@ -103,8 +103,10 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 			do_action( 'wpml_cache_clear' );
 
 			foreach ( $this->translationStatusesUpdaters as $originalPostId => $translationStatusesUpdater ) {
-				call_user_func( $translationStatusesUpdater );
-				$this->resaveTranslations( $originalPostId );
+				if ( \get_post( $originalPostId ) ) {
+					call_user_func( $translationStatusesUpdater );
+					$this->resaveTranslations( $originalPostId );
+				}
 			}
 		}
 	}

--- a/tests/phpunit/tests/AutoUpdate/TestHooks.php
+++ b/tests/phpunit/tests/AutoUpdate/TestHooks.php
@@ -346,6 +346,11 @@ class TestHooks extends  TestCase {
 		$post = $this->getMockBuilder( '\WP_Post' )->getMock();
 		$post->ID = $id;
 
+		\WP_Mock::userFunction( 'get_post', [
+			'args'   => [ $id ],
+			'return' => $post,
+		] );
+
 		return $post;
 	}
 


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmltm-4002

It causes tons of notices like:
```
Notice: Trying to get property 'post_title' of non-object in /home/jakubbis/Projects/develop/htdocs/wp-content/plugins/sitepress-multilingual-cms/vendor/wpml/tm/inc/actions/wpml-tm-action-helper.class.php on line 62
```

On shutdown function at the end of integration tests which pollutes the output. 

@strategio @OnTheGoSystems/page-builders-devs 