### PR TITLE
Filter post content before copying post without translatable elements

### DIFF
--- a/src/tm/class-wpml-pb-handle-post-body.php
+++ b/src/tm/class-wpml-pb-handle-post-body.php
@@ -31,7 +31,9 @@ class WPML_PB_Handle_Post_Body implements IWPML_Backend_Action, IWPML_Frontend_A
 	public function copy( $new_post_id, $original_post_id, array $fields ) {
 		$original_post = get_post( $original_post_id );
 		if ( $original_post && $this->page_builders_built->is_page_builder_page( $original_post ) && ! $this->job_has_packages( $fields ) ) {
-			wpml_update_escaped_post( [ 'ID' => $new_post_id, 'post_content' => $original_post->post_content ] );
+			$post_content =
+				apply_filters( 'wpml_pb_before_page_without_elements_post_content_copy', $original_post->post_content, $new_post_id, $original_post_id );
+			wpml_update_escaped_post( [ 'ID' => $new_post_id, 'post_content' => $post_content ] );
 			do_action( 'wpml_pb_after_page_without_elements_post_content_copy', $new_post_id, $original_post_id );
 		}
 	}

--- a/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
+++ b/tests/phpunit/tests/tm/test-wpml-pb-handle-post-body.php
@@ -250,4 +250,45 @@ class Test_WPML_PB_Handle_Post_Body extends OTGS\PHPUnit\Tools\TestCase {
 		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
 		$subject->copy( $new_post_id, $original_post_id, $fields );
 	}
+
+	/**
+	 * @test
+	 */
+	public function post_body_is_filtered_before_the_save() {
+		$page_builders_built = $this->getMockBuilder( 'WPML_Page_Builders_Page_Built' )
+			->disableOriginalConstructor()
+			->getMock();
+
+
+
+		$content_original            = 'content original';
+		$content_translated          = 'content translated';
+		$new_post_id                 = 2;
+		$original_post_id            = 1;
+		$original_post               = $this->getMockBuilder( 'WP_Post' )->disableOriginalConstructor()->getMock();
+		$original_post->post_content = $content_original;
+
+		$page_builders_built->method( 'is_page_builder_page' )
+			->with( $original_post )
+			->willReturn( true );
+
+		$fields = array(
+			'some-something' => 'something',
+		);
+
+		\WP_Mock::wpFunction( 'get_post', array(
+			'args'   => $original_post_id,
+			'return' => $original_post,
+		) );
+
+		WP_Mock::userFunction( 'apply_filters', [
+			'args' => [ 'wpml_pb_before_page_without_elements_post_content_copy', $content_original, $new_post_id, $original_post_id ],
+			'return' => $content_translated
+		] );
+		WP_Mock::userFunction( 'wpml_update_escaped_post' );
+		WP_Mock::userFunction( 'do_action' );
+
+		$subject = new WPML_PB_Handle_Post_Body( $page_builders_built );
+		$subject->copy( $new_post_id, $original_post_id, $fields );
+	}
 }


### PR DESCRIPTION
- introducing filter wpml_pb_before_page_without_elements_post_content_copy in \WPML_PB_Handle_Post_Body::copy

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-194