### PR TITLE
Fix warnings due to `WPML_PB_Last_Translation_Edit_Mode` uses as an instance instead of the static methods

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
+		failOnWarning="true"
 >
 	<testsuites>
 		<testsuite name="wpml-pb-tests">

--- a/src/st/class-wpml-pb-factory.php
+++ b/src/st/class-wpml-pb-factory.php
@@ -82,6 +82,9 @@ class WPML_PB_Factory {
 		);
 	}
 
+	/**
+	 * @depecated Use the static methods instead of the instance.
+	 */
 	public function get_last_translation_edit_mode() {
 		return new WPML_PB_Last_Translation_Edit_Mode();
 	}

--- a/src/st/class-wpml-pb-integration.php
+++ b/src/st/class-wpml-pb-integration.php
@@ -75,7 +75,7 @@ class WPML_PB_Integration {
 			return;
 		}
 
-		if ( $this->factory->get_last_translation_edit_mode()->is_native_editor( $post_element->get_id() ) ) {
+		if ( WPML_PB_Last_Translation_Edit_Mode::is_native_editor( $post_element->get_id() ) ) {
 			return;
 		}
 
@@ -122,12 +122,10 @@ class WPML_PB_Integration {
 			return;
 		}
 
-		$last_edit_mode = $this->factory->get_last_translation_edit_mode();
-
 		if ( $this->is_editing_translation_with_native_editor() ) {
-			$last_edit_mode->set_native_editor( $post_id );
+			WPML_PB_Last_Translation_Edit_Mode::set_native_editor( $post_id );
 		} else {
-			$last_edit_mode->set_translation_editor( $post_id );
+			WPML_PB_Last_Translation_Edit_Mode::set_translation_editor( $post_id );
 		}
 	}
 


### PR DESCRIPTION
I also forced the tests to fail on warning because I discovered the problem by chance, the pipeline was showing the green light.

@kkarpieszuk, this is about the class I shared this morning :)

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-187