### PR TITLE
Improve the way we flag is a translation has been edited with a translation editor or not

### DIFF
--- a/tests/phpunit/tests/st/test-wpml-pb-integration.php
+++ b/tests/phpunit/tests/st/test-wpml-pb-integration.php
@@ -789,7 +789,7 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 
 		$_POST = array(
 			'action' => 'editpost',
-			'ID'     => $post_id,
+			'ID'     => (string) $post_id,
 		);
 
 		$post         = $this->get_post( $post_id );
@@ -819,12 +819,11 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	 * @dataProvider dp_post_payload_not_from_native_editor
 	 * @group        wpmlcore-6120
 	 *
-	 * @param array $_post_payloaad
+	 * @param array $_post_payload
 	 */
-	public function it_should_set_last_editor_mode_to_translation_editor( $_post_payloaad ) {
-		$_POST = $_post_payloaad;
+	public function it_should_set_last_editor_mode_to_translation_editor( $_post_payload, $post_id ) {
+		$_POST = $_post_payload;
 
-		$post_id      = 123;
 		$post         = $this->get_post( $post_id );
 		$post_element = $this->get_post_element( $post_id, $post );
 		$post_element->method( 'get_source_language_code' )->willReturn( 'en' );
@@ -848,10 +847,22 @@ class Test_WPML_PB_Integration extends WPML_PB_TestCase {
 	}
 
 	public function dp_post_payload_not_from_native_editor() {
-		return array(
-			array( array() ),
-			array( array( 'action' => 'something' ) ),
-		);
+		$post_id = 123;
+
+		return [
+			'no payload' => [
+				[],
+				$post_id
+			],
+			'wrong action' => [
+				[ 'action' => 'something' ],
+				$post_id
+			],
+			'not same post ID' => [
+				[ 'action' => 'editpost', 'ID' => 456 ],
+				$post_id
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION
With the "translation auto-update" feature, we can have translations
automatically updated while editing the original.

- We need to compare the globablly edited post ID with the locally saved
post ID.
- We will also pass the translated post ID to the filter.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-8858